### PR TITLE
Support Android 9+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "org.woheller69.whobird"
-        minSdk 30
+        minSdk 28
         targetSdk 34
         versionCode 32
         versionName "3.2"

--- a/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/ViewActivity.kt
+++ b/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/ViewActivity.kt
@@ -3,8 +3,10 @@ package org.tensorflow.lite.examples.soundclassifier
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.text.format.DateFormat
+import android.util.DisplayMetrics
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
@@ -40,8 +42,14 @@ class ViewActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         //Set aspect ratio for webview and icon
-        val windowMetrics = windowManager.currentWindowMetrics
-        val width = windowMetrics.bounds.width()
+        val width = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val windowMetrics = windowManager.currentWindowMetrics
+            windowMetrics.bounds.width()
+        } else {
+            val displayMetrics = DisplayMetrics()
+            windowManager.defaultDisplay.getMetrics(displayMetrics)
+            displayMetrics.widthPixels
+        }
         val paramsWebview: ViewGroup.LayoutParams = binding.webview.getLayoutParams() as ViewGroup.LayoutParams
         paramsWebview.height = (width / 1.8f).toInt()
         val paramsIcon: ViewGroup.LayoutParams = binding.icon.getLayoutParams() as ViewGroup.LayoutParams


### PR DESCRIPTION
I got the app to work on Android 9 and tested it on a real device.


The UI code needed minor changes to get window metrics on Android <11.

The backup function did not work on my device (access denied), so I rewrote it to use `Intent.ACTION_CREATE_DOCUMENT` (API level 19). This API uses streams (it can store, for example, to a cloud provider) and required a workaround to work with Zip4j because `ZipOutputStream` does not provide the `addFolder` method and requires iterating over and manually adding metadata+content for each file. I opted to keep using `ZipFile` with a temporary file and it gets copied to the destination.

No other changes were necessary and identification worked out of the box.


Closes #22, #50
