### PR TITLE
Make recognition rectangle disappear

### DIFF
--- a/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt
+++ b/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt
@@ -603,7 +603,7 @@ class SoundClassifier(
     } else {
       Handler(Looper.getMainLooper()).post {
         tv.setText("")
-        tv.setBackgroundColor(ContextCompat.getColor(mContext, R.color.dark_blue_gray700))
+        tv.setBackgroundResource(0)
       }
     }
   }


### PR DESCRIPTION
If recognition level is low not only text, but rectangle also disappears.