### PR TITLE
Fix Chinese names in labels_zh, following translation in IOC 14.2.

### DIFF
--- a/app/src/main/assets/labels_zh.txt
+++ b/app/src/main/assets/labels_zh.txt
@@ -1,278 +1,278 @@
-Abroscopus albogularis_棕面鶯
-Abroscopus schisticeps_Black-faced Warbler
-Abroscopus superciliaris_Yellow-bellied Warbler
-Aburria aburri_Wattled Guan
-Acanthagenys rufogularis_Spiny-cheeked Honeyeater
-Acanthidops bairdi_Peg-billed Finch
+Abroscopus albogularis_棕脸鹟莺
+Abroscopus schisticeps_黑脸鹟莺
+Abroscopus superciliaris_黄腹鹟莺
+Aburria aburri_肉垂冠雉
+Acanthagenys rufogularis_刺颊垂蜜鸟
+Acanthidops bairdi_尖嘴雀鹀
 Acanthis cabaret_Lesser Redpoll
-Acanthis flammea_普通朱頂雀
+Acanthis flammea_白腰朱顶雀
 Acanthis hornemanni_Hoary Redpoll
-Acanthisitta chloris_Rifleman
-Acanthiza apicalis_Inland Thornbill
-Acanthiza chrysorrhoa_Yellow-rumped Thornbill
-Acanthiza ewingii_Tasmanian Thornbill
-Acanthiza inornata_Western Thornbill
-Acanthiza lineata_Striated Thornbill
-Acanthiza nana_Yellow Thornbill
-Acanthiza pusilla_Brown Thornbill
-Acanthiza reguloides_Buff-rumped Thornbill
-Acanthiza uropygialis_Chestnut-rumped Thornbill
-Acanthorhynchus superciliosus_Western Spinebill
-Acanthorhynchus tenuirostris_Eastern Spinebill
-Accipiter badius_褐耳鷹
-Accipiter bicolor_Bicolored Hawk
-Accipiter cirrocephalus_Collared Sparrowhawk
-Accipiter cooperii_Cooper's Hawk
-Accipiter fasciatus_Brown Goshawk
-Accipiter gentilis_蒼鷹
-Accipiter gularis_日本松雀鷹
-Accipiter hiogaster_Variable Goshawk
+Acanthisitta chloris_刺鹩
+Acanthiza apicalis_宽尾刺嘴莺
+Acanthiza chrysorrhoa_黄尾刺嘴莺
+Acanthiza ewingii_塔岛刺嘴莺
+Acanthiza inornata_西刺嘴莺
+Acanthiza lineata_纵纹刺嘴莺
+Acanthiza nana_小刺嘴莺
+Acanthiza pusilla_褐刺嘴莺
+Acanthiza reguloides_棕尾刺嘴莺
+Acanthiza uropygialis_栗尾刺嘴莺
+Acanthorhynchus superciliosus_西尖嘴吸蜜鸟
+Acanthorhynchus tenuirostris_东尖嘴吸蜜鸟
+Accipiter badius_褐耳鹰
+Accipiter bicolor_双色鹰
+Accipiter cirrocephalus_领雀鹰
+Accipiter cooperii_库氏鹰
+Accipiter fasciatus_褐鹰
+Accipiter gentilis_Northern Goshawk
+Accipiter gularis_日本松雀鹰
+Accipiter hiogaster_杂色鹰
 Accipiter melanoleucus_Black Goshawk
-Accipiter minullus_Little Sparrowhawk
-Accipiter nisus_北雀鷹
+Accipiter minullus_非洲小雀鹰
+Accipiter nisus_雀鹰
 Accipiter novaehollandiae_Gray Goshawk
-Accipiter poliogaster_Gray-bellied Hawk
-Accipiter soloensis_赤腹鷹
-Accipiter striatus_Sharp-shinned Hawk
-Accipiter superciliosus_Tiny Hawk
-Accipiter tachiro_African Goshawk
+Accipiter poliogaster_灰腹鹰
+Accipiter soloensis_赤腹鹰
+Accipiter striatus_纹腹鹰
+Accipiter superciliosus_侏鹰
+Accipiter tachiro_非洲鹰
 Accipiter trinotatus_Spot-tailed Goshawk
-Accipiter trivirgatus_鳳頭蒼鷹
-Accipiter virgatus_松雀鷹
-Aceros nipalensis_Rufous-necked Hornbill
-Achaetops pycnopygius_Rockrunner
-Acridotheres burmannicus_緬甸椋鳥
-Acridotheres cristatellus_八哥(冠八哥)
-Acridotheres fuscus_林八哥
-Acridotheres ginginianus_岸八哥
-Acridotheres grandis_大八哥(叢八哥)
-Acridotheres javanicus_白尾八哥
+Accipiter trivirgatus_凤头鹰
+Accipiter virgatus_松雀鹰
+Aceros nipalensis_棕颈犀鸟
+Achaetops pycnopygius_岩莺
+Acridotheres burmannicus_红嘴椋鸟
+Acridotheres cristatellus_八哥
+Acridotheres fuscus_丛林八哥
+Acridotheres ginginianus_灰背岸八哥
+Acridotheres grandis_林八哥
+Acridotheres javanicus_爪哇八哥
 Acridotheres tristis_家八哥
 Acris crepitans_Northern Cricket Frog
 Acris gryllus_Southern Cricket Frog
-Acrobatornis fonsecai_Pink-legged Graveteiro
-Acrocephalus agricola_稻田葦鶯
-Acrocephalus arundinaceus_Great Reed Warbler
-Acrocephalus australis_Australian Reed Warbler
+Acrobatornis fonsecai_粉腿针尾雀
+Acrocephalus agricola_稻田苇莺
+Acrocephalus arundinaceus_大苇莺
+Acrocephalus australis_澳洲苇莺
 Acrocephalus baeticatus_African Reed Warbler
-Acrocephalus bistrigiceps_雙眉葦鶯
-Acrocephalus concinens_鈍翅葦鶯
-Acrocephalus dumetorum_布氏葦鶯
-Acrocephalus gracilirostris_Lesser Swamp Warbler
-Acrocephalus griseldis_Basra Reed Warbler
-Acrocephalus melanopogon_Moustached Warbler
-Acrocephalus newtoni_Madagascar Swamp Warbler
-Acrocephalus orientalis_東方大葦鶯
-Acrocephalus paludicola_Aquatic Warbler
-Acrocephalus palustris_Marsh Warbler
-Acrocephalus rufescens_Greater Swamp Warbler
-Acrocephalus schoenobaenus_Sedge Warbler
-Acrocephalus scirpaceus_Eurasian Reed Warbler
-Acrocephalus stentoreus_Clamorous Reed Warbler
-Acrocephalus tangorum_遠東葦鶯
-Acropternis orthonyx_Ocellated Tapaculo
-Actenoides concretus_Rufous-collared Kingfisher
-Actenoides lindsayi_Spotted Kingfisher
-Actenoides monachus_Green-backed Kingfisher
-Actinodura cyanouroptera_Blue-winged Minla
-Actinodura egertoni_Rusty-fronted Barwing
-Actinodura nipalensis_Hoary-throated Barwing
-Actinodura ramsayi_Spectacled Barwing
-Actinodura strigula_Chestnut-tailed Minla
-Actinodura waldeni_Streak-throated Barwing
-Actitis hypoleucos_磯鷸
-Actitis macularius_Spotted Sandpiper
-Actophilornis africanus_African Jacana
-Adelomyia melanogenys_Speckled Hummingbird
-Aechmophorus clarkii_Clark's Grebe
-Aechmophorus occidentalis_Western Grebe
-Aegithalos caudatus_Long-tailed Tit
-Aegithalos concinnus_紅頭山雀
-Aegithalos glaucogularis_Silver-throated Tit
-Aegithalos iouschistos_Black-browed Tit
-Aegithalos niveogularis_White-throated Tit
-Aegithina nigrolutea_White-tailed Iora
-Aegithina tiphia_Common Iora
-Aegithina viridissima_Green Iora
-Aegolius acadicus_Northern Saw-whet Owl
-Aegolius funereus_Boreal Owl
-Aegolius harrisii_Buff-fronted Owl
-Aegolius ridgwayi_Unspotted Saw-whet Owl
-Aegotheles cristatus_Australian Owlet-nightjar
-Aegypius monachus_禿鷲
-Aerodramus bartschi_Mariana Swiftlet
-Aerodramus fuciphagus_White-nest Swiftlet
-Aerodramus maximus_Black-nest Swiftlet
-Aeronautes andecolus_Andean Swift
-Aeronautes montivagus_White-tipped Swift
-Aeronautes saxatalis_White-throated Swift
-Aethia pusilla_Least Auklet
-Aethia pygmaea_Whiskered Auklet
-Aethopyga christinae_叉尾太陽鳥
-Aethopyga gouldiae_藍喉太陽鳥
-Aethopyga ignicauda_Fire-tailed Sunbird
-Aethopyga nipalensis_Green-tailed Sunbird
-Aethopyga saturata_Black-throated Sunbird
-Aethopyga siparaja_Crimson Sunbird
-Aethopyga temminckii_Temminck's Sunbird
-Aethopyga vigorsii_Vigors's Sunbird
-Agapornis canus_Gray-headed Lovebird
-Agapornis fischeri_費氏愛情鳥
-Agapornis personatus_黃領愛情鳥
-Agapornis roseicollis_桃臉愛情鳥
-Agapornis taranta_Black-winged Lovebird
-Agelaioides badius_Grayish Baywing
-Agelaius phoeniceus_Red-winged Blackbird
-Agelaius tricolor_Tricolored Blackbird
-Agelasticus cyanopus_Unicolored Blackbird
-Agelasticus thilius_Yellow-winged Blackbird
-Agelasticus xanthophthalmus_Pale-eyed Blackbird
-Aglaiocercus coelestis_Violet-tailed Sylph
-Aglaiocercus kingii_Long-tailed Sylph
-Agriornis montanus_Black-billed Shrike-Tyrant
-Agropsar philippensis_小椋鳥
-Agropsar sturninus_北椋鳥
-Ailuroedus crassirostris_Green Catbird
-Ailuroedus maculosus_Spotted Catbird
-Aimophila notosticta_Oaxaca Sparrow
-Aimophila rufescens_Rusty Sparrow
-Aimophila ruficeps_Rufous-crowned Sparrow
-Aix galericulata_鴛鴦
-Aix sponsa_林鴛鴦
-Akletos goeldii_Goeldi's Antbird
-Akletos melanoceps_White-shouldered Antbird
-Alaemon alaudipes_Greater Hoopoe-Lark
-Alauda arvensis_歐亞雲雀
-Alauda gulgula_小雲雀
-Alaudala cheleensis_亞洲短趾百靈
-Alaudala heinei_Turkestan Short-toed Lark
-Alaudala raytal_Sand Lark
-Alaudala rufescens_Mediterranean Short-toed Lark
-Alaudala somalica_Somali Short-toed Lark
-Alca torda_Razorbill
-Alcedo atthis_翠鳥
-Alcedo meninting_Blue-eared Kingfisher
-Alcippe brunneicauda_Brown Fulvetta
-Alcippe fratercula_Yunnan Fulvetta
-Alcippe hueti_Huet's Fulvetta
-Alcippe morrisonia_繡眼畫眉
-Alcippe nipalensis_Nepal Fulvetta
-Alcippe peracensis_Mountain Fulvetta
-Alcippe poioicephala_Brown-cheeked Fulvetta
-Alcippe pyrrhoptera_Javan Fulvetta
-Aleadryas rufinucha_Rufous-naped Bellbird
-Alectoris barbara_Barbary Partridge
-Alectoris chukar_Chukar
-Alectoris graeca_Rock Partridge
-Alectoris rufa_Red-legged Partridge
-Alectura lathami_Australian Brushturkey
-Alethe castanea_Fire-crested Alethe
-Alethe diademata_White-tailed Alethe
-Alipiopsitta xanthops_Yellow-faced Parrot
-Alisterus scapularis_Australian King-Parrot
-Allenia fusca_Scaly-breasted Thrasher
+Acrocephalus bistrigiceps_黑眉苇莺
+Acrocephalus concinens_钝翅苇莺
+Acrocephalus dumetorum_布氏苇莺
+Acrocephalus gracilirostris_细嘴苇莺
+Acrocephalus griseldis_巴士拉苇莺
+Acrocephalus melanopogon_须苇莺
+Acrocephalus newtoni_马岛沼泽苇莺
+Acrocephalus orientalis_东方大苇莺
+Acrocephalus paludicola_水栖苇莺
+Acrocephalus palustris_湿地苇莺
+Acrocephalus rufescens_大沼泽苇莺
+Acrocephalus schoenobaenus_水蒲苇莺
+Acrocephalus scirpaceus_芦苇莺
+Acrocephalus stentoreus_噪大苇莺
+Acrocephalus tangorum_远东苇莺
+Acropternis orthonyx_眼斑窜鸟
+Actenoides concretus_栗领翡翠
+Actenoides lindsayi_斑林翡翠
+Actenoides monachus_绿背翡翠
+Actinodura cyanouroptera_蓝翅希鹛
+Actinodura egertoni_锈额斑翅鹛
+Actinodura nipalensis_纹头斑翅鹛
+Actinodura ramsayi_白眶斑翅鹛
+Actinodura strigula_斑喉希鹛
+Actinodura waldeni_纹胸斑翅鹛
+Actitis hypoleucos_矶鹬
+Actitis macularius_斑腹矶鹬
+Actophilornis africanus_非洲雉鸻
+Adelomyia melanogenys_鳞斑蜂鸟
+Aechmophorus clarkii_克氏䴙䴘
+Aechmophorus occidentalis_北美䴙䴘
+Aegithalos caudatus_北长尾山雀
+Aegithalos concinnus_红头长尾山雀
+Aegithalos glaucogularis_银喉长尾山雀
+Aegithalos iouschistos_棕额长尾山雀
+Aegithalos niveogularis_白喉长尾山雀
+Aegithina nigrolutea_白尾雀鹎
+Aegithina tiphia_黑翅雀鹎
+Aegithina viridissima_绿雀鹎
+Aegolius acadicus_棕榈鬼鸮
+Aegolius funereus_鬼鸮
+Aegolius harrisii_黄额鬼鸮
+Aegolius ridgwayi_无斑棕榈鬼鸮
+Aegotheles cristatus_澳洲裸鼻夜鹰
+Aegypius monachus_秃鹫
+Aerodramus bartschi_关岛金丝燕
+Aerodramus fuciphagus_爪哇金丝燕
+Aerodramus maximus_大金丝燕
+Aeronautes andecolus_安第斯雨燕
+Aeronautes montivagus_白尾梢雨燕
+Aeronautes saxatalis_白喉雨燕
+Aethia pusilla_小海雀
+Aethia pygmaea_须海雀
+Aethopyga christinae_叉尾太阳鸟
+Aethopyga gouldiae_蓝喉太阳鸟
+Aethopyga ignicauda_火尾太阳鸟
+Aethopyga nipalensis_绿喉太阳鸟
+Aethopyga saturata_黑胸太阳鸟
+Aethopyga siparaja_黄腰太阳鸟
+Aethopyga temminckii_特氏太阳鸟
+Aethopyga vigorsii_猩红太阳鸟
+Agapornis canus_灰头牡丹鹦鹉
+Agapornis fischeri_费氏牡丹鹦鹉
+Agapornis personatus_黄领牡丹鹦鹉
+Agapornis roseicollis_粉脸牡丹鹦鹉
+Agapornis taranta_黑翅牡丹鹦鹉
+Agelaioides badius_栗翅牛鹂
+Agelaius phoeniceus_红翅黑鹂
+Agelaius tricolor_三色黑鹂
+Agelasticus cyanopus_纯蓝黑鹂
+Agelasticus thilius_黄翅黑鹂
+Agelasticus xanthophthalmus_白眼黑鹂
+Aglaiocercus coelestis_紫长尾蜂鸟
+Aglaiocercus kingii_长尾蜂鸟
+Agriornis montanus_黑嘴鵙霸鹟
+Agropsar philippensis_紫背椋鸟
+Agropsar sturninus_北椋鸟
+Ailuroedus crassirostris_绿园丁鸟
+Ailuroedus maculosus_点斑园丁鸟
+Aimophila notosticta_瓦哈猛雀鹀
+Aimophila rufescens_锈红猛雀鹀
+Aimophila ruficeps_棕顶猛雀鹀
+Aix galericulata_鸳鸯
+Aix sponsa_林鸳鸯
+Akletos goeldii_高氏蚁鸟
+Akletos melanoceps_白肩蚁鸟
+Alaemon alaudipes_拟戴胜百灵
+Alauda arvensis_云雀
+Alauda gulgula_小云雀
+Alaudala cheleensis_亚洲短趾百灵
+Alaudala heinei_中亚短趾百灵
+Alaudala raytal_恒河沙百灵
+Alaudala rufescens_小短趾百灵
+Alaudala somalica_棕短趾百灵
+Alca torda_刀嘴海雀
+Alcedo atthis_普通翠鸟
+Alcedo meninting_蓝耳翠鸟
+Alcippe brunneicauda_褐雀鹛
+Alcippe fratercula_云南雀鹛
+Alcippe hueti_淡眉雀鹛
+Alcippe morrisonia_台湾雀鹛
+Alcippe nipalensis_白眶雀鹛
+Alcippe peracensis_山雀鹛
+Alcippe poioicephala_褐脸雀鹛
+Alcippe pyrrhoptera_爪哇雀鹛
+Aleadryas rufinucha_棕颈钟鹟
+Alectoris barbara_北非石鸡
+Alectoris chukar_石鸡
+Alectoris graeca_欧石鸡
+Alectoris rufa_红腿石鸡
+Alectura lathami_大塚雉
+Alethe castanea_红冠鸲鸫
+Alethe diademata_白尾鸲鸫
+Alipiopsitta xanthops_黄颊鹦哥
+Alisterus scapularis_澳洲王鹦鹉
+Allenia fusca_鳞胸嘲鸫
 Allonemobius allardi_Allard's Ground Cricket
 Allonemobius tinnulus_Tinkling Ground Cricket
 Allonemobius walkeri_Walker's Ground Cricket
-Alophoixus finschii_Finsch's Bulbul
-Alophoixus flaveolus_White-throated Bulbul
-Alophoixus ochraceus_Ochraceous Bulbul
-Alophoixus pallidus_Puff-throated Bulbul
-Alophoixus phaeocephalus_Yellow-bellied Bulbul
-Alophoixus tephrogenys_Gray-cheeked Bulbul
-Alopochelidon fucata_Tawny-headed Swallow
+Alophoixus finschii_芬氏冠鹎
+Alophoixus flaveolus_黄腹冠鹎
+Alophoixus ochraceus_白喉褐冠鹎
+Alophoixus pallidus_白喉冠鹎
+Alophoixus phaeocephalus_灰头冠鹎
+Alophoixus tephrogenys_灰颊冠鹎
+Alopochelidon fucata_棕头燕
 Alopochen aegyptiaca_埃及雁
 Alouatta pigra_Mexican Black Howler Monkey
-Amalocichla incerta_Lesser Ground-Robin
-Amandava amandava_紅梅花雀
-Amaurolimnas concolor_Uniform Crake
-Amaurornis isabellina_Isabelline Bush-hen
-Amaurornis moluccana_Pale-vented Bush-hen
-Amaurornis phoenicurus_白腹秧雞
-Amaurospiza concolor_Blue Seedeater
-Amaurospiza moesta_Blackish-blue Seedeater
-Amazilia luciae_Honduran Emerald
-Amazilia rutila_Cinnamon Hummingbird
-Amazilia tzacatl_Rufous-tailed Hummingbird
-Amazilia yucatanensis_Buff-bellied Hummingbird
-Amazilis amazilia_Amazilia Hummingbird
-Amazona aestiva_Turquoise-fronted Parrot
-Amazona agilis_Black-billed Parrot
-Amazona albifrons_White-fronted Parrot
-Amazona amazonica_Orange-winged Parrot
-Amazona auropalliata_Yellow-naped Parrot
-Amazona autumnalis_Red-lored Parrot
-Amazona brasiliensis_Red-tailed Parrot
-Amazona dufresniana_Blue-cheeked Parrot
-Amazona farinosa_Mealy Parrot
-Amazona festiva_Festive Parrot
-Amazona finschi_Lilac-crowned Parrot
-Amazona kawalli_Kawall's Parrot
-Amazona leucocephala_Cuban Parrot
-Amazona mercenarius_Scaly-naped Parrot
-Amazona ochrocephala_Yellow-crowned Parrot
-Amazona oratrix_Yellow-headed Parrot
-Amazona rhodocorytha_Red-browed Parrot
-Amazona tucumana_Tucuman Parrot
-Amazona ventralis_Hispaniolan Parrot
-Amazona vinacea_Vinaceous-breasted Parrot
-Amazona viridigenalis_Red-crowned Parrot
-Amazona xantholora_Yellow-lored Parrot
-Amazonetta brasiliensis_Brazilian Teal
-Amblycercus holosericeus_Yellow-billed Cacique
+Amalocichla incerta_小地鸲
+Amandava amandava_红梅花雀
+Amaurolimnas concolor_纯色秧鸡
+Amaurornis isabellina_苏拉威西苦恶鸟
+Amaurornis moluccana_棕尾苦恶鸟
+Amaurornis phoenicurus_白胸苦恶鸟
+Amaurospiza concolor_蓝籽雀
+Amaurospiza moesta_黑蓝籽雀
+Amazilia luciae_洪都拉斯蜂鸟
+Amazilia rutila_桂红蜂鸟
+Amazilia tzacatl_棕尾蜂鸟
+Amazilia yucatanensis_棕腹蜂鸟
+Amazilis amazilia_艳蜂鸟
+Amazona aestiva_蓝顶鹦哥
+Amazona agilis_黑嘴鹦哥
+Amazona albifrons_白额绿鹦哥
+Amazona amazonica_橙翅鹦哥
+Amazona auropalliata_黄枕鹦哥
+Amazona autumnalis_红眼鹦哥
+Amazona brasiliensis_红尾鹦哥
+Amazona dufresniana_蓝颊鹦哥
+Amazona farinosa_斑点鹦哥
+Amazona festiva_红额蓝颊鹦哥
+Amazona finschi_淡紫冠鹦哥
+Amazona kawalli_白脸鹦哥
+Amazona leucocephala_古巴白额鹦哥
+Amazona mercenarius_鳞颈鹦哥
+Amazona ochrocephala_黄冠鹦哥
+Amazona oratrix_黄头鹦哥
+Amazona rhodocorytha_红眉鹦哥
+Amazona tucumana_图库曼鹦哥
+Amazona ventralis_白眶绿鹦哥
+Amazona vinacea_红胸鹦哥
+Amazona viridigenalis_红冠鹦哥
+Amazona xantholora_黄眼先鹦哥
+Amazonetta brasiliensis_巴西凫
+Amblycercus holosericeus_黄嘴酋长鹂
 Amblycorypha alexanderi_Clicker Round-winged Katydid
 Amblycorypha longinicta_Common Virtuoso Katydid
 Amblycorypha oblongifolia_Oblong-winged Katydid
 Amblycorypha rotundifolia_Rattler Round-winged Katydid
-Amblyornis newtoniana_Golden Bowerbird
-Amblyospiza albifrons_Grosbeak Weaver
-Amblyramphus holosericeus_Scarlet-headed Blackbird
-Ammodramus aurifrons_Yellow-browed Sparrow
-Ammodramus humeralis_Grassland Sparrow
-Ammodramus savannarum_Grasshopper Sparrow
-Ammomanes cinctura_Bar-tailed Lark
-Ammomanes deserti_Desert Lark
-Ammomanes phoenicura_Rufous-tailed Lark
-Ammonastes pelzelni_Gray-bellied Antbird
-Ammospiza caudacuta_Saltmarsh Sparrow
-Ammospiza leconteii_LeConte's Sparrow
-Ammospiza maritima_Seaside Sparrow
-Ammospiza nelsoni_Nelson's Sparrow
-Ampelioides tschudii_Scaled Fruiteater
-Ampelion rubrocristatus_Red-crested Cotinga
-Ampelion rufaxilla_Chestnut-crested Cotinga
-Ampelornis griseiceps_Gray-headed Antbird
-Amphispiza bilineata_Black-throated Sparrow
-Amphispizopsis quinquestriata_Five-striped Sparrow
-Anabacerthia amaurotis_White-browed Foliage-gleaner
-Anabacerthia lichtensteini_Ochre-breasted Foliage-gleaner
-Anabacerthia ruficaudata_Rufous-tailed Foliage-gleaner
-Anabacerthia striaticollis_Montane Foliage-gleaner
-Anabacerthia variegaticeps_Scaly-throated Foliage-gleaner
-Anabazenops dorsalis_Dusky-cheeked Foliage-gleaner
-Anabazenops fuscus_White-collared Foliage-gleaner
-Anairetes alpinus_Ash-breasted Tit-Tyrant
-Anairetes flavirostris_Yellow-billed Tit-Tyrant
-Anairetes nigrocristatus_Black-crested Tit-Tyrant
-Anairetes parulus_Tufted Tit-Tyrant
-Anairetes reguloides_Pied-crested Tit-Tyrant
-Anas acuta_尖尾鴨
-Anas andium_Andean Teal
-Anas castanea_Chestnut Teal
-Anas crecca_小水鴨
-Anas diazi_Mexican Duck
-Anas flavirostris_Yellow-billed Teal
-Anas fulvigula_Mottled Duck
-Anas georgica_Yellow-billed Pintail
-Anas gracilis_Gray Teal
-Anas platyrhynchos_綠頭鴨
-Anas poecilorhyncha_Indian Spot-billed Duck
-Anas rubripes_American Black Duck
-Anas superciliosa_Pacific Black Duck
-Anas undulata_Yellow-billed Duck
-Anas wyvilliana_Hawaiian Duck
-Anas zonorhyncha_花嘴鴨
-Anastomus oscitans_Asian Openbill
+Amblyornis newtoniana_金亭鸟
+Amblyospiza albifrons_厚嘴织雀
+Amblyramphus holosericeus_红头黑鹂
+Ammodramus aurifrons_黄眉蝇鹀
+Ammodramus humeralis_草地蝇鹀
+Ammodramus savannarum_黄胸草鹀
+Ammomanes cinctura_斑尾漠百灵
+Ammomanes deserti_漠百灵
+Ammomanes phoenicura_棕尾漠百灵
+Ammonastes pelzelni_灰腹蚁鸟
+Ammospiza caudacuta_尖尾沙鹀
+Ammospiza leconteii_莱氏沙鹀
+Ammospiza maritima_海滨沙鹀
+Ammospiza nelsoni_纳氏沙鹀
+Ampelioides tschudii_鳞斑食果伞鸟
+Ampelion rubrocristatus_红冠伞鸟
+Ampelion rufaxilla_栗冠伞鸟
+Ampelornis griseiceps_灰头蚁鸟
+Amphispiza bilineata_黑喉漠鹀
+Amphispizopsis quinquestriata_五纹猛雀鹀
+Anabacerthia amaurotis_白眉拾叶雀
+Anabacerthia lichtensteini_赭胸拾叶雀
+Anabacerthia ruficaudata_棕尾拾叶雀
+Anabacerthia striaticollis_高山拾叶雀
+Anabacerthia variegaticeps_鳞喉拾叶雀
+Anabazenops dorsalis_冠拾叶雀
+Anabazenops fuscus_白领拾叶雀
+Anairetes alpinus_灰胸雀霸鹟
+Anairetes flavirostris_黄嘴雀霸鹟
+Anairetes nigrocristatus_黑冠雀霸鹟
+Anairetes parulus_须雀霸鹟
+Anairetes reguloides_斑冠雀霸鹟
+Anas acuta_针尾鸭
+Anas andium_斑头鸭
+Anas castanea_栗胸鸭
+Anas crecca_绿翅鸭
+Anas diazi_墨西哥鸭
+Anas flavirostris_黄嘴鸭
+Anas fulvigula_北美斑鸭
+Anas georgica_黄嘴针尾鸭
+Anas gracilis_灰鸭
+Anas platyrhynchos_绿头鸭
+Anas poecilorhyncha_印缅斑嘴鸭
+Anas rubripes_北美黑鸭
+Anas superciliosa_太平洋黑鸭
+Anas undulata_非洲黄嘴鸭
+Anas wyvilliana_夏威夷鸭
+Anas zonorhyncha_斑嘴鸭
+Anastomus oscitans_钳嘴鹳
 Anaxipha exigua_Say's Trig
 Anaxyrus americanus_American Toad
 Anaxyrus canorus_Yosemite Toad
@@ -284,1721 +284,1721 @@ Anaxyrus quercicus_Oak Toad
 Anaxyrus speciosus_Texas Toad
 Anaxyrus terrestris_Southern Toad
 Anaxyrus woodhousii_Woodhouse's Toad
-Ancistrops strigilatus_Chestnut-winged Hookbill
-Andigena hypoglauca_Gray-breasted Mountain-Toucan
-Andigena laminirostris_Plate-billed Mountain-Toucan
-Andigena nigrirostris_Black-billed Mountain-Toucan
-Androdon aequatorialis_Tooth-billed Hummingbird
-Andropadus importunus_Sombre Greenbul
-Anhima cornuta_Horned Screamer
-Anhinga anhinga_Anhinga
-Anhinga melanogaster_Oriental Darter
-Anhinga novaehollandiae_Australasian Darter
-Anisognathus igniventris_Scarlet-bellied Mountain Tanager
-Anisognathus lacrymosus_Lacrimose Mountain Tanager
-Anisognathus somptuosus_Blue-winged Mountain Tanager
-Anodorhynchus hyacinthinus_Hyacinth Macaw
-Anodorhynchus leari_Indigo Macaw
-Anorrhinus galeritus_Bushy-crested Hornbill
-Anous ceruleus_Blue-gray Noddy
-Anous minutus_黑玄燕鷗
-Anous stolidus_玄燕鷗
-Anous tenuirostris_Lesser Noddy
-Anser albifrons_白額雁
+Ancistrops strigilatus_栗翅钩嘴雀
+Andigena hypoglauca_灰胸山巨嘴鸟
+Andigena laminirostris_扁嘴山巨嘴鸟
+Andigena nigrirostris_黑嘴山巨嘴鸟
+Androdon aequatorialis_齿嘴蜂鸟
+Andropadus importunus_黄腹绿鹎
+Anhima cornuta_角叫鸭
+Anhinga anhinga_美洲蛇鹈
+Anhinga melanogaster_黑腹蛇鹈
+Anhinga novaehollandiae_澳洲蛇鹈
+Anisognathus igniventris_朱腹岭裸鼻雀
+Anisognathus lacrymosus_黄腹岭裸鼻雀
+Anisognathus somptuosus_蓝翅岭裸鼻雀
+Anodorhynchus hyacinthinus_紫蓝金刚鹦鹉
+Anodorhynchus leari_青蓝金刚鹦鹉
+Anorrhinus galeritus_凤头犀鸟
+Anous ceruleus_蓝灰燕鸥
+Anous minutus_玄燕鸥
+Anous stolidus_白顶玄燕鸥
+Anous tenuirostris_小玄燕鸥
+Anser albifrons_白额雁
 Anser anser_灰雁
-Anser brachyrhynchus_Pink-footed Goose
-Anser caerulescens_Snow Goose
-Anser canagicus_Emperor Goose
-Anser cygnoides_鴻雁
-Anser erythropus_小白額雁
-Anser fabalis_寒林豆雁
-Anser indicus_斑頭雁
-Anser rossii_Ross's Goose
-Anser serrirostris_凍原豆雁
-Anseranas semipalmata_Magpie Goose
-Anthipes monileger_White-gorgeted Flycatcher
-Anthipes solitaris_Rufous-browed Flycatcher
-Anthobaphes violacea_Orange-breasted Sunbird
-Anthochaera carunculata_Red Wattlebird
-Anthochaera chrysoptera_Little Wattlebird
-Anthochaera lunulata_Western Wattlebird
-Anthochaera paradoxa_Yellow Wattlebird
-Anthochaera phrygia_Regent Honeyeater
-Anthornis melanura_New Zealand Bellbird
-Anthoscopus minutus_Southern Penduline-Tit
-Anthoscopus musculus_Mouse-colored Penduline-Tit
-Anthracoceros albirostris_Oriental Pied-Hornbill
-Anthracoceros coronatus_Malabar Pied-Hornbill
-Anthracoceros malayanus_Black Hornbill
-Anthracothorax nigricollis_Black-throated Mango
-Anthreptes malacensis_Brown-throated Sunbird
-Anthreptes orientalis_Eastern Violet-backed Sunbird
-Anthropoides paradiseus_Blue Crane
-Anthropoides virgo_簑羽鶴
-Anthus berthelotii_Berthelot's Pipit
-Anthus bogotensis_Paramo Pipit
-Anthus campestris_Tawny Pipit
-Anthus cervinus_赤喉鷚
-Anthus chacoensis_Pampas Pipit
-Anthus cinnamomeus_African Pipit
-Anthus correndera_Correndera Pipit
-Anthus crenatus_Yellow-tufted Pipit
-Anthus furcatus_Short-billed Pipit
-Anthus godlewskii_布萊氏鷚
-Anthus gustavi_白背鷚
-Anthus hellmayri_Hellmayr's Pipit
-Anthus hodgsoni_樹鷚
-Anthus leucophrys_Plain-backed Pipit
-Anthus lineiventris_Striped Pipit
-Anthus lutescens_Yellowish Pipit
-Anthus nattereri_Ochre-breasted Pipit
-Anthus novaeseelandiae_Australasian Pipit (New Zealand)
-Anthus peruvianus_Peruvian Pipit
-Anthus petrosus_Rock Pipit
-Anthus pratensis_草地鷚
-Anthus richardi_大花鷚
-Anthus roseatus_粉紅胸鷚
-Anthus rubescens_黃腹鷚
-Anthus rufulus_稻田鷚
-Anthus similis_Long-billed Pipit
-Anthus spinoletta_水鷚
-Anthus spragueii_Sprague's Pipit
-Anthus sylvanus_Upland Pipit
-Anthus trivialis_林鷚
-Antigone antigone_Sarus Crane
-Antigone canadensis_沙丘鶴
-Antigone rubicunda_Brolga
-Antigone vipio_白枕鶴
-Antilophia bokermanni_Araripe Manakin
-Antilophia galeata_Helmeted Manakin
-Antrostomus arizonae_Mexican Whip-poor-will
-Antrostomus badius_Yucatan Nightjar
-Antrostomus carolinensis_Chuck-will's-widow
-Antrostomus noctitherus_Puerto Rican Nightjar
-Antrostomus ridgwayi_Buff-collared Nightjar
-Antrostomus rufus_Rufous Nightjar
-Antrostomus salvini_Tawny-collared Nightjar
-Antrostomus saturatus_Dusky Nightjar
-Antrostomus sericocaudatus_Silky-tailed Nightjar
-Antrostomus vociferus_Eastern Whip-poor-will
-Anumbius annumbi_Firewood-gatherer
-Anurolimnas castaneiceps_Chestnut-headed Crake
-Anurolimnas fasciatus_Black-banded Crake
-Anurolimnas viridis_Russet-crowned Crake
-Apalis alticola_Brown-headed Apalis
-Apalis chapini_Chapin's Apalis
-Apalis cinerea_Gray Apalis
-Apalis flavida_Yellow-breasted Apalis
-Apalis jacksoni_Black-throated Apalis
-Apalis melanocephala_Black-headed Apalis
-Apalis personata_Black-faced Apalis
-Apalis porphyrolaema_Chestnut-throated Apalis
-Apalis ruddi_Rudd's Apalis
-Apalis rufogularis_Buff-throated Apalis
-Apalis sharpii_Sharpe's Apalis
-Apalis thoracica_Bar-throated Apalis
-Apaloderma narina_Narina Trogon
-Apaloderma vittatum_Bar-tailed Trogon
-Aphanotriccus audax_Black-billed Flycatcher
-Aphanotriccus capitalis_Tawny-chested Flycatcher
-Aphelocephala leucopsis_Southern Whiteface
-Aphelocoma californica_California Scrub-Jay
-Aphelocoma coerulescens_Florida Scrub-Jay
-Aphelocoma ultramarina_Transvolcanic Jay
-Aphelocoma unicolor_Unicolored Jay
-Aphelocoma wollweberi_Mexican Jay
-Aphelocoma woodhouseii_Woodhouse's Scrub-Jay
-Aphrastura spinicauda_Thorn-tailed Rayadito
+Anser brachyrhynchus_粉脚雁
+Anser caerulescens_雪雁
+Anser canagicus_帝雁
+Anser cygnoides_鸿雁
+Anser erythropus_小白额雁
+Anser fabalis_豆雁
+Anser indicus_斑头雁
+Anser rossii_细嘴雁
+Anser serrirostris_短嘴豆雁
+Anseranas semipalmata_鹊雁
+Anthipes monileger_白喉姬鹟
+Anthipes solitaris_棕眉姬鹟
+Anthobaphes violacea_橙胸花蜜鸟
+Anthochaera carunculata_红垂蜜鸟
+Anthochaera chrysoptera_灰颊垂蜜鸟
+Anthochaera lunulata_小垂蜜鸟
+Anthochaera paradoxa_黄垂蜜鸟
+Anthochaera phrygia_王吸蜜鸟
+Anthornis melanura_新西兰吸蜜鸟
+Anthoscopus minutus_南攀雀
+Anthoscopus musculus_灰攀雀
+Anthracoceros albirostris_冠斑犀鸟
+Anthracoceros coronatus_印度冠斑犀鸟
+Anthracoceros malayanus_黑斑犀鸟
+Anthracothorax nigricollis_黑喉芒果蜂鸟
+Anthreptes malacensis_褐喉食蜜鸟
+Anthreptes orientalis_东紫背食蜜鸟
+Anthropoides paradiseus_蓝蓑羽鹤
+Anthropoides virgo_蓑羽鹤
+Anthus berthelotii_伯氏鹨
+Anthus bogotensis_帕拉鹨
+Anthus campestris_平原鹨
+Anthus cervinus_红喉鹨
+Anthus chacoensis_查科鹨
+Anthus cinnamomeus_非洲鹨
+Anthus correndera_科雷鹨
+Anthus crenatus_南非石鹨
+Anthus furcatus_短嘴鹨
+Anthus godlewskii_布氏鹨
+Anthus gustavi_北鹨
+Anthus hellmayri_赫氏鹨
+Anthus hodgsoni_树鹨
+Anthus leucophrys_纯背鹨
+Anthus lineiventris_条纹鹨
+Anthus lutescens_黄鹨
+Anthus nattereri_赭胸鹨
+Anthus novaeseelandiae_新西兰鹨
+Anthus peruvianus_秘鲁黄鹨
+Anthus petrosus_石鹨
+Anthus pratensis_草地鹨
+Anthus richardi_理氏鹨
+Anthus roseatus_粉红胸鹨
+Anthus rubescens_黄腹鹨
+Anthus rufulus_田鹨
+Anthus similis_长嘴鹨
+Anthus spinoletta_水鹨
+Anthus spragueii_斯氏鹨
+Anthus sylvanus_山鹨
+Anthus trivialis_林鹨
+Antigone antigone_赤颈鹤
+Antigone canadensis_沙丘鹤
+Antigone rubicunda_澳洲鹤
+Antigone vipio_白枕鹤
+Antilophia bokermanni_鹊色盔娇鹟
+Antilophia galeata_盔娇鹟
+Antrostomus arizonae_墨西哥三声夜鹰
+Antrostomus badius_尤卡褐领夜鹰
+Antrostomus carolinensis_卡氏夜鹰
+Antrostomus noctitherus_波多黎各夜鹰
+Antrostomus ridgwayi_黄领夜鹰
+Antrostomus rufus_棕夜鹰
+Antrostomus salvini_褐领夜鹰
+Antrostomus saturatus_美洲乌夜鹰
+Antrostomus sericocaudatus_丝尾夜鹰
+Antrostomus vociferus_三声夜鹰
+Anumbius annumbi_集木雀
+Anurolimnas castaneiceps_栗头田鸡
+Anurolimnas fasciatus_黑斑田鸡
+Anurolimnas viridis_红顶田鸡
+Apalis alticola_褐头娇莺
+Apalis chapini_查氏娇莺
+Apalis cinerea_灰娇莺
+Apalis flavida_黄胸娇莺
+Apalis jacksoni_黑喉娇莺
+Apalis melanocephala_黑头娇莺
+Apalis personata_黑脸娇莺
+Apalis porphyrolaema_栗喉娇莺
+Apalis ruddi_拉氏娇莺
+Apalis rufogularis_棕喉娇莺
+Apalis sharpii_夏氏娇莺
+Apalis thoracica_斑喉娇莺
+Apaloderma narina_绿颊咬鹃
+Apaloderma vittatum_斑尾咬鹃
+Aphanotriccus audax_黑嘴斑翅霸鹟
+Aphanotriccus capitalis_褐胸斑翅霸鹟
+Aphelocephala leucopsis_白脸刺莺
+Aphelocoma californica_西丛鸦
+Aphelocoma coerulescens_丛鸦
+Aphelocoma ultramarina_灰胸丛鸦
+Aphelocoma unicolor_纯色丛鸦
+Aphelocoma wollweberi_墨西哥丛鸦
+Aphelocoma woodhouseii_伍氏丛鸦
+Aphrastura spinicauda_棘尾雷雀
 Apis mellifera_Honey Bee
-Aplonis atrifusca_Samoan Starling
-Aplonis grandis_Brown-winged Starling
-Aplonis metallica_Metallic Starling
-Aplonis mysolensis_Moluccan Starling
-Aplonis opaca_Micronesian Starling
-Aplonis panayensis_亞洲輝椋鳥
-Aplonis tabuensis_Polynesian Starling
-Aprosmictus erythropterus_Red-winged Parrot
-Aptenodytes patagonicus_King Penguin
-Apteryx mantelli_North Island Brown Kiwi
-Apus affinis_Little Swift
-Apus apus_Common Swift
-Apus caffer_White-rumped Swift
-Apus melba_Alpine Swift
-Apus nipalensis_小雨燕
-Apus pacificus_叉尾雨燕
-Apus pallidus_Pallid Swift
-Apus unicolor_Plain Swift
-Aquila adalberti_Spanish Eagle
-Aquila chrysaetos_金鵰
-Aquila heliaca_白肩鵰
-Aquila nipalensis_Steppe Eagle
-Ara ambiguus_Great Green Macaw
-Ara ararauna_藍黃金剛鸚鵡
-Ara chloropterus_紅綠金剛鸚鵡
-Ara glaucogularis_Blue-throated Macaw
-Ara macao_緋紅金剛鸚鵡
-Ara militaris_Military Macaw
-Ara severus_Chestnut-fronted Macaw
-Arachnothera chrysogenys_Yellow-eared Spiderhunter
-Arachnothera crassirostris_Thick-billed Spiderhunter
-Arachnothera flavigaster_Spectacled Spiderhunter
-Arachnothera longirostra_Little Spiderhunter
-Arachnothera magna_Streaked Spiderhunter
-Aramides albiventris_Russet-naped Wood-Rail
-Aramides axillaris_Rufous-necked Wood-Rail
-Aramides cajaneus_Gray-cowled Wood-Rail
-Aramides saracura_Slaty-breasted Wood-Rail
-Aramides wolfi_Brown Wood-Rail
-Aramides ypecaha_Giant Wood-Rail
-Aramus guarauna_Limpkin
-Aratinga auricapillus_Golden-capped Parakeet
-Aratinga jandaya_Jandaya Parakeet
-Aratinga nenday_Nanday Parakeet
-Aratinga weddellii_Dusky-headed Parakeet
-Arborophila atrogularis_White-cheeked Partridge
-Arborophila brunneopectus_Bar-backed Partridge
-Arborophila crudigularis_台灣山鷓鴣
-Arborophila hyperythra_Red-breasted Partridge
-Arborophila javanica_Chestnut-bellied Partridge
-Arborophila mandellii_Chestnut-breasted Partridge
-Arborophila rufogularis_Rufous-throated Partridge
-Arborophila torqueola_Hill Partridge
-Archilochus alexandri_Black-chinned Hummingbird
-Archilochus colubris_Ruby-throated Hummingbird
-Ardea alba_大白鷺
-Ardea cinerea_蒼鷺
-Ardea cocoi_Cocoi Heron
-Ardea herodias_Great Blue Heron
-Ardea intermedia_中白鷺
-Ardea melanocephala_Black-headed Heron
-Ardea purpurea_紫鷺
-Ardea sumatrana_Great-billed Heron
-Ardenna bulleri_Buller's Shearwater
-Ardenna carneipes_肉足水薙鳥
-Ardenna creatopus_Pink-footed Shearwater
-Ardenna grisea_灰水薙鳥
-Ardenna pacifica_長尾水薙鳥
-Ardenna tenuirostris_短尾水薙鳥
-Ardeola bacchus_池鷺
-Ardeola grayii_印度池鷺
-Ardeola ralloides_Squacco Heron
-Ardeola speciosa_爪哇池鷺
-Arenaria interpres_翻石鷸
-Arenaria melanocephala_Black Turnstone
-Argusianus argus_Great Argus
-Argya affinis_Yellow-billed Babbler
-Argya caudata_Common Babbler
-Argya earlei_Striated Babbler
-Argya malcolmi_Large Gray Babbler
-Argya striata_Jungle Babbler
-Argya subrufa_Rufous Babbler
-Arizelocichla masukuensis_Shelley's Greenbul
-Arizelocichla milanjensis_Stripe-cheeked Greenbul
-Arizelocichla nigriceps_Eastern Mountain Greenbul
-Arremon abeillei_Black-capped Sparrow
-Arremon assimilis_Gray-browed Brushfinch
-Arremon atricapillus_Black-headed Brushfinch
-Arremon aurantiirostris_Orange-billed Sparrow
-Arremon basilicus_Sierra Nevada Brushfinch
-Arremon brunneinucha_Chestnut-capped Brushfinch
-Arremon castaneiceps_Olive Finch
-Arremon costaricensis_Costa Rican Brushfinch
-Arremon crassirostris_Sooty-faced Finch
-Arremon flavirostris_Saffron-billed Sparrow
-Arremon franciscanus_Sao Francisco Sparrow
-Arremon perijanus_Perija Brushfinch
-Arremon schlegeli_Golden-winged Sparrow
-Arremon semitorquatus_Half-collared Sparrow
-Arremon taciturnus_Pectoral Sparrow
-Arremon torquatus_White-browed Brushfinch
-Arremon virenticeps_Green-striped Brushfinch
-Arremonops chloronotus_Green-backed Sparrow
-Arremonops conirostris_Black-striped Sparrow
-Arremonops rufivirgatus_Olive Sparrow
-Arremonops tocuyensis_Tocuyo Sparrow
-Arses telescopthalmus_Frilled Monarch
-Artamus cinereus_Black-faced Woodswallow
-Artamus cyanopterus_Dusky Woodswallow
-Artamus fuscus_Ashy Woodswallow
+Aplonis atrifusca_黑辉椋鸟
+Aplonis grandis_褐翅辉椋鸟
+Aplonis metallica_群辉椋鸟
+Aplonis mysolensis_摩鹿加辉椋鸟
+Aplonis opaca_花辉椋鸟
+Aplonis panayensis_亚洲辉椋鸟
+Aplonis tabuensis_玻利辉椋鸟
+Aprosmictus erythropterus_红翅鹦鹉
+Aptenodytes patagonicus_王企鹅
+Apteryx mantelli_北岛褐几维
+Apus affinis_小雨燕
+Apus apus_普通雨燕
+Apus caffer_非洲白腰雨燕
+Apus melba_高山雨燕
+Apus nipalensis_小白腰雨燕
+Apus pacificus_白腰雨燕
+Apus pallidus_苍雨燕
+Apus unicolor_纯色雨燕
+Aquila adalberti_西班牙雕
+Aquila chrysaetos_金雕
+Aquila heliaca_白肩雕
+Aquila nipalensis_草原雕
+Ara ambiguus_大绿金刚鹦鹉
+Ara ararauna_蓝黄金刚鹦鹉
+Ara chloropterus_红绿金刚鹦鹉
+Ara glaucogularis_蓝喉金刚鹦鹉
+Ara macao_绯红金刚鹦鹉
+Ara militaris_军绿金刚鹦鹉
+Ara severus_栗额金刚鹦鹉
+Arachnothera chrysogenys_小黄耳捕蛛鸟
+Arachnothera crassirostris_厚嘴捕蛛鸟
+Arachnothera flavigaster_大黄耳捕蛛鸟
+Arachnothera longirostra_长嘴捕蛛鸟
+Arachnothera magna_纹背捕蛛鸟
+Aramides albiventris_白腹林秧鸡
+Aramides axillaris_棕颈林秧鸡
+Aramides cajaneus_灰颈林秧鸡
+Aramides saracura_灰胸林秧鸡
+Aramides wolfi_褐林秧鸡
+Aramides ypecaha_大林秧鸡
+Aramus guarauna_秧鹤
+Aratinga auricapillus_金帽鹦哥
+Aratinga jandaya_绿翅金鹦哥
+Aratinga nenday_黑头鹦哥
+Aratinga weddellii_暗头鹦哥
+Arborophila atrogularis_白颊山鹧鸪
+Arborophila brunneopectus_褐胸山鹧鸪
+Arborophila crudigularis_台湾山鹧鸪
+Arborophila hyperythra_赤胸山鹧鸪
+Arborophila javanica_棕腹山鹧鸪
+Arborophila mandellii_红胸山鹧鸪
+Arborophila rufogularis_红喉山鹧鸪
+Arborophila torqueola_环颈山鹧鸪
+Archilochus alexandri_黑颏北蜂鸟
+Archilochus colubris_红喉北蜂鸟
+Ardea alba_大白鹭
+Ardea cinerea_苍鹭
+Ardea cocoi_黑冠白颈鹭
+Ardea herodias_大蓝鹭
+Ardea intermedia_中白鹭
+Ardea melanocephala_黑头鹭
+Ardea purpurea_草鹭
+Ardea sumatrana_大嘴鹭
+Ardenna bulleri_灰背鹱
+Ardenna carneipes_淡足鹱
+Ardenna creatopus_粉脚鹱
+Ardenna grisea_灰鹱
+Ardenna pacifica_楔尾鹱
+Ardenna tenuirostris_短尾鹱
+Ardeola bacchus_池鹭
+Ardeola grayii_印度池鹭
+Ardeola ralloides_白翅黄池鹭
+Ardeola speciosa_爪哇池鹭
+Arenaria interpres_翻石鹬
+Arenaria melanocephala_黑翻石鹬
+Argusianus argus_大眼斑雉
+Argya affinis_印度白头鸫鹛
+Argya caudata_普通鸫鹛
+Argya earlei_纹背鸫鹛
+Argya malcolmi_灰鸫鹛
+Argya striata_丛林鸫鹛
+Argya subrufa_棕鸫鹛
+Arizelocichla masukuensis_塞氏绿鹎
+Arizelocichla milanjensis_纹颊绿鹎
+Arizelocichla nigriceps_东绿鹎
+Arremon abeillei_黑顶金肩雀
+Arremon assimilis_灰眉薮雀
+Arremon atricapillus_黑头薮雀
+Arremon aurantiirostris_橙嘴金肩雀
+Arremon basilicus_北纹头薮雀
+Arremon brunneinucha_栗顶薮雀
+Arremon castaneiceps_栗头绿雀
+Arremon costaricensis_哥斯达黎加薮雀
+Arremon crassirostris_乌脸雀
+Arremon flavirostris_黄嘴金肩雀
+Arremon franciscanus_巴西金肩雀
+Arremon perijanus_东纹头薮雀
+Arremon schlegeli_金翅金肩雀
+Arremon semitorquatus_半领金肩雀
+Arremon taciturnus_白眉金肩雀
+Arremon torquatus_纹头薮雀
+Arremon virenticeps_绿纹薮雀
+Arremonops chloronotus_绿背纹头雀
+Arremonops conirostris_大黑纹头雀
+Arremonops rufivirgatus_褐纹头雀
+Arremonops tocuyensis_小黑纹头雀
+Arses telescopthalmus_饰颈皱鹟
+Artamus cinereus_黑脸燕鵙
+Artamus cyanopterus_暗燕鵙
+Artamus fuscus_灰燕鵙
 Artamus leucorynchus_白胸燕鵙
-Artamus personatus_Masked Woodswallow
-Artamus superciliosus_White-browed Woodswallow
-Artemisiospiza belli_Bell's Sparrow
-Artemisiospiza nevadensis_Sagebrush Sparrow
-Artisornis metopias_African Tailorbird
-Artisornis moreaui_Long-billed Tailorbird
-Arundinax aedon_厚嘴葦鶯
-Arundinicola leucocephala_White-headed Marsh Tyrant
-Asemospiza fuliginosa_Sooty Grassquit
-Asemospiza obscura_Dull-colored Grassquit
-Asio clamator_Striped Owl
-Asio flammeus_短耳鴞
-Asio grammicus_Jamaican Owl
-Asio otus_長耳鴞
-Asio stygius_Stygian Owl
-Aspatha gularis_Blue-throated Motmot
-Asthenes anthoides_Austral Canastero
-Asthenes baeri_Short-billed Canastero
-Asthenes coryi_Ochre-browed Thistletail
-Asthenes dorbignyi_Creamy-breasted Canastero
-Asthenes flammulata_Many-striped Canastero
-Asthenes fuliginosa_White-chinned Thistletail
-Asthenes griseomurina_Mouse-colored Thistletail
-Asthenes harterti_Black-throated Thistletail
-Asthenes helleri_Puna Thistletail
-Asthenes heterura_Maquis Canastero
-Asthenes hudsoni_Hudson's Canastero
-Asthenes humilis_Streak-throated Canastero
-Asthenes maculicauda_Scribble-tailed Canastero
-Asthenes modesta_Cordilleran Canastero
-Asthenes moreirae_Itatiaia Spinetail
-Asthenes ottonis_Rusty-fronted Canastero
-Asthenes palpebralis_Eye-ringed Thistletail
-Asthenes perijana_Perija Thistletail
-Asthenes pudibunda_Canyon Canastero
-Asthenes pyrrholeuca_Sharp-billed Canastero
+Artamus personatus_黑眼燕鵙
+Artamus superciliosus_白眉燕鵙
+Artemisiospiza belli_贝氏漠鹀
+Artemisiospiza nevadensis_艾草漠鹀
+Artisornis metopias_红顶缝叶莺
+Artisornis moreaui_长嘴缝叶莺
+Arundinax aedon_厚嘴苇莺
+Arundinicola leucocephala_白头沼泽霸鹟
+Asemospiza fuliginosa_乌草雀
+Asemospiza obscura_暗色草雀
+Asio clamator_纹鸮
+Asio flammeus_短耳鸮
+Asio grammicus_牙买加鸮
+Asio otus_长耳鸮
+Asio stygius_乌耳鸮
+Aspatha gularis_蓝喉翠鴗
+Asthenes anthoides_安第斯卡纳灶鸟
+Asthenes baeri_短嘴卡纳灶鸟
+Asthenes coryi_赭额棘尾雀
+Asthenes dorbignyi_白胸卡纳灶鸟
+Asthenes flammulata_斑纹卡纳灶鸟
+Asthenes fuliginosa_白颏棘尾雀
+Asthenes griseomurina_灰棘尾雀
+Asthenes harterti_黑喉棘尾雀
+Asthenes helleri_高山棘尾雀
+Asthenes heterura_马基卡纳灶鸟
+Asthenes hudsoni_赫氏卡纳灶鸟
+Asthenes humilis_纹喉卡纳灶鸟
+Asthenes maculicauda_蓬尾卡纳灶鸟
+Asthenes modesta_高山卡纳灶鸟
+Asthenes moreirae_巴西棘尾雀
+Asthenes ottonis_锈额卡纳灶鸟
+Asthenes palpebralis_绣眼棘尾雀
+Asthenes perijana_秘鲁棘尾雀
+Asthenes pudibunda_峡谷卡纳灶鸟
+Asthenes pyrrholeuca_小卡纳灶鸟
 Asthenes sclateri_Puna Canastero
-Asthenes urubambensis_Line-fronted Canastero
-Asthenes virgata_Junin Canastero
-Asthenes wyatti_Streak-backed Canastero
-Atalotriccus pilaris_Pale-eyed Pygmy-Tyrant
-Atelornis crossleyi_Rufous-headed Ground-Roller
-Atelornis pittoides_Pitta-like Ground-Roller
-Athene blewitti_Forest Owlet
-Athene brama_Spotted Owlet
-Athene cunicularia_Burrowing Owl
-Athene noctua_縱紋腹小鴞
-Athene superciliaris_White-browed Owl
-Atimastillas flavicollis_Yellow-throated Greenbul
+Asthenes urubambensis_线额卡纳灶鸟
+Asthenes virgata_秘鲁卡纳灶鸟
+Asthenes wyatti_纹背卡纳灶鸟
+Atalotriccus pilaris_淡眼侏霸鹟
+Atelornis crossleyi_栗头地三宝鸟
+Atelornis pittoides_地三宝鸟
+Athene blewitti_林斑小鸮
+Athene brama_横斑腹小鸮
+Athene cunicularia_穴小鸮
+Athene noctua_纵纹腹小鸮
+Athene superciliaris_白眉小鸮
+Atimastillas flavicollis_黄喉绿鸫鹎
 Atlanticus testaceus_Protean Shieldback
-Atlapetes albinucha_White-naped Brushfinch
-Atlapetes albofrenatus_Moustached Brushfinch
-Atlapetes citrinellus_Yellow-striped Brushfinch
-Atlapetes flaviceps_Yellow-headed Brushfinch
-Atlapetes fulviceps_Fulvous-headed Brushfinch
-Atlapetes fuscoolivaceus_Dusky-headed Brushfinch
-Atlapetes latinuchus_Yellow-breasted Brushfinch
-Atlapetes leucopis_White-rimmed Brushfinch
-Atlapetes leucopterus_White-winged Brushfinch
-Atlapetes melanocephalus_Santa Marta Brushfinch
-Atlapetes melanolaemus_Black-faced Brushfinch
-Atlapetes pallidiceps_Pale-headed Brushfinch
-Atlapetes pallidinucha_Pale-naped Brushfinch
-Atlapetes personatus_Tepui Brushfinch
-Atlapetes pileatus_Rufous-capped Brushfinch
-Atlapetes rufigenis_Rufous-eared Brushfinch
-Atlapetes rufinucha_Bolivian Brushfinch
-Atlapetes schistaceus_Slaty Brushfinch
-Atlapetes semirufus_Ochre-breasted Brushfinch
-Atlapetes tibialis_Yellow-thighed Brushfinch
-Atlapetes tricolor_Tricolored Brushfinch
-Atrichornis clamosus_Noisy Scrub-bird
-Atrichornis rufescens_Rufous Scrub-bird
-Attagis gayi_Rufous-bellied Seedsnipe
-Atticora fasciata_White-banded Swallow
-Atticora pileata_Black-capped Swallow
-Atticora tibialis_White-thighed Swallow
-Attila bolivianus_Dull-capped Attila
-Attila cinnamomeus_Cinnamon Attila
-Attila citriniventris_Citron-bellied Attila
-Attila phoenicurus_Rufous-tailed Attila
-Attila rufus_Gray-hooded Attila
-Attila spadiceus_Bright-rumped Attila
-Attila torridus_Ochraceous Attila
-Augastes lumachella_Hooded Visorbearer
-Augastes scutatus_Hyacinth Visorbearer
-Aulacorhynchus albivitta_Southern Emerald-Toucanet
-Aulacorhynchus coeruleicinctis_Blue-banded Toucanet
-Aulacorhynchus derbianus_Chestnut-tipped Toucanet
-Aulacorhynchus haematopygus_Crimson-rumped Toucanet
-Aulacorhynchus prasinus_Northern Emerald-Toucanet
-Aulacorhynchus sulcatus_Groove-billed Toucanet
-Auriparus flaviceps_Verdin
-Automolus exsertus_Chiriqui Foliage-gleaner
-Automolus infuscatus_Olive-backed Foliage-gleaner
-Automolus leucophthalmus_White-eyed Foliage-gleaner
-Automolus melanopezus_Brown-rumped Foliage-gleaner
-Automolus ochrolaemus_Buff-throated Foliage-gleaner
-Automolus paraensis_Para Foliage-gleaner
-Automolus rufipileatus_Chestnut-crowned Foliage-gleaner
-Automolus subulatus_Striped Woodhaunter
-Aviceda jerdoni_Jerdon's Baza
-Aviceda leuphotes_黑冠鵑隼
-Aviceda subcristata_Pacific Baza
-Aythya affinis_小斑背潛鴨
-Aythya americana_Redhead
-Aythya collaris_環頸潛鴨
-Aythya ferina_紅頭潛鴨
-Aythya fuligula_鳳頭潛鴨
-Aythya marila_斑背潛鴨
-Aythya nyroca_白眼潛鴨
-Aythya valisineria_帆背潛鴨
-Baeolophus atricristatus_Black-crested Titmouse
-Baeolophus bicolor_Tufted Titmouse
-Baeolophus inornatus_Oak Titmouse
-Baeolophus ridgwayi_Juniper Titmouse
-Baeolophus wollweberi_Bridled Titmouse
-Baeopogon indicator_Honeyguide Greenbul
-Balearica regulorum_Gray Crowned-Crane
-Bambusicola fytchii_Mountain Bamboo-Partridge
-Bambusicola sonorivox_台灣竹雞
-Bambusicola thoracicus_灰胸竹雞
-Bangsia aureocincta_Gold-ringed Tanager
-Bangsia edwardsi_Moss-backed Tanager
-Bangsia melanochlamys_Black-and-gold Tanager
-Barnardius zonarius_Australian Ringneck
-Bartramia longicauda_Upland Sandpiper
-Baryphthengus martii_Rufous Motmot
-Baryphthengus ruficapillus_Rufous-capped Motmot
-Basileuterus belli_Golden-browed Warbler
-Basileuterus culicivorus_Golden-crowned Warbler
-Basileuterus delattrii_Chestnut-capped Warbler
-Basileuterus lachrymosus_Fan-tailed Warbler
-Basileuterus melanogenys_Black-cheeked Warbler
-Basileuterus melanotis_Costa Rican Warbler
-Basileuterus rufifrons_Rufous-capped Warbler
-Basileuterus trifasciatus_Three-banded Warbler
-Basileuterus tristriatus_Three-striped Warbler
-Basilinna leucotis_White-eared Hummingbird
-Batara cinerea_Giant Antshrike
-Bathmocercus rufus_Black-faced Rufous-Warbler
-Batis capensis_Cape Batis
-Batis erlangeri_Western Black-headed Batis
-Batis mixta_Short-tailed Batis
-Batis molitor_Chinspot Batis
-Batis orientalis_Gray-headed Batis
-Batis perkeo_Pygmy Batis
-Batis pririt_Pririt Batis
-Batis soror_Pale Batis
-Batrachostomus affinis_Blyth's Frogmouth
-Batrachostomus auritus_Large Frogmouth
-Batrachostomus cornutus_Sunda Frogmouth
-Batrachostomus hodgsoni_Hodgson's Frogmouth
-Batrachostomus moniliger_Sri Lanka Frogmouth
-Batrachostomus septimus_Philippine Frogmouth
-Batrachostomus stellatus_Gould's Frogmouth
-Berenicornis comatus_White-crowned Hornbill
-Berlepschia rikeri_Point-tailed Palmcreeper
-Bernieria madagascariensis_Long-billed Bernieria
-Bias musicus_Black-and-white Shrike-flycatcher
-Biatas nigropectus_White-bearded Antshrike
-Biziura lobata_Musk Duck
-Bleda canicapillus_Gray-headed Bristlebill
-Bleda notatus_Lesser Bristlebill
-Bleda syndactylus_Red-tailed Bristlebill
-Blythipicus pyrrhotis_Bay Woodpecker
-Blythipicus rubiginosus_Maroon Woodpecker
-Boissonneaua flavescens_Buff-tailed Coronet
-Boissonneaua jardini_Velvet-purple Coronet
-Boissonneaua matthewsii_Chestnut-breasted Coronet
-Bolbopsittacus lunulatus_Guaiabero
-Bolborhynchus lineola_Barred Parakeet
-Bolborhynchus orbygnesius_Andean Parakeet
-Bolemoreus frenatus_Bridled Honeyeater
-Bombycilla cedrorum_Cedar Waxwing
-Bombycilla garrulus_黃連雀
-Bombycilla japonica_朱連雀
-Bonasa umbellus_Ruffed Grouse
-Bostrychia carunculata_Wattled Ibis
-Bostrychia hagedash_Hadada Ibis
-Botaurus lentiginosus_American Bittern
-Botaurus stellaris_大麻鷺
-Brachygalba albogularis_White-throated Jacamar
-Brachygalba lugubris_Brown Jacamar
-Brachypodius eutilotus_Puff-backed Bulbul
-Brachypodius melanocephalos_Black-headed Bulbul
-Brachypodius melanoleucos_Black-and-white Bulbul
-Brachypodius priocephalus_Gray-headed Bulbul
-Brachypodius urostictus_Yellow-wattled Bulbul
-Brachypteryx cruralis_Himalayan Shortwing
-Brachypteryx goodfellowi_小翼鶇
-Brachypteryx hyperythra_Rusty-bellied Shortwing
-Brachypteryx leucophris_白喉短翅鶇
-Brachypteryx montana_White-browed Shortwing (Javan)
-Brachyramphus marmoratus_Marbled Murrelet
-Bradornis microrhynchus_African Gray Flycatcher
-Bradypterus baboecala_Little Rush Warbler
-Bradypterus barratti_Barratt's Warbler
-Bradypterus brunneus_Brown Emutail
-Bradypterus carpalis_White-winged Swamp Warbler
-Bradypterus cinnamomeus_Cinnamon Bracken-Warbler
-Bradypterus lopezi_Evergreen-forest Warbler
-Bradypterus sylvaticus_Knysna Warbler
+Atlapetes albinucha_白颈薮雀
+Atlapetes albofrenatus_白须薮雀
+Atlapetes citrinellus_黄纹薮雀
+Atlapetes flaviceps_绿头薮雀
+Atlapetes fulviceps_黄头薮雀
+Atlapetes fuscoolivaceus_乌头薮雀
+Atlapetes latinuchus_黄胸薮雀
+Atlapetes leucopis_白翅缘薮雀
+Atlapetes leucopterus_白翅薮雀
+Atlapetes melanocephalus_哥伦比亚薮雀
+Atlapetes melanolaemus_灰耳薮雀
+Atlapetes pallidiceps_苍头薮雀
+Atlapetes pallidinucha_黄枕薮雀
+Atlapetes personatus_栗头薮雀
+Atlapetes pileatus_棕顶薮雀
+Atlapetes rufigenis_棕耳薮雀
+Atlapetes rufinucha_棕枕薮雀
+Atlapetes schistaceus_灰蓝薮雀
+Atlapetes semirufus_赭胸薮雀
+Atlapetes tibialis_黄踝饰雀
+Atlapetes tricolor_三色薮雀
+Atrichornis clamosus_噪薮鸟
+Atrichornis rufescens_棕薮鸟
+Attagis gayi_棕腹籽鹬
+Atticora fasciata_白斑燕
+Atticora pileata_黑顶南美燕
+Atticora tibialis_白腿燕
+Attila bolivianus_暗顶阿蒂霸鹟
+Attila cinnamomeus_桂红阿蒂霸鹟
+Attila citriniventris_黄腹阿蒂霸鹟
+Attila phoenicurus_褐尾阿蒂霸鹟
+Attila rufus_灰头阿蒂霸鹟
+Attila spadiceus_亮腰阿蒂霸鹟
+Attila torridus_赭色阿蒂霸鹟
+Augastes lumachella_妆脸蜂鸟
+Augastes scutatus_紫蓝妆脸蜂鸟
+Aulacorhynchus albivitta_白喉巨嘴鸟
+Aulacorhynchus coeruleicinctis_蓝斑巨嘴鸟
+Aulacorhynchus derbianus_栗斑巨嘴鸟
+Aulacorhynchus haematopygus_绯腰巨嘴鸟
+Aulacorhynchus prasinus_绿巨嘴鸟
+Aulacorhynchus sulcatus_沟嘴巨嘴鸟
+Auriparus flaviceps_黄头金雀
+Automolus exsertus_巴拿马拾叶雀
+Automolus infuscatus_绿背拾叶雀
+Automolus leucophthalmus_白眼拾叶雀
+Automolus melanopezus_褐腰拾叶雀
+Automolus ochrolaemus_南黄喉拾叶雀
+Automolus paraensis_帕拉拾叶雀
+Automolus rufipileatus_栗冠拾叶雀
+Automolus subulatus_条纹拾叶雀
+Aviceda jerdoni_褐冠鹃隼
+Aviceda leuphotes_黑冠鹃隼
+Aviceda subcristata_凤头鹃隼
+Aythya affinis_小潜鸭
+Aythya americana_美洲潜鸭
+Aythya collaris_环颈潜鸭
+Aythya ferina_红头潜鸭
+Aythya fuligula_凤头潜鸭
+Aythya marila_斑背潜鸭
+Aythya nyroca_白眼潜鸭
+Aythya valisineria_帆背潜鸭
+Baeolophus atricristatus_黑冠凤头山雀
+Baeolophus bicolor_美洲凤头山雀
+Baeolophus inornatus_纯色冠山雀
+Baeolophus ridgwayi_林山雀
+Baeolophus wollweberi_白眉冠山雀
+Baeopogon indicator_白尾鹎
+Balearica regulorum_灰冕鹤
+Bambusicola fytchii_棕胸竹鸡
+Bambusicola sonorivox_台湾竹鸡
+Bambusicola thoracicus_灰胸竹鸡
+Bangsia aureocincta_金环唐纳雀
+Bangsia edwardsi_苔背唐纳雀
+Bangsia melanochlamys_黑金唐纳雀
+Barnardius zonarius_黑头环颈鹦鹉
+Bartramia longicauda_高原鹬
+Baryphthengus martii_棕翠鴗
+Baryphthengus ruficapillus_棕顶翠鴗
+Basileuterus belli_金眉王森莺
+Basileuterus culicivorus_金冠王森莺
+Basileuterus delattrii_栗顶王森莺
+Basileuterus lachrymosus_扇尾森莺
+Basileuterus melanogenys_黑颊王森莺
+Basileuterus melanotis_黑耳王森莺
+Basileuterus rufifrons_棕顶王森莺
+Basileuterus trifasciatus_三斑王森莺
+Basileuterus tristriatus_三纹王森莺
+Basilinna leucotis_白耳蜂鸟
+Batara cinerea_巨蚁鵙
+Bathmocercus rufus_黑脸棕莺
+Batis capensis_海角蓬背鹟
+Batis erlangeri_西黑头蓬背鹟
+Batis mixta_短尾蓬背鹟
+Batis molitor_点颏蓬背鹟
+Batis orientalis_灰头蓬背鹟
+Batis perkeo_侏蓬背鹟
+Batis pririt_南非蓬背鹟
+Batis soror_白颏蓬背鹟
+Batrachostomus affinis_星喉蟆口鸱
+Batrachostomus auritus_大蛙口夜鹰
+Batrachostomus cornutus_巽他蛙口夜鹰
+Batrachostomus hodgsoni_黑顶蟆口鸱
+Batrachostomus moniliger_领蛙口夜鹰
+Batrachostomus septimus_菲律宾蛙口夜鹰
+Batrachostomus stellatus_鳞腹蛙口夜鹰
+Berenicornis comatus_白冠犀鸟
+Berlepschia rikeri_尖尾棕榈雀
+Bernieria madagascariensis_长嘴马岛莺
+Bias musicus_黑白鵙鹟
+Biatas nigropectus_白须蚁鵙
+Biziura lobata_麝鸭
+Bleda canicapillus_灰头须鹎
+Bleda notatus_黄眼先须鹎
+Bleda syndactylus_须鹎
+Blythipicus pyrrhotis_黄嘴栗啄木鸟
+Blythipicus rubiginosus_小栗啄木鸟
+Boissonneaua flavescens_黄尾冕蜂鸟
+Boissonneaua jardini_紫冕蜂鸟
+Boissonneaua matthewsii_栗胸冕蜂鸟
+Bolbopsittacus lunulatus_菲律宾鹦鹉
+Bolborhynchus lineola_横斑鹦哥
+Bolborhynchus orbygnesius_安第斯鹦哥
+Bolemoreus frenatus_暗喉吸蜜鸟
+Bombycilla cedrorum_雪松太平鸟
+Bombycilla garrulus_太平鸟
+Bombycilla japonica_小太平鸟
+Bonasa umbellus_披肩榛鸡
+Bostrychia carunculata_肉垂鹮
+Bostrychia hagedash_噪鹮
+Botaurus lentiginosus_美洲麻鳽
+Botaurus stellaris_大麻鳽
+Brachygalba albogularis_白喉鹟䴕
+Brachygalba lugubris_褐鹟䴕
+Brachypodius eutilotus_凤头褐鹎
+Brachypodius melanocephalos_黑头鹎
+Brachypodius melanoleucos_黑白鹎
+Brachypodius priocephalus_灰头鹎
+Brachypodius urostictus_黄肉垂鹎
+Brachypteryx cruralis_喜山短翅鸫
+Brachypteryx goodfellowi_台湾短翅鸫
+Brachypteryx hyperythra_锈腹短翅鸫
+Brachypteryx leucophris_白喉短翅鸫
+Brachypteryx montana_蓝短翅鸫
+Brachyramphus marmoratus_云石斑海雀
+Bradornis microrhynchus_非洲灰鹟
+Bradypterus baboecala_蒲草短翅莺
+Bradypterus barratti_薮短翅莺
+Bradypterus brunneus_褐短翅莺
+Bradypterus carpalis_白翅短翅莺
+Bradypterus cinnamomeus_桂红短翅莺
+Bradypterus lopezi_喀麦隆短翅莺
+Bradypterus sylvaticus_灌丛短翅莺
 Branta bernicla_黑雁
-Branta canadensis_加拿大雁
-Branta hutchinsii_小加拿大雁
-Branta leucopsis_Barnacle Goose
-Branta sandvicensis_Hawaiian Goose
-Brotogeris chiriri_Yellow-chevroned Parakeet
-Brotogeris chrysoptera_Golden-winged Parakeet
-Brotogeris cyanoptera_Cobalt-winged Parakeet
-Brotogeris jugularis_Orange-chinned Parakeet
-Brotogeris pyrrhoptera_Gray-cheeked Parakeet
-Brotogeris sanctithomae_Tui Parakeet
-Brotogeris tirica_Plain Parakeet
-Brotogeris versicolurus_White-winged Parakeet
-Bubalornis albirostris_White-billed Buffalo-Weaver
-Bubalornis niger_Red-billed Buffalo-Weaver
-Bubo africanus_Spotted Eagle-Owl
-Bubo bengalensis_Rock Eagle-Owl
-Bubo bubo_鵰鴞
-Bubo coromandus_Dusky Eagle-Owl
-Bubo lacteus_Verreaux's Eagle-Owl
-Bubo nipalensis_Spot-bellied Eagle-Owl
-Bubo scandiacus_Snowy Owl
-Bubo sumatranus_Barred Eagle-Owl
-Bubo virginianus_Great Horned Owl
-Bubulcus ibis_黃頭鷺
-Bucanetes githagineus_Trumpeter Finch
-Buccanodon duchaillui_Yellow-spotted Barbet
-Bucco capensis_Collared Puffbird
-Bucco macrodactylus_Chestnut-capped Puffbird
-Bucco tamatia_Spotted Puffbird
-Bucephala albeola_Bufflehead
-Bucephala clangula_鵲鴨
-Bucephala islandica_Barrow's Goldeneye
-Buceros bicornis_Great Hornbill
-Buceros hydrocorax_Rufous Hornbill
-Buceros rhinoceros_Rhinoceros Hornbill
-Buceros vigil_Helmeted Hornbill
-Bucorvus leadbeateri_Southern Ground-Hornbill
-Bulweria bulwerii_穴鳥
-Buphagus africanus_Yellow-billed Oxpecker
-Buphagus erythrorynchus_Red-billed Oxpecker
-Burhinus bistriatus_Double-striped Thick-knee
-Burhinus capensis_Spotted Thick-knee
-Burhinus grallarius_Bush Thick-knee
-Burhinus indicus_Indian Thick-knee
-Burhinus oedicnemus_Eurasian Thick-knee
-Burhinus senegalensis_Senegal Thick-knee
-Burhinus superciliaris_Peruvian Thick-knee
-Burhinus vermiculatus_Water Thick-knee
-Busarellus nigricollis_Black-collared Hawk
-Butastur indicus_灰面鵟鷹
-Butastur teesa_White-eyed Buzzard
-Buteo albigula_White-throated Hawk
-Buteo albonotatus_Zone-tailed Hawk
-Buteo augur_Augur Buzzard
-Buteo brachypterus_Madagascar Buzzard
-Buteo brachyurus_Short-tailed Hawk
-Buteo buteo_歐亞鵟
-Buteo jamaicensis_Red-tailed Hawk
-Buteo japonicus_東方鵟
-Buteo lagopus_毛足鵟
-Buteo lineatus_Red-shouldered Hawk
-Buteo nitidus_Gray-lined Hawk
-Buteo oreophilus_Mountain Buzzard
-Buteo plagiatus_Gray Hawk
-Buteo platypterus_Broad-winged Hawk
-Buteo regalis_Ferruginous Hawk
-Buteo ridgwayi_Ridgway's Hawk
-Buteo solitarius_Hawaiian Hawk
-Buteo swainsoni_Swainson's Hawk
-Buteogallus anthracinus_Common Black Hawk
-Buteogallus coronatus_Chaco Eagle
-Buteogallus meridionalis_Savanna Hawk
-Buteogallus schistaceus_Slate-colored Hawk
-Buteogallus solitarius_Solitary Eagle
-Buteogallus urubitinga_Great Black Hawk
-Buthraupis montana_Hooded Mountain Tanager
-Butorides striata_綠簑鷺
-Butorides virescens_Green Heron
-Bycanistes albotibialis_White-thighed Hornbill
-Bycanistes brevis_Silvery-cheeked Hornbill
-Bycanistes bucinator_噪犀鳥
-Bycanistes fistulator_Piping Hornbill
-Bycanistes subcylindricus_Black-and-white-casqued Hornbill
-Cacatua alba_白鳳頭鸚鵡
-Cacatua ducorpsii_Ducorps's Cockatoo
-Cacatua galerita_葵花鳳頭鸚鵡
-Cacatua goffiniana_戈芬氏鳳頭鸚鵡
-Cacatua sanguinea_Little Corella
-Cacatua tenuirostris_Long-billed Corella
-Cacicus cela_Yellow-rumped Cacique
-Cacicus chrysonotus_Mountain Cacique
-Cacicus chrysopterus_Golden-winged Cacique
-Cacicus haemorrhous_Red-rumped Cacique
-Cacicus latirostris_Band-tailed Cacique
-Cacicus oseryi_Casqued Cacique
-Cacicus solitarius_Solitary Black Cacique
-Cacicus uropygialis_Scarlet-rumped Cacique
-Cacomantis castaneiventris_Chestnut-breasted Cuckoo
-Cacomantis flabelliformis_Fan-tailed Cuckoo
+Branta canadensis_加拿大黑雁
+Branta hutchinsii_小美洲黑雁
+Branta leucopsis_白颊黑雁
+Branta sandvicensis_夏威夷黑雁
+Brotogeris chiriri_黄翅斑鹦哥
+Brotogeris chrysoptera_金翅斑鹦哥
+Brotogeris cyanoptera_绣眼蓝翅鹦哥
+Brotogeris jugularis_橙颏鹦哥
+Brotogeris pyrrhoptera_灰颊鹦哥
+Brotogeris sanctithomae_图伊鹦哥
+Brotogeris tirica_纯色鹦哥
+Brotogeris versicolurus_淡黄翅鹦哥
+Bubalornis albirostris_白嘴牛文鸟
+Bubalornis niger_红嘴牛文鸟
+Bubo africanus_斑雕鸮
+Bubo bengalensis_印度雕鸮
+Bubo bubo_雕鸮
+Bubo coromandus_乌雕鸮
+Bubo lacteus_黄雕鸮
+Bubo nipalensis_林雕鸮
+Bubo scandiacus_雪鸮
+Bubo sumatranus_马来雕鸮
+Bubo virginianus_美洲雕鸮
+Bubulcus ibis_Cattle Egret
+Bucanetes githagineus_沙雀
+Buccanodon duchaillui_黄斑拟啄木鸟
+Bucco capensis_领蓬头䴕
+Bucco macrodactylus_栗顶蓬头䴕
+Bucco tamatia_斑蓬头䴕
+Bucephala albeola_白枕鹊鸭
+Bucephala clangula_鹊鸭
+Bucephala islandica_巴氏鹊鸭
+Buceros bicornis_双角犀鸟
+Buceros hydrocorax_棕犀鸟
+Buceros rhinoceros_马来犀鸟
+Buceros vigil_盔犀鸟
+Bucorvus leadbeateri_红脸地犀鸟
+Bulweria bulwerii_褐燕鹱
+Buphagus africanus_黄嘴牛椋鸟
+Buphagus erythrorynchus_红嘴牛椋鸟
+Burhinus bistriatus_双纹石鸻
+Burhinus capensis_斑石鸻
+Burhinus grallarius_长尾石鸻
+Burhinus indicus_印度石鸻
+Burhinus oedicnemus_石鸻
+Burhinus senegalensis_小石鸻
+Burhinus superciliaris_秘鲁石鸻
+Burhinus vermiculatus_水石鸻
+Busarellus nigricollis_黑领鹰
+Butastur indicus_灰脸鵟鹰
+Butastur teesa_白眼鵟鹰
+Buteo albigula_白喉鵟
+Buteo albonotatus_斑尾鵟
+Buteo augur_非洲鵟
+Buteo brachypterus_马岛鵟
+Buteo brachyurus_短尾鵟
+Buteo buteo_欧亚鵟
+Buteo jamaicensis_红尾鵟
+Buteo japonicus_普通鵟
+Buteo lagopus_毛脚鵟
+Buteo lineatus_赤肩鵟
+Buteo nitidus_灰纹鵟
+Buteo oreophilus_山鵟
+Buteo plagiatus_灰鵟
+Buteo platypterus_巨翅鵟
+Buteo regalis_锈色鵟
+Buteo ridgwayi_里氏鵟
+Buteo solitarius_夏威夷鵟
+Buteo swainsoni_斯氏鵟
+Buteogallus anthracinus_黑鸡鵟
+Buteogallus coronatus_冕雕
+Buteogallus meridionalis_草原鸡鵟
+Buteogallus schistaceus_青灰南美鵟
+Buteogallus solitarius_孤冕雕
+Buteogallus urubitinga_大黑鸡鵟
+Buthraupis montana_黑头山裸鼻雀
+Butorides striata_绿鹭
+Butorides virescens_美洲绿鹭
+Bycanistes albotibialis_白腿噪犀鸟
+Bycanistes brevis_银颊噪犀鸟
+Bycanistes bucinator_噪犀鸟
+Bycanistes fistulator_笛声噪犀鸟
+Bycanistes subcylindricus_黑白噪犀鸟
+Cacatua alba_白凤头鹦鹉
+Cacatua ducorpsii_杜氏凤头鹦鹉
+Cacatua galerita_葵花鹦鹉
+Cacatua goffiniana_戈氏凤头鹦鹉
+Cacatua sanguinea_小凤头鹦鹉
+Cacatua tenuirostris_长嘴凤头鹦鹉
+Cacicus cela_黄腰酋长鹂
+Cacicus chrysonotus_南山酋长鹂
+Cacicus chrysopterus_金翅酋长鹂
+Cacicus haemorrhous_红腰酋长鹂
+Cacicus latirostris_斑尾拟椋鸟
+Cacicus oseryi_盔拟椋鸟
+Cacicus solitarius_黑酋长鹂
+Cacicus uropygialis_亚热带酋长鹂
+Cacomantis castaneiventris_栗胸杜鹃
+Cacomantis flabelliformis_扇尾杜鹃
 Cacomantis leucolophus_White-crowned Koel
-Cacomantis merulinus_八聲杜鵑
-Cacomantis pallidus_Pallid Cuckoo
-Cacomantis passerinus_Gray-bellied Cuckoo
-Cacomantis sonneratii_Banded Bay Cuckoo
-Cacomantis variolosus_Brush Cuckoo
-Cairina moschata_疣鼻棲鴨(薑母鴨)
-Calamanthus fuliginosus_Striated Fieldwren
-Calamonastes fasciolatus_Barred Wren-Warbler
-Calamonastes simplex_Gray Wren-Warbler
-Calamonastes stierlingi_Stierling's Wren-Warbler
-Calamospiza melanocorys_Lark Bunting
-Calandrella acutirostris_Hume's Lark
-Calandrella brachydactyla_大短趾百靈
-Calandrella cinerea_Red-capped Lark
-Calandrella dukhunensis_賽氏短趾百靈
-Calcarius lapponicus_鐵爪鵐
-Calcarius ornatus_Chestnut-collared Longspur
-Calcarius pictus_Smith's Longspur
-Calendulauda africanoides_Fawn-colored Lark
-Calendulauda albescens_Karoo Lark
+Cacomantis merulinus_八声杜鹃
+Cacomantis pallidus_淡色杜鹃
+Cacomantis passerinus_灰腹杜鹃
+Cacomantis sonneratii_栗斑杜鹃
+Cacomantis variolosus_灌丛杜鹃
+Cairina moschata_疣鼻栖鸭
+Calamanthus fuliginosus_田刺莺
+Calamonastes fasciolatus_斑拱翅莺
+Calamonastes simplex_灰拱翅莺
+Calamonastes stierlingi_斯氏拱翅莺
+Calamospiza melanocorys_白斑黑鹀
+Calandrella acutirostris_细嘴短趾百灵
+Calandrella brachydactyla_大短趾百灵
+Calandrella cinerea_红顶短趾百灵
+Calandrella dukhunensis_蒙古短趾百灵
+Calcarius lapponicus_铁爪鹀
+Calcarius ornatus_栗领铁爪鹀
+Calcarius pictus_黄腹铁爪鹀
+Calendulauda africanoides_黄褐歌百灵
+Calendulauda albescens_红背歌百灵
 Calendulauda alopex_Foxy Lark
-Calendulauda poecilosterna_Pink-breasted Lark
-Calendulauda sabota_Sabota Lark
-Calicalicus madagascariensis_Red-tailed Vanga
-Calidris acuminata_尖尾濱鷸
-Calidris alba_三趾濱鷸
-Calidris alpina_黑腹濱鷸
-Calidris bairdii_Baird's Sandpiper
-Calidris canutus_紅腹濱鷸
-Calidris falcinellus_寬嘴鷸
-Calidris ferruginea_彎嘴濱鷸
-Calidris fuscicollis_White-rumped Sandpiper
-Calidris himantopus_高蹺濱鷸
-Calidris maritima_Purple Sandpiper
-Calidris mauri_西濱鷸
-Calidris melanotos_美洲尖尾濱鷸
-Calidris minuta_小濱鷸
-Calidris minutilla_Least Sandpiper
-Calidris ptilocnemis_Rock Sandpiper
-Calidris pugnax_流蘇鷸
-Calidris pusilla_Semipalmated Sandpiper
-Calidris pygmaea_琵嘴鷸
-Calidris ruficollis_紅胸濱鷸
-Calidris subminuta_長趾濱鷸
-Calidris subruficollis_黃胸鷸
-Calidris temminckii_丹氏濱鷸
-Calidris tenuirostris_大濱鷸
-Calidris virgata_Surfbird
-Caligavis chrysops_Yellow-faced Honeyeater
-Caligavis subfrenata_Black-throated Honeyeater
-Callacanthis burtoni_Spectacled Finch
-Callaeas wilsoni_North Island Kokako
-Calliope calliope_野鴝
-Calliope pectardens_Firethroat
-Calliope pectoralis_Himalayan Rubythroat
-Calliope tschebaiewi_Chinese Rubythroat
-Callipepla californica_California Quail
-Callipepla douglasii_Elegant Quail
-Callipepla gambelii_Gambel's Quail
-Callipepla squamata_Scaled Quail
-Callocephalon fimbriatum_Gang-gang Cockatoo
-Calocitta colliei_Black-throated Magpie-Jay
-Calocitta formosa_White-throated Magpie-Jay
-Calonectris diomedea_Cory's Shearwater
-Caloramphus fuliginosus_Brown Barbet
-Calothorax lucifer_Lucifer Hummingbird
-Calypte anna_Anna's Hummingbird
-Calypte costae_Costa's Hummingbird
-Calyptomena viridis_Green Broadbill
-Calyptomena whiteheadi_Whitehead's Broadbill
-Calyptophilus frugivorus_Eastern Chat-Tanager
-Calyptophilus tertius_Western Chat-Tanager
-Calyptorhynchus banksii_Red-tailed Black-Cockatoo
+Calendulauda poecilosterna_粉胸歌百灵
+Calendulauda sabota_萨博塔歌百灵
+Calicalicus madagascariensis_红尾钩嘴鵙
+Calidris acuminata_尖尾滨鹬
+Calidris alba_三趾滨鹬
+Calidris alpina_黑腹滨鹬
+Calidris bairdii_黑腰滨鹬
+Calidris canutus_红腹滨鹬
+Calidris falcinellus_阔嘴鹬
+Calidris ferruginea_弯嘴滨鹬
+Calidris fuscicollis_白腰滨鹬
+Calidris himantopus_高跷鹬
+Calidris maritima_紫滨鹬
+Calidris mauri_西方滨鹬
+Calidris melanotos_斑胸滨鹬
+Calidris minuta_小滨鹬
+Calidris minutilla_美洲小滨鹬
+Calidris ptilocnemis_岩滨鹬
+Calidris pugnax_流苏鹬
+Calidris pusilla_半蹼滨鹬
+Calidris pygmaea_勺嘴鹬
+Calidris ruficollis_红颈滨鹬
+Calidris subminuta_长趾滨鹬
+Calidris subruficollis_黄胸滨鹬
+Calidris temminckii_青脚滨鹬
+Calidris tenuirostris_大滨鹬
+Calidris virgata_短嘴鹬
+Caligavis chrysops_黄脸吸蜜鸟
+Caligavis subfrenata_黑喉吸蜜鸟
+Callacanthis burtoni_红眉金翅雀
+Callaeas wilsoni_北岛垂耳鸦
+Calliope calliope_红喉歌鸲
+Calliope pectardens_金胸歌鸲
+Calliope pectoralis_黑胸歌鸲
+Calliope tschebaiewi_白须黑胸歌鸲
+Callipepla californica_珠颈斑鹑
+Callipepla douglasii_华丽翎鹑
+Callipepla gambelii_黑腹翎鹑
+Callipepla squamata_鳞斑鹑
+Callocephalon fimbriatum_红冠灰凤头鹦鹉
+Calocitta colliei_黑喉鹊鸦
+Calocitta formosa_白喉鹊鸦
+Calonectris diomedea_斯氏鹱
+Caloramphus fuliginosus_褐拟啄木鸟
+Calothorax lucifer_瑰丽蜂鸟
+Calypte anna_安氏蜂鸟
+Calypte costae_科氏蜂鸟
+Calyptomena viridis_绿阔嘴鸟
+Calyptomena whiteheadi_黑喉绿阔嘴鸟
+Calyptophilus frugivorus_东䳭唐纳雀
+Calyptophilus tertius_西䳭唐纳雀
+Calyptorhynchus banksii_红尾凤头鹦鹉
 Calyptorhynchus funereus_Yellow-tailed Black-Cockatoo
-Calyptorhynchus lathami_Glossy Black-Cockatoo
+Calyptorhynchus lathami_辉凤头鹦鹉
 Calyptorhynchus latirostris_Carnaby's Black-Cockatoo
-Camaroptera brachyura_Green-backed Camaroptera
-Camaroptera chloronota_Olive-green Camaroptera
-Camaroptera superciliaris_Yellow-browed Camaroptera
-Campephaga flava_Black Cuckooshrike
-Campephaga quiscalina_Purple-throated Cuckooshrike
-Campephilus gayaquilensis_Guayaquil Woodpecker
-Campephilus guatemalensis_Pale-billed Woodpecker
-Campephilus haematogaster_Crimson-bellied Woodpecker
-Campephilus leucopogon_Cream-backed Woodpecker
-Campephilus magellanicus_Magellanic Woodpecker
-Campephilus melanoleucos_Crimson-crested Woodpecker
-Campephilus pollens_Powerful Woodpecker
-Campephilus robustus_Robust Woodpecker
-Campephilus rubricollis_Red-necked Woodpecker
-Campethera abingoni_Golden-tailed Woodpecker
-Campethera cailliautii_Green-backed Woodpecker
-Campethera mombassica_Mombasa Woodpecker
-Campethera nubica_Nubian Woodpecker
-Camptostoma imberbe_Northern Beardless-Tyrannulet
-Camptostoma obsoletum_Southern Beardless-Tyrannulet
-Campylopterus falcatus_Lazuline Sabrewing
-Campylopterus hemileucurus_Violet Sabrewing
-Campylopterus largipennis_Gray-breasted Sabrewing
-Campylorhamphus falcularius_Black-billed Scythebill
-Campylorhamphus procurvoides_Curve-billed Scythebill
-Campylorhamphus pusillus_Brown-billed Scythebill
-Campylorhamphus trochilirostris_Red-billed Scythebill
-Campylorhynchus albobrunneus_White-headed Wren
-Campylorhynchus brunneicapillus_Cactus Wren
-Campylorhynchus chiapensis_Giant Wren
-Campylorhynchus fasciatus_Fasciated Wren
-Campylorhynchus griseus_Bicolored Wren
-Campylorhynchus gularis_Spotted Wren
-Campylorhynchus jocosus_Boucard's Wren
-Campylorhynchus megalopterus_Gray-barred Wren
-Campylorhynchus nuchalis_Stripe-backed Wren
-Campylorhynchus rufinucha_Rufous-naped Wren
-Campylorhynchus turdinus_Thrush-like Wren
-Campylorhynchus yucatanicus_Yucatan Wren
-Campylorhynchus zonatus_Band-backed Wren
-Canachites canadensis_Spruce Grouse
+Camaroptera brachyura_绿背拱翅莺
+Camaroptera chloronota_绿拱翅莺
+Camaroptera superciliaris_黄眉拱翅莺
+Campephaga flava_黑鹃鵙
+Campephaga quiscalina_紫喉鹃鵙
+Campephilus gayaquilensis_厄瓜多尔啄木鸟
+Campephilus guatemalensis_淡嘴啄木鸟
+Campephilus haematogaster_朱腹啄木鸟
+Campephilus leucopogon_乳白背啄木鸟
+Campephilus magellanicus_阿根廷啄木鸟
+Campephilus melanoleucos_朱冠啄木鸟
+Campephilus pollens_红冠颈纹啄木鸟
+Campephilus robustus_南美啄木鸟
+Campephilus rubricollis_红颈啄木鸟
+Campethera abingoni_金尾啄木鸟
+Campethera cailliautii_绿背啄木鸟
+Campethera mombassica_蒙巴萨啄木鸟
+Campethera nubica_东非啄木鸟
+Camptostoma imberbe_北无须小霸鹟
+Camptostoma obsoletum_南无须小霸鹟
+Campylopterus falcatus_棕尾刀翅蜂鸟
+Campylopterus hemileucurus_紫刀翅蜂鸟
+Campylopterus largipennis_灰胸刀翅蜂鸟
+Campylorhamphus falcularius_黑嘴镰嘴䴕雀
+Campylorhamphus procurvoides_淡嘴镰嘴䴕雀
+Campylorhamphus pusillus_褐嘴镰嘴䴕雀
+Campylorhamphus trochilirostris_红嘴镰嘴䴕雀
+Campylorhynchus albobrunneus_白头曲嘴鹪鹩
+Campylorhynchus brunneicapillus_棕曲嘴鹪鹩
+Campylorhynchus chiapensis_大曲嘴鹪鹩
+Campylorhynchus fasciatus_横斑曲嘴鹪鹩
+Campylorhynchus griseus_灰曲嘴鹪鹩
+Campylorhynchus gularis_斑曲嘴鹪鹩
+Campylorhynchus jocosus_波氏曲嘴鹪鹩
+Campylorhynchus megalopterus_灰斑曲嘴鹪鹩
+Campylorhynchus nuchalis_纹背曲嘴鹪鹩
+Campylorhynchus rufinucha_棕颈曲嘴鹪鹩
+Campylorhynchus turdinus_拟鸫曲嘴鹪鹩
+Campylorhynchus yucatanicus_尤卡曲嘴鹪鹩
+Campylorhynchus zonatus_斑背曲嘴鹪鹩
+Canachites canadensis_枞树镰翅鸡
 Canis latrans_Coyote
 Canis lupus_Gray Wolf
-Cantorchilus elutus_Isthmian Wren
-Cantorchilus guarayanus_Fawn-breasted Wren
-Cantorchilus leucopogon_Stripe-throated Wren
-Cantorchilus leucotis_Buff-breasted Wren
-Cantorchilus longirostris_Long-billed Wren
-Cantorchilus modestus_Cabanis's Wren
-Cantorchilus nigricapillus_Bay Wren
-Cantorchilus semibadius_Riverside Wren
-Cantorchilus superciliaris_Superciliated Wren
-Cantorchilus thoracicus_Stripe-breasted Wren
-Cantorchilus zeledoni_Canebrake Wren
-Capito auratus_Gilded Barbet
-Capito aurovirens_Scarlet-crowned Barbet
-Capito dayi_Black-girdled Barbet
-Capito hypoleucus_White-mantled Barbet
-Capito niger_Black-spotted Barbet
-Capito quinticolor_Five-colored Barbet
-Capito squamatus_Orange-fronted Barbet
-Capito wallacei_Scarlet-banded Barbet
-Caprimulgus affinis_南亞夜鷹
-Caprimulgus asiaticus_Indian Nightjar
-Caprimulgus atripennis_Jerdon's Nightjar
-Caprimulgus clarus_Slender-tailed Nightjar
-Caprimulgus climacurus_Long-tailed Nightjar
-Caprimulgus europaeus_Eurasian Nightjar
-Caprimulgus fossii_Square-tailed Nightjar
-Caprimulgus indicus_Jungle Nightjar
-Caprimulgus jotaka_普通夜鷹
-Caprimulgus macrurus_Large-tailed Nightjar
-Caprimulgus madagascariensis_Madagascar Nightjar
-Caprimulgus manillensis_Philippine Nightjar
-Caprimulgus natalensis_Swamp Nightjar
+Cantorchilus elutus_地峡苇鹪鹩
+Cantorchilus guarayanus_褐胸苇鹪鹩
+Cantorchilus leucopogon_纹喉苇鹪鹩
+Cantorchilus leucotis_黄胸苇鹪鹩
+Cantorchilus longirostris_长嘴苇鹪鹩
+Cantorchilus modestus_纯色苇鹪鹩
+Cantorchilus nigricapillus_栗苇鹪鹩
+Cantorchilus semibadius_滨苇鹪鹩
+Cantorchilus superciliaris_纹眉苇鹪鹩
+Cantorchilus thoracicus_纹胸苇鹪鹩
+Cantorchilus zeledoni_灰冠苇鹪鹩
+Capito auratus_金胸拟啄木鸟
+Capito aurovirens_红顶拟啄木鸟
+Capito dayi_黑环拟啄木鸟
+Capito hypoleucus_白背拟啄木鸟
+Capito niger_红喉拟啄木鸟
+Capito quinticolor_五色拟啄木鸟
+Capito squamatus_橙额拟啄木鸟
+Capito wallacei_红领须啄木鸟
+Caprimulgus affinis_林夜鹰
+Caprimulgus asiaticus_印度夜鹰
+Caprimulgus atripennis_印度长尾夜鹰
+Caprimulgus clarus_细尾夜鹰
+Caprimulgus climacurus_非洲长尾夜鹰
+Caprimulgus europaeus_欧夜鹰
+Caprimulgus fossii_方尾夜鹰
+Caprimulgus indicus_丛林夜鹰
+Caprimulgus jotaka_普通夜鹰
+Caprimulgus macrurus_长尾夜鹰
+Caprimulgus madagascariensis_马岛夜鹰
+Caprimulgus manillensis_菲律宾夜鹰
+Caprimulgus natalensis_非洲白尾夜鹰
 Caprimulgus nigriscapularis_Black-shouldered Nightjar
-Caprimulgus pectoralis_Fiery-necked Nightjar
-Caprimulgus poliocephalus_Montane Nightjar
-Caprimulgus ruficollis_Red-necked Nightjar
-Caprimulgus rufigena_Rufous-cheeked Nightjar
-Caprimulgus tristigma_Freckled Nightjar
-Capsiempis flaveola_Yellow Tyrannulet
-Caracara plancus_Crested Caracara
-Cardellina canadensis_Canada Warbler
-Cardellina pusilla_Wilson's Warbler
-Cardellina rubra_Red Warbler
-Cardellina rubrifrons_Red-faced Warbler
-Cardellina versicolor_Pink-headed Warbler
-Cardinalis cardinalis_Northern Cardinal
-Cardinalis phoeniceus_Vermilion Cardinal
-Cardinalis sinuatus_Pyrrhuloxia
-Carduelis carduelis_European Goldfinch
-Carduelis citrinella_Citril Finch
-Carduelis corsicana_Corsican Finch
-Cariama cristata_Red-legged Seriema
-Carpococcyx radiceus_Bornean Ground-Cuckoo
-Carpococcyx renauldi_Coral-billed Ground-Cuckoo
-Carpodacus dubius_Chinese White-browed Rosefinch
+Caprimulgus pectoralis_非洲夜鹰
+Caprimulgus poliocephalus_灰头夜鹰
+Caprimulgus ruficollis_红颈夜鹰
+Caprimulgus rufigena_棕颊夜鹰
+Caprimulgus tristigma_雀斑夜鹰
+Capsiempis flaveola_黄小霸鹟
+Caracara plancus_凤头巨隼
+Cardellina canadensis_加拿大威森莺
+Cardellina pusilla_黑头威森莺
+Cardellina rubra_红头虫莺
+Cardellina rubrifrons_红脸森莺
+Cardellina versicolor_粉头虫莺
+Cardinalis cardinalis_主红雀
+Cardinalis phoeniceus_锡嘴主红雀
+Cardinalis sinuatus_灰额主红雀
+Carduelis carduelis_红额金翅雀
+Carduelis citrinella_桔黄丝雀
+Carduelis corsicana_科西嘉黄丝雀
+Cariama cristata_红腿叫鹤
+Carpococcyx radiceus_地鹃
+Carpococcyx renauldi_瑞氏红嘴地鹃
+Carpodacus dubius_白眉朱雀
 Carpodacus erythrinus_普通朱雀
-Carpodacus puniceus_Red-fronted Rosefinch
-Carpodacus rodochroa_Pink-browed Rosefinch
-Carpodacus rubicilla_Great Rosefinch
-Carpodacus rubicilloides_Streaked Rosefinch
-Carpodacus sibiricus_Long-tailed Rosefinch
-Carpodacus synoicus_Sinai Rosefinch
-Carpodacus thura_Himalayan White-browed Rosefinch
-Carpornis cucullata_Hooded Berryeater
-Carpornis melanocephala_Black-headed Berryeater
-Carpospiza brachydactyla_Pale Rockfinch
-Carterornis chrysomela_Golden Monarch
-Carterornis leucotis_White-eared Monarch
-Carterornis pileatus_White-naped Monarch
-Caryothraustes canadensis_Yellow-green Grosbeak
-Caryothraustes poliogaster_Black-faced Grosbeak
-Casiornis rufus_Rufous Casiornis
-Cassiculus melanicterus_Yellow-winged Cacique
-Casuarius casuarius_Southern Cassowary
-Catamblyrhynchus diadema_Plushcap
-Catamenia analis_Band-tailed Seedeater
-Catamenia homochroa_Paramo Seedeater
-Catamenia inornata_Plain-colored Seedeater
-Cathartes aura_Turkey Vulture
-Catharus aurantiirostris_Orange-billed Nightingale-Thrush
-Catharus bicknelli_Bicknell's Thrush
-Catharus dryas_Yellow-throated Nightingale-Thrush
-Catharus frantzii_Ruddy-capped Nightingale-Thrush
-Catharus fuscater_Slaty-backed Nightingale-Thrush
-Catharus fuscescens_Veery
-Catharus gracilirostris_Black-billed Nightingale-Thrush
-Catharus guttatus_Hermit Thrush
-Catharus maculatus_Speckled Nightingale-Thrush
-Catharus mexicanus_Black-headed Nightingale-Thrush
-Catharus minimus_Gray-cheeked Thrush
-Catharus occidentalis_Russet Nightingale-Thrush
-Catharus ustulatus_Swainson's Thrush
-Catherpes mexicanus_Canyon Wren
-Catreus wallichii_Cheer Pheasant
-Cecropis abyssinica_Lesser Striped Swallow
-Cecropis cucullata_Greater Striped Swallow
+Carpodacus puniceus_红胸朱雀
+Carpodacus rodochroa_玫红眉朱雀
+Carpodacus rubicilla_大朱雀
+Carpodacus rubicilloides_拟大朱雀
+Carpodacus sibiricus_长尾雀
+Carpodacus synoicus_西沙色朱雀
+Carpodacus thura_喜山白眉朱雀
+Carpornis cucullata_冠食果伞鸟
+Carpornis melanocephala_黑头食果伞鸟
+Carpospiza brachydactyla_淡色石雀
+Carterornis chrysomela_金王鹟
+Carterornis leucotis_白耳王鹟
+Carterornis pileatus_白枕王鹟
+Caryothraustes canadensis_黄绿厚嘴雀
+Caryothraustes poliogaster_黑脸厚嘴雀
+Casiornis rufus_棕卡西霸鹟
+Cassiculus melanicterus_黄翅酋长鹂
+Casuarius casuarius_双垂鹤鸵
+Catamblyrhynchus diadema_绒顶唐纳雀
+Catamenia analis_斑尾栗臀雀
+Catamenia homochroa_黄嘴栗臀雀
+Catamenia inornata_纯色栗臀雀
+Cathartes aura_红头美洲鹫
+Catharus aurantiirostris_橙腹夜鸫
+Catharus bicknelli_比氏夜鸫
+Catharus dryas_斑夜鸫
+Catharus frantzii_红顶夜鸫
+Catharus fuscater_灰背夜鸫
+Catharus fuscescens_棕夜鸫
+Catharus gracilirostris_黑嘴夜鸫
+Catharus guttatus_隐夜鸫
+Catharus maculatus_斯克氏夜鸫
+Catharus mexicanus_黑头夜鸫
+Catharus minimus_灰颊夜鸫
+Catharus occidentalis_茶色夜鸫
+Catharus ustulatus_斯氏夜鸫
+Catherpes mexicanus_墨西哥鹪鹩
+Catreus wallichii_彩雉
+Cecropis abyssinica_小纹燕
+Cecropis cucullata_大纹燕
 Cecropis daurica_金腰燕
-Cecropis semirufa_Rufous-chested Swallow
-Cecropis striolata_赤腰燕
-Celeus castaneus_Chestnut-colored Woodpecker
-Celeus elegans_Chestnut Woodpecker
-Celeus flavescens_Blond-crested Woodpecker
-Celeus flavus_Cream-colored Woodpecker
-Celeus galeatus_Helmeted Woodpecker
+Cecropis semirufa_褐胸燕
+Cecropis striolata_Striated Swallow
+Celeus castaneus_中美栗啄木鸟
+Celeus elegans_南美栗啄木鸟
+Celeus flavescens_淡黄冠啄木鸟
+Celeus flavus_乳白啄木鸟
+Celeus galeatus_盔啄木鸟
 Celeus grammicus_Scale-breasted Woodpecker
-Celeus loricatus_Cinnamon Woodpecker
-Celeus lugubris_Pale-crested Woodpecker
-Celeus obrieni_Kaempfer's Woodpecker
-Celeus ochraceus_Ochre-backed Woodpecker
-Celeus spectabilis_Rufous-headed Woodpecker
-Celeus torquatus_Ringed Woodpecker
-Celeus undatus_Waved Woodpecker
-Centrocercus urophasianus_Greater Sage-Grouse
-Centronyx bairdii_Baird's Sparrow
-Centronyx henslowii_Henslow's Sparrow
-Centropus andamanensis_Andaman Coucal
-Centropus bengalensis_番鵑
-Centropus celebensis_Bay Coucal
-Centropus chlororhynchos_Green-billed Coucal
-Centropus leucogaster_Black-throated Coucal
-Centropus melanops_Black-faced Coucal
-Centropus menbeki_Greater Black Coucal
-Centropus milo_Buff-headed Coucal
-Centropus monachus_Blue-headed Coucal
-Centropus phasianinus_Pheasant Coucal
-Centropus rectunguis_Short-toed Coucal
-Centropus senegalensis_Senegal Coucal
-Centropus sinensis_褐翅鴉鵑
-Centropus superciliosus_White-browed Coucal
-Centropus toulou_Malagasy Coucal
-Centropus viridis_Philippine Coucal
-Cephalopterus penduliger_Long-wattled Umbrellabird
-Cepphus columba_Pigeon Guillemot
-Cepphus grylle_Black Guillemot
-Ceratogymna atrata_Black-casqued Hornbill
-Ceratopipra chloromeros_Round-tailed Manakin
-Ceratopipra cornuta_Scarlet-horned Manakin
-Ceratopipra erythrocephala_Golden-headed Manakin
-Ceratopipra mentalis_Red-capped Manakin
-Ceratopipra rubrocapilla_Red-headed Manakin
-Cercibis oxycerca_Sharp-tailed Ibis
-Cercococcyx mechowi_Dusky Long-tailed Cuckoo
-Cercococcyx montanus_Barred Long-tailed Cuckoo
-Cercococcyx olivinus_Olive Long-tailed Cuckoo
-Cercomacra brasiliana_Rio de Janeiro Antbird
-Cercomacra carbonaria_Rio Branco Antbird
-Cercomacra cinerascens_Gray Antbird
-Cercomacra ferdinandi_Bananal Antbird
-Cercomacra manu_Manu Antbird
-Cercomacra melanaria_Mato Grosso Antbird
-Cercomacra nigricans_Jet Antbird
-Cercomacroides fuscicauda_Riparian Antbird
-Cercomacroides laeta_Willis's Antbird
-Cercomacroides nigrescens_Blackish Antbird
-Cercomacroides parkeri_Parker's Antbird
-Cercomacroides serva_Black Antbird
-Cercomacroides tyrannina_Dusky Antbird
-Cercotrichas barbata_Miombo Scrub-Robin
-Cercotrichas coryphoeus_Karoo Scrub-Robin
-Cercotrichas galactotes_Rufous-tailed Scrub-Robin
-Cercotrichas hartlaubi_Brown-backed Scrub-Robin
-Cercotrichas leucophrys_Red-backed Scrub-Robin
-Cercotrichas paena_Kalahari Scrub-Robin
-Cercotrichas podobe_Black Scrub-Robin
-Cercotrichas quadrivirgata_Bearded Scrub-Robin
-Cercotrichas signata_Brown Scrub-Robin
-Certhia americana_Brown Creeper
-Certhia brachydactyla_Short-toed Treecreeper
-Certhia discolor_Sikkim Treecreeper
-Certhia familiaris_Eurasian Treecreeper
-Certhia himalayana_Bar-tailed Treecreeper
-Certhia hodgsoni_Hodgson's Treecreeper
-Certhia manipurensis_Hume's Treecreeper
-Certhiasomus stictolaemus_Spot-throated Woodcreeper
-Certhiaxis cinnamomeus_Yellow-chinned Spinetail
-Certhiaxis mustelinus_Red-and-white Spinetail
-Certhilauda chuana_Short-clawed Lark
-Certhilauda semitorquata_Eastern Long-billed Lark
-Certhilauda subcoronata_Karoo Long-billed Lark
-Certhionyx variegatus_Pied Honeyeater
-Ceryle rudis_斑翡翠
-Cettia brunnifrons_Gray-sided Bush Warbler
-Cettia castaneocoronata_Chestnut-headed Tesia
-Cettia cetti_Cetti's Warbler
-Cettia major_Chestnut-crowned Bush Warbler
-Ceuthmochares aereus_Blue Malkoha
-Ceuthmochares australis_Green Malkoha
-Ceyx azureus_Azure Kingfisher
-Ceyx erithaca_黑背三趾翠鳥
-Chaetocercus mulsant_White-bellied Woodstar
-Chaetops frenatus_Cape Rockjumper
-Chaetura brachyura_Short-tailed Swift
-Chaetura chapmani_Chapman's Swift
-Chaetura cinereiventris_Gray-rumped Swift
-Chaetura meridionalis_Sick's Swift
-Chaetura pelagica_Chimney Swift
-Chaetura spinicaudus_Band-rumped Swift
-Chaetura vauxi_Vaux's Swift
-Chalcomitra amethystina_Amethyst Sunbird
-Chalcomitra senegalensis_Scarlet-chested Sunbird
-Chalcoparia singalensis_Ruby-cheeked Sunbird
-Chalcophaps indica_翠翼鳩
-Chalcophaps longirostris_Pacific Emerald Dove
-Chalcophaps stephani_Stephan's Dove
-Chalybura buffonii_White-vented Plumeleteer
-Chalybura urochrysia_Bronze-tailed Plumeleteer
-Chamaea fasciata_Wrentit
-Chamaepetes goudotii_Sickle-winged Guan
-Chamaepetes unicolor_Black Guan
-Chamaetylas fuelleborni_White-chested Alethe
-Chamaetylas poliocephala_Brown-chested Alethe
-Chamaeza campanisona_Short-tailed Antthrush
-Chamaeza meruloides_Such's Antthrush
-Chamaeza mollissima_Barred Antthrush
-Chamaeza nobilis_Striated Antthrush
-Chamaeza ruficauda_Rufous-tailed Antthrush
-Chamaeza turdina_Schwartz's Antthrush
-Charadrius alexandrinus_東方環頸鴴
-Charadrius bicinctus_Double-banded Plover
-Charadrius collaris_Collared Plover
-Charadrius dubius_小環頸鴴
-Charadrius falklandicus_Two-banded Plover
-Charadrius hiaticula_環頸鴴
-Charadrius javanicus_Javan Plover
-Charadrius leschenaultii_鐵嘴鴴
-Charadrius melodus_Piping Plover
-Charadrius modestus_Rufous-chested Dotterel
-Charadrius mongolus_蒙古鴴
-Charadrius montanus_Mountain Plover
-Charadrius morinellus_Eurasian Dotterel
-Charadrius nivosus_Snowy Plover
-Charadrius peronii_Malaysian Plover
-Charadrius placidus_劍鴴
-Charadrius semipalmatus_Semipalmated Plover
-Charadrius tricollaris_Three-banded Plover
-Charadrius veredus_東方紅胸鴴
-Charadrius vociferus_Killdeer
-Charadrius wilsonia_Wilson's Plover
-Charitospiza eucosma_Coal-crested Finch
-Charmosyna papou_Papuan Lorikeet
-Chasiempis ibidis_Oahu Elepaio
-Chasiempis sandwichensis_Hawaii Elepaio
-Chasiempis sclateri_Kauai Elepaio
-Chauna chavaria_Northern Screamer
-Chauna torquata_Southern Screamer
-Chelidoptera tenebrosa_Swallow-winged Puffbird
-Chelidorhynx hypoxanthus_Yellow-bellied Fairy-Fantail
-Chenonetta jubata_Maned Duck
-Chersomanes albofasciata_Spike-heeled Lark
-Chersophilus duponti_Dupont's Lark
-Chionomesa fimbriata_Glittering-throated Emerald
-Chionomesa lactea_Sapphire-spangled Emerald
-Chiroxiphia boliviana_Yungas Manakin
-Chiroxiphia caudata_Swallow-tailed Manakin
-Chiroxiphia lanceolata_Lance-tailed Manakin
-Chiroxiphia linearis_Long-tailed Manakin
-Chiroxiphia pareola_Blue-backed Manakin
-Chlamydera maculata_Spotted Bowerbird
-Chlamydera nuchalis_Great Bowerbird
-Chlidonias albostriatus_Black-fronted Tern
-Chlidonias hybrida_黑腹燕鷗
-Chlidonias leucopterus_白翅黑燕鷗
-Chlidonias niger_黑浮鷗
-Chloephaga picta_Upland Goose
-Chlorestes candida_White-bellied Emerald
-Chlorestes cyanus_White-chinned Sapphire
-Chlorestes eliciae_Blue-throated Goldentail
-Chlorestes julie_Violet-bellied Hummingbird
-Chlorestes notata_Blue-chinned Sapphire
-Chloris chloris_European Greenfinch
-Chloris monguilloti_Vietnamese Greenfinch
+Celeus loricatus_桂红啄木鸟
+Celeus lugubris_白冠啄木鸟
+Celeus obrieni_肯氏啄木鸟
+Celeus ochraceus_赭背啄木鸟
+Celeus spectabilis_棕头啄木鸟
+Celeus torquatus_环颈啄木鸟
+Celeus undatus_波斑啄木鸟
+Centrocercus urophasianus_艾草松鸡
+Centronyx bairdii_贝氏草鹀
+Centronyx henslowii_亨氏草鹀
+Centropus andamanensis_褐鸦鹃
+Centropus bengalensis_小鸦鹃
+Centropus celebensis_苏拉威西鸦鹃
+Centropus chlororhynchos_绿嘴鸦鹃
+Centropus leucogaster_黑喉鸦鹃
+Centropus melanops_黑脸鸦鹃
+Centropus menbeki_大鸦鹃
+Centropus milo_黄头鸦鹃
+Centropus monachus_蓝头鸦鹃
+Centropus phasianinus_雉鸦鹃
+Centropus rectunguis_短趾鸦鹃
+Centropus senegalensis_塞内加尔鸦鹃
+Centropus sinensis_褐翅鸦鹃
+Centropus superciliosus_白眉鸦鹃
+Centropus toulou_马岛小鸦鹃
+Centropus viridis_绿鸦鹃
+Cephalopterus penduliger_长耳垂伞鸟
+Cepphus columba_海鸽
+Cepphus grylle_白翅斑海鸽
+Ceratogymna atrata_黑盔噪犀鸟
+Ceratopipra chloromeros_圆尾娇鹟
+Ceratopipra cornuta_红角娇鹟
+Ceratopipra erythrocephala_金头娇鹟
+Ceratopipra mentalis_红顶娇鹟
+Ceratopipra rubrocapilla_红头娇鹟
+Cercibis oxycerca_长尾鹮
+Cercococcyx mechowi_暗色长尾鹃
+Cercococcyx montanus_长尾鹃
+Cercococcyx olivinus_绿长尾鹃
+Cercomacra brasiliana_里约蚁鸟
+Cercomacra carbonaria_巴西蚁鸟
+Cercomacra cinerascens_灰蚁鸟
+Cercomacra ferdinandi_巴纳蚁鸟
+Cercomacra manu_马努蚁鸟
+Cercomacra melanaria_马托蚁鸟
+Cercomacra nigricans_辉黑蚁鸟
+Cercomacroides fuscicauda_河岸蚁鸟
+Cercomacroides laeta_威氏蚁鸟
+Cercomacroides nigrescens_淡黑蚁鸟
+Cercomacroides parkeri_帕氏蚁鸟
+Cercomacroides serva_黑蚁鸟
+Cercomacroides tyrannina_暗蚁鸟
+Cercotrichas barbata_须薮鸲
+Cercotrichas coryphoeus_栗腹薮鸲
+Cercotrichas galactotes_棕薮鸲
+Cercotrichas hartlaubi_褐背薮鸲
+Cercotrichas leucophrys_白眉薮鸲
+Cercotrichas paena_沙薮鸲
+Cercotrichas podobe_黑薮鸲
+Cercotrichas quadrivirgata_东须薮鸲
+Cercotrichas signata_褐薮鸲
+Certhia americana_美洲旋木雀
+Certhia brachydactyla_短趾旋木雀
+Certhia discolor_褐喉旋木雀
+Certhia familiaris_旋木雀
+Certhia himalayana_高山旋木雀
+Certhia hodgsoni_霍氏旋木雀
+Certhia manipurensis_休氏旋木雀
+Certhiasomus stictolaemus_斑喉䴕雀
+Certhiaxis cinnamomeus_黄颏针尾雀
+Certhiaxis mustelinus_红白针尾雀
+Certhilauda chuana_短爪歌百灵
+Certhilauda semitorquata_半颈环歌百灵
+Certhilauda subcoronata_卡鲁歌百灵
+Certhionyx variegatus_白肩黑吸蜜鸟
+Ceryle rudis_斑鱼狗
+Cettia brunnifrons_棕顶树莺
+Cettia castaneocoronata_栗头地莺
+Cettia cetti_宽尾树莺
+Cettia major_大树莺
+Ceuthmochares aereus_黄嘴鹃
+Ceuthmochares australis_哨声黄嘴鹃
+Ceyx azureus_蓝翠鸟
+Ceyx erithaca_三趾翠鸟
+Chaetocercus mulsant_白腹林蜂鸟
+Chaetops frenatus_棕岩鸫
+Chaetura brachyura_短尾雨燕
+Chaetura chapmani_查氏雨燕
+Chaetura cinereiventris_淡腰雨燕
+Chaetura meridionalis_西氏雨燕
+Chaetura pelagica_烟囱雨燕
+Chaetura spinicaudus_斑腰雨燕
+Chaetura vauxi_沃氏雨燕
+Chalcomitra amethystina_艾米花蜜鸟
+Chalcomitra senegalensis_赤胸花蜜鸟
+Chalcoparia singalensis_紫颊直嘴太阳鸟
+Chalcophaps indica_绿翅金鸠
+Chalcophaps longirostris_太平洋金鸠
+Chalcophaps stephani_褐背金鸠
+Chalybura buffonii_白腹棕尾蜂鸟
+Chalybura urochrysia_斑胸棕尾蜂鸟
+Chamaea fasciata_鹪雀莺
+Chamaepetes goudotii_褐镰翅冠雉
+Chamaepetes unicolor_黑镰翅冠雉
+Chamaetylas fuelleborni_白胸鸲鸫
+Chamaetylas poliocephala_褐胸鸲鸫
+Chamaeza campanisona_短尾蚁鸫
+Chamaeza meruloides_萨氏蚁鸫
+Chamaeza mollissima_横斑蚁鸫
+Chamaeza nobilis_纵纹蚁鸫
+Chamaeza ruficauda_棕尾蚁鸫
+Chamaeza turdina_施氏蚁鸫
+Charadrius alexandrinus_环颈鸻
+Charadrius bicinctus_栗胸鸻
+Charadrius collaris_领鸻
+Charadrius dubius_金眶鸻
+Charadrius falklandicus_双斑鸻
+Charadrius hiaticula_剑鸻
+Charadrius javanicus_爪哇鸻
+Charadrius leschenaultii_Greater Sand-Plover
+Charadrius melodus_笛鸻
+Charadrius modestus_棕胸鸻
+Charadrius mongolus_Lesser Sand-Plover
+Charadrius montanus_岩鸻
+Charadrius morinellus_小嘴鸻
+Charadrius nivosus_雪鸻
+Charadrius peronii_马来鸻
+Charadrius placidus_长嘴剑鸻
+Charadrius semipalmatus_半蹼鸻
+Charadrius tricollaris_三色鸻
+Charadrius veredus_东方鸻
+Charadrius vociferus_双领鸻
+Charadrius wilsonia_厚嘴鸻
+Charitospiza eucosma_煤冠雀
+Charmosyna papou_巴布亚鹦鹉
+Chasiempis ibidis_檀香山蚋鹟
+Chasiempis sandwichensis_蚋鹟
+Chasiempis sclateri_考岛蚋鹟
+Chauna chavaria_黑颈冠叫鸭
+Chauna torquata_冠叫鸭
+Chelidoptera tenebrosa_燕翅䴕
+Chelidorhynx hypoxanthus_黄腹扇尾鹟
+Chenonetta jubata_鬃林鸭
+Chersomanes albofasciata_直爪百灵
+Chersophilus duponti_杜氏百灵
+Chionomesa fimbriata_辉喉蜂鸟
+Chionomesa lactea_蓝喉蜂鸟
+Chiroxiphia boliviana_玻利维亚娇鹟
+Chiroxiphia caudata_燕尾娇鹟
+Chiroxiphia lanceolata_尖尾娇鹟
+Chiroxiphia linearis_长尾娇鹟
+Chiroxiphia pareola_蓝背娇鹟
+Chlamydera maculata_斑大亭鸟
+Chlamydera nuchalis_大亭鸟
+Chlidonias albostriatus_黑额燕鸥
+Chlidonias hybrida_须浮鸥
+Chlidonias leucopterus_白翅浮鸥
+Chlidonias niger_黑浮鸥
+Chloephaga picta_斑胁草雁
+Chlorestes candida_白腹绿蜂鸟
+Chlorestes cyanus_白颊红嘴蜂鸟
+Chlorestes eliciae_蓝喉红嘴蜂鸟
+Chlorestes julie_紫腹蜂鸟
+Chlorestes notata_蓝颏青蜂鸟
+Chloris chloris_欧金翅雀
+Chloris monguilloti_越南金翅雀
 Chloris sinica_金翅雀
-Chloris spinoides_Yellow-breasted Greenfinch
-Chloroceryle aenea_American Pygmy Kingfisher
-Chloroceryle amazona_Amazon Kingfisher
-Chloroceryle americana_Green Kingfisher
-Chloroceryle inda_Green-and-rufous Kingfisher
-Chlorochrysa phoenicotis_Glistening-green Tanager
-Chlorocichla flaviventris_Yellow-bellied Greenbul
-Chlorocichla laetissima_Joyful Greenbul
-Chlorocichla simplex_Simple Greenbul
-Chlorodrepanis flava_Oahu Amakihi
-Chlorodrepanis stejnegeri_Kauai Amakihi
-Chlorodrepanis virens_Hawaii Amakihi
-Chlorophanes spiza_Green Honeycreeper
-Chlorophonia callophrys_Golden-browed Chlorophonia
-Chlorophonia cyanea_Blue-naped Chlorophonia
-Chlorophonia cyanocephala_Golden-rumped Euphonia
-Chlorophonia elegantissima_Elegant Euphonia
-Chlorophonia flavirostris_Yellow-collared Chlorophonia
-Chlorophonia musica_Antillean Euphonia
-Chlorophonia occipitalis_Blue-crowned Chlorophonia
-Chlorophonia pyrrhophrys_Chestnut-breasted Chlorophonia
-Chloropicus fuscescens_Cardinal Woodpecker
+Chloris spinoides_高山金翅雀
+Chloroceryle aenea_侏绿鱼狗
+Chloroceryle amazona_亚马逊绿鱼狗
+Chloroceryle americana_绿鱼狗
+Chloroceryle inda_棕腹绿鱼狗
+Chlorochrysa phoenicotis_辉绿雀
+Chlorocichla flaviventris_黄腹绿鸫鹎
+Chlorocichla laetissima_娇绿鸫鹎
+Chlorocichla simplex_绿鸫鹎
+Chlorodrepanis flava_瓦岛绿雀
+Chlorodrepanis stejnegeri_考岛绿雀
+Chlorodrepanis virens_夏威夷绿雀
+Chlorophanes spiza_绿旋蜜雀
+Chlorophonia callophrys_金眉绿雀
+Chlorophonia cyanea_蓝枕绿雀
+Chlorophonia cyanocephala_金腰歌雀
+Chlorophonia elegantissima_亮丽歌雀
+Chlorophonia flavirostris_黄领绿雀
+Chlorophonia musica_蓝头歌雀
+Chlorophonia occipitalis_蓝冠绿雀
+Chlorophonia pyrrhophrys_栗胸绿雀
+Chloropicus fuscescens_暗红啄木鸟
 Chloropicus goertae_African Gray Woodpecker
-Chloropicus griseocephalus_Olive Woodpecker
-Chloropicus namaquus_Bearded Woodpecker
+Chloropicus griseocephalus_非洲灰啄木鸟
+Chloropicus namaquus_须啄木鸟
 Chloropicus spodocephalus_Mountain Gray Woodpecker
-Chloropsis aurifrons_金額葉鵯
-Chloropsis cochinchinensis_藍翅葉鵯
-Chloropsis cyanopogon_Lesser Green Leafbird
-Chloropsis hardwickii_橙腹葉鵯
-Chloropsis jerdoni_Jerdon's Leafbird
-Chloropsis sonnerati_Greater Green Leafbird
-Chlorornis riefferii_Grass-green Tanager
-Chlorospingus canigularis_Ashy-throated Chlorospingus
-Chlorospingus flavigularis_Yellow-throated Chlorospingus
-Chlorospingus flavopectus_Common Chlorospingus
-Chlorospingus pileatus_Sooty-capped Chlorospingus
-Chlorospingus semifuscus_Dusky Chlorospingus
-Chlorostilbon gibsoni_Red-billed Emerald
-Chlorostilbon lucidus_Glittering-bellied Emerald
-Chlorostilbon mellisugus_Blue-tailed Emerald
-Chlorothraupis carmioli_Carmiol's Tanager
-Chlorothraupis olivacea_Lemon-spectacled Tanager
-Chlorothraupis stolzmanni_Ochre-breasted Tanager
-Cholornis unicolor_Brown Parrotbill
-Chondestes grammacus_Lark Sparrow
-Chondrohierax uncinatus_Hook-billed Kite
-Chordeiles acutipennis_Lesser Nighthawk
-Chordeiles gundlachii_Antillean Nighthawk
-Chordeiles minor_Common Nighthawk
-Chordeiles nacunda_Nacunda Nighthawk
-Chordeiles pusillus_Least Nighthawk
-Chroicocephalus brunnicephalus_棕頭鷗
-Chroicocephalus cirrocephalus_Gray-hooded Gull
-Chroicocephalus genei_細嘴鷗
-Chroicocephalus maculipennis_Brown-hooded Gull
-Chroicocephalus novaehollandiae_紐澳紅嘴鷗
-Chroicocephalus philadelphia_Bonaparte's Gull
-Chroicocephalus ridibundus_紅嘴鷗
-Chroicocephalus serranus_Andean Gull
+Chloropsis aurifrons_金额叶鹎
+Chloropsis cochinchinensis_爪哇叶鹎
+Chloropsis cyanopogon_小绿叶鹎
+Chloropsis hardwickii_橙腹叶鹎
+Chloropsis jerdoni_南亚叶鹎
+Chloropsis sonnerati_大绿叶鹎
+Chlorornis riefferii_草绿唐纳雀
+Chlorospingus canigularis_灰喉丛唐纳雀
+Chlorospingus flavigularis_黄喉丛唐纳雀
+Chlorospingus flavopectus_丛唐纳雀
+Chlorospingus pileatus_乌顶丛唐纳雀
+Chlorospingus semifuscus_暗腹丛唐纳雀
+Chlorostilbon gibsoni_红嘴翠蜂鸟
+Chlorostilbon lucidus_辉腹翠蜂鸟
+Chlorostilbon mellisugus_蓝尾翠蜂鸟
+Chlorothraupis carmioli_卡氏唐纳雀
+Chlorothraupis olivacea_黄眉绿唐纳雀
+Chlorothraupis stolzmanni_赭胸绿唐纳雀
+Cholornis unicolor_褐鸦雀
+Chondestes grammacus_云雀鹀
+Chondrohierax uncinatus_钩嘴鸢
+Chordeiles acutipennis_小灰眉夜鹰
+Chordeiles gundlachii_安岛夜鹰
+Chordeiles minor_美洲夜鹰
+Chordeiles nacunda_纳昆达夜鹰
+Chordeiles pusillus_小白喉夜鹰
+Chroicocephalus brunnicephalus_棕头鸥
+Chroicocephalus cirrocephalus_灰头鸥
+Chroicocephalus genei_细嘴鸥
+Chroicocephalus maculipennis_褐头鸥
+Chroicocephalus novaehollandiae_澳洲红嘴鸥
+Chroicocephalus philadelphia_伯氏鸥
+Chroicocephalus ridibundus_红嘴鸥
+Chroicocephalus serranus_安第斯鸥
 Chrysococcyx basalis_Horsfield's Bronze-Cuckoo
-Chrysococcyx caprius_Dideric Cuckoo
-Chrysococcyx cupreus_African Emerald Cuckoo
-Chrysococcyx klaas_Klaas's Cuckoo
+Chrysococcyx caprius_白眉金鹃
+Chrysococcyx cupreus_黄腹金鹃
+Chrysococcyx klaas_白腹金鹃
 Chrysococcyx lucidus_Shining Bronze-Cuckoo
-Chrysococcyx maculatus_Asian Emerald Cuckoo
+Chrysococcyx maculatus_翠金鹃
 Chrysococcyx minutillus_Little Bronze-Cuckoo
-Chrysococcyx osculans_Black-eared Cuckoo
-Chrysococcyx xanthorhynchus_Violet Cuckoo
-Chrysocolaptes festivus_White-naped Woodpecker
-Chrysocolaptes guttacristatus_Greater Flameback
-Chrysolampis mosquitus_Ruby-topaz Hummingbird
-Chrysolophus amherstiae_白腹錦雞
-Chrysolophus pictus_紅腹錦雞
-Chrysomma altirostre_Jerdon's Babbler
-Chrysomma sinense_Yellow-eyed Babbler
-Chrysomus icterocephalus_Yellow-hooded Blackbird
-Chrysomus ruficapillus_Chestnut-capped Blackbird
-Chrysophlegma flavinucha_Greater Yellownape
-Chrysophlegma mentale_Checker-throated Woodpecker
-Chrysophlegma miniaceum_Banded Woodpecker
-Chrysothlypis chrysomelas_Black-and-yellow Tanager
-Chrysothlypis salmoni_Scarlet-and-white Tanager
-Chrysuronia oenone_Golden-tailed Sapphire
-Chrysuronia versicolor_Versicolored Emerald
-Chunga burmeisteri_Black-legged Seriema
-Ciccaba albitarsis_Rufous-banded Owl
-Ciccaba huhula_Black-banded Owl
-Ciccaba nigrolineata_Black-and-white Owl
-Ciccaba virgata_Mottled Owl
-Cichladusa arquata_Collared Palm-Thrush
-Cichladusa guttata_Spotted Morning-Thrush
-Cichlocolaptes leucophrus_Pale-browed Treehunter
-Cichlopsis leucogenys_Rufous-brown Solitaire
+Chrysococcyx osculans_黑耳金鹃
+Chrysococcyx xanthorhynchus_紫金鹃
+Chrysocolaptes festivus_黑腰啄木鸟
+Chrysocolaptes guttacristatus_大金背啄木鸟
+Chrysolampis mosquitus_金喉红顶蜂鸟
+Chrysolophus amherstiae_白腹锦鸡
+Chrysolophus pictus_红腹锦鸡
+Chrysomma altirostre_杰氏鹛雀
+Chrysomma sinense_金眼鹛雀
+Chrysomus icterocephalus_黄巾黑鹂
+Chrysomus ruficapillus_栗顶黑鹂
+Chrysophlegma flavinucha_大黄冠啄木鸟
+Chrysophlegma mentale_斑喉绿啄木鸟
+Chrysophlegma miniaceum_红翅绿背啄木鸟
+Chrysothlypis chrysomelas_黑黄唐纳雀
+Chrysothlypis salmoni_红白唐纳雀
+Chrysuronia oenone_金尾蜂鸟
+Chrysuronia versicolor_虹彩蜂鸟
+Chunga burmeisteri_黑腿叫鹤
+Ciccaba albitarsis_棕斑叫鸮
+Ciccaba huhula_黑斑林鸮
+Ciccaba nigrolineata_斑眉林鸮
+Ciccaba virgata_杂斑林鸮
+Cichladusa arquata_晨鸫
+Cichladusa guttata_斑晨鸫
+Cichlocolaptes leucophrus_淡眉树猎雀
+Cichlopsis leucogenys_棕褐孤鸫
 Cicinnurus magnificus_Magnificent Bird-of-Paradise
-Cicinnurus regius_King Bird-of-Paradise
+Cicinnurus regius_王极乐鸟
 Cicinnurus respublica_Wilson's Bird-of-Paradise
-Ciconia ciconia_白鸛
-Ciconia nigra_黑鸛
-Cinclidium frontale_Blue-fronted Robin
-Cinclocerthia gutturalis_Gray Trembler
-Cinclodes albidiventris_Chestnut-winged Cinclodes
-Cinclodes albiventris_Cream-winged Cinclodes
-Cinclodes excelsior_Stout-billed Cinclodes
-Cinclodes fuscus_Buff-winged Cinclodes
-Cinclodes nigrofumosus_Seaside Cinclodes
-Cinclodes oustaleti_Gray-flanked Cinclodes
-Cinclodes pabsti_Long-tailed Cinclodes
-Cinclodes patagonicus_Dark-bellied Cinclodes
-Cincloramphus cruralis_Brown Songlark
-Cincloramphus macrurus_Papuan Grassbird
-Cincloramphus mathewsi_Rufous Songlark
-Cincloramphus timoriensis_Tawny Grassbird
-Cinclosoma ajax_Painted Quail-thrush
-Cinclosoma castaneothorax_Chestnut-breasted Quail-thrush
-Cinclosoma punctatum_Spotted Quail-thrush
-Cinclus cinclus_White-throated Dipper
-Cinclus mexicanus_American Dipper
-Cinclus pallasii_河烏
-Cinnycerthia fulva_Fulvous Wren
-Cinnycerthia olivascens_Sharpe's Wren
-Cinnycerthia peruana_Peruvian Wren
-Cinnycerthia unirufa_Rufous Wren
-Cinnyricinclus leucogaster_Violet-backed Starling
-Cinnyris afer_Greater Double-collared Sunbird
-Cinnyris asiaticus_Purple Sunbird
-Cinnyris bifasciatus_Purple-banded Sunbird
-Cinnyris chalybeus_Southern Double-collared Sunbird
-Cinnyris chloropygius_Olive-bellied Sunbird
-Cinnyris coccinigastrus_Splendid Sunbird
-Cinnyris cupreus_Copper Sunbird
-Cinnyris erythrocercus_Red-chested Sunbird
-Cinnyris fuscus_Dusky Sunbird
-Cinnyris gertrudis_Western Miombo Sunbird
-Cinnyris habessinicus_Shining Sunbird
-Cinnyris jugularis_黃腹花蜜鳥
-Cinnyris lotenius_Loten's Sunbird
-Cinnyris mariquensis_Mariqua Sunbird
-Cinnyris mediocris_Eastern Double-collared Sunbird
-Cinnyris nectarinioides_Black-bellied Sunbird
-Cinnyris osea_Palestine Sunbird
-Cinnyris pulchellus_Beautiful Sunbird
-Cinnyris regius_Regal Sunbird
-Cinnyris reichenowi_Northern Double-collared Sunbird
-Cinnyris solaris_Flame-breasted Sunbird
-Cinnyris sovimanga_Souimanga Sunbird
-Cinnyris talatala_White-breasted Sunbird
-Cinnyris venustus_Variable Sunbird
-Circaetus gallicus_Short-toed Snake-Eagle
-Circus aeruginosus_西方澤鵟
-Circus approximans_Swamp Harrier
-Circus buffoni_Long-winged Harrier
-Circus cyaneus_灰澤鵟
-Circus hudsonius_Northern Harrier
-Circus macrourus_Pallid Harrier
-Circus melanoleucos_花澤鵟
-Circus pygargus_Montagu's Harrier
-Circus spilonotus_東方澤鵟
-Cissa chinensis_Common Green-Magpie
-Cissa hypoleuca_Indochinese Green-Magpie
-Cissa jefferyi_Bornean Green-Magpie
-Cissopis leverianus_Magpie Tanager
-Cisticola aberrans_Rock-loving Cisticola
-Cisticola anonymus_Chattering Cisticola
-Cisticola aridulus_Desert Cisticola
-Cisticola ayresii_Wing-snapping Cisticola
-Cisticola brachypterus_Siffling Cisticola
-Cisticola cantans_Singing Cisticola
-Cisticola cherina_Madagascar Cisticola
-Cisticola chiniana_Rattling Cisticola
-Cisticola chubbi_Chubb's Cisticola
-Cisticola cinereolus_Ashy Cisticola
-Cisticola erythrops_Red-faced Cisticola
-Cisticola exilis_黃頭扇尾鶯
-Cisticola fulvicapilla_Piping Cisticola
-Cisticola haematocephalus_Coastal Cisticola
-Cisticola hunteri_Hunter's Cisticola
-Cisticola juncidis_棕扇尾鶯
-Cisticola lais_Wailing Cisticola
-Cisticola lateralis_Whistling Cisticola
-Cisticola marginatus_Winding Cisticola
-Cisticola natalensis_Croaking Cisticola
-Cisticola nigriloris_Black-lored Cisticola
-Cisticola njombe_Churring Cisticola
-Cisticola pipiens_Chirping Cisticola
-Cisticola robustus_Stout Cisticola
-Cisticola subruficapilla_Red-headed Cisticola
-Cisticola textrix_Cloud Cisticola
-Cisticola tinniens_Levaillant's Cisticola
-Cisticola woosnami_Trilling Cisticola
-Cistothorus apolinari_Apolinar's Wren
-Cistothorus palustris_Marsh Wren
-Cistothorus platensis_Grass Wren
-Cistothorus stellaris_Sedge Wren
-Clamator coromandus_冠郭公
-Clamator glandarius_Great Spotted Cuckoo
-Clamator jacobinus_斑翅鳳頭鵑
-Clamator levaillantii_Levaillant's Cuckoo
-Clanga clanga_花鵰
-Clanga pomarina_Lesser Spotted Eagle
-Clangula hyemalis_長尾鴨
-Claravis pretiosa_Blue Ground Dove
-Clibanornis dendrocolaptoides_Canebrake Groundcreeper
-Clibanornis erythrocephalus_Henna-hooded Foliage-gleaner
-Clibanornis rectirostris_Chestnut-capped Foliage-gleaner
-Clibanornis rubiginosus_Ruddy Foliage-gleaner
-Clibanornis rufipectus_Santa Marta Foliage-gleaner
-Climacteris picumnus_Brown Treecreeper
-Clytoctantes alixii_Recurve-billed Bushbird
-Clytolaema rubricauda_Brazilian Ruby
-Clytorhynchus vitiensis_Fiji Shrikebill
-Cnemoscopus rubrirostris_Gray-hooded Bush Tanager
-Cnemotriccus fuscatus_Fuscous Flycatcher
-Cnipodectes subbrunneus_Brownish Twistwing
-Coccopygia melanotis_Swee Waxbill
-Coccopygia quartinia_Yellow-bellied Waxbill
-Coccothraustes abeillei_Hooded Grosbeak
-Coccothraustes coccothraustes_臘嘴雀
-Coccothraustes vespertinus_Evening Grosbeak
-Coccycua cinerea_Ash-colored Cuckoo
-Coccycua minuta_Little Cuckoo
-Coccyzus americanus_Yellow-billed Cuckoo
-Coccyzus erythropthalmus_Black-billed Cuckoo
-Coccyzus euleri_Pearly-breasted Cuckoo
-Coccyzus longirostris_Hispaniolan Lizard-Cuckoo
-Coccyzus melacoryphus_Dark-billed Cuckoo
-Coccyzus merlini_Great Lizard-Cuckoo
-Coccyzus minor_Mangrove Cuckoo
-Coccyzus vieilloti_Puerto Rican Lizard-Cuckoo
-Cochlearius cochlearius_Boat-billed Heron
-Cochoa viridis_Green Cochoa
-Coeligena coeligena_Bronzy Inca
-Coeligena iris_Rainbow Starfrontlet
-Coeligena lutetiae_Buff-winged Starfrontlet
-Coeligena wilsoni_Brown Inca
-Coereba flaveola_Bananaquit
-Colaptes atricollis_Black-necked Woodpecker
-Colaptes auratus_Northern Flicker
-Colaptes auricularis_Gray-crowned Woodpecker
-Colaptes campestris_Campo Flicker
-Colaptes chrysoides_Gilded Flicker
-Colaptes fernandinae_Fernandina's Flicker
-Colaptes melanochloros_Green-barred Woodpecker
-Colaptes pitius_Chilean Flicker
-Colaptes punctigula_Spot-breasted Woodpecker
-Colaptes rivolii_Crimson-mantled Woodpecker
-Colaptes rubiginosus_Golden-olive Woodpecker
-Colaptes rupicola_Andean Flicker
-Colibri coruscans_Sparkling Violetear
-Colibri cyanotus_Lesser Violetear
-Colibri delphinae_Brown Violetear
-Colibri serrirostris_White-vented Violetear
-Colibri thalassinus_Mexican Violetear
-Colinus cristatus_Crested Bobwhite
-Colinus nigrogularis_Black-throated Bobwhite
-Colinus virginianus_Northern Bobwhite
-Colius colius_White-backed Mousebird
-Colius striatus_Speckled Mousebird
-Collocalia affinis_Plume-toed Swiftlet
-Colluricincla boweri_Bower's Shrikethrush
-Colluricincla harmonica_Gray Shrikethrush
-Colluricincla megarhyncha_Arafura Shrikethrush
-Colluricincla rufogaster_Rufous Shrikethrush
-Colonia colonus_Long-tailed Tyrant
-Colorhamphus parvirostris_Patagonian Tyrant
-Columba arquatrix_Rameron Pigeon
-Columba delegorguei_Delegorgue's Pigeon
-Columba guinea_Speckled Pigeon
-Columba iriditorques_Bronze-naped Pigeon
-Columba janthina_黑林鴿
-Columba larvata_Lemon Dove
-Columba livia_野鴿
-Columba oenas_Stock Dove
-Columba palumbus_Common Wood-Pigeon
-Columba unicincta_Afep Pigeon
-Columba vitiensis_白喉林鴿
-Columbina buckleyi_Ecuadorian Ground Dove
-Columbina cruziana_Croaking Ground Dove
-Columbina cyanopis_Blue-eyed Ground Dove
-Columbina inca_Inca Dove
-Columbina minuta_Plain-breasted Ground Dove
-Columbina passerina_Common Ground Dove
-Columbina picui_Picui Ground Dove
-Columbina squammata_Scaled Dove
-Columbina talpacoti_Ruddy Ground Dove
-Compsothraupis loricata_Scarlet-throated Tanager
-Conioptilon mcilhennyi_Black-faced Cotinga
-Conirostrum albifrons_Capped Conebill
-Conirostrum bicolor_Bicolored Conebill
-Conirostrum binghami_Giant Conebill
-Conirostrum cinereum_Cinereous Conebill
-Conirostrum leucogenys_White-eared Conebill
-Conirostrum margaritae_Pearly-breasted Conebill
-Conirostrum rufum_Rufous-browed Conebill
-Conirostrum sitticolor_Blue-backed Conebill
-Conirostrum speciosum_Chestnut-vented Conebill
-Conirostrum tamarugense_Tamarugo Conebill
+Ciconia ciconia_白鹳
+Ciconia nigra_黑鹳
+Cinclidium frontale_蓝额长脚地鸲
+Cinclocerthia gutturalis_灰旋木嘲鸫
+Cinclodes albidiventris_红翅抖尾地雀
+Cinclodes albiventris_淡翅抖尾地雀
+Cinclodes excelsior_粗嘴抖尾地雀
+Cinclodes fuscus_斑翅抖尾地雀
+Cinclodes nigrofumosus_海滨抖尾地雀
+Cinclodes oustaleti_灰胁抖尾地雀
+Cinclodes pabsti_长尾抖尾地雀
+Cinclodes patagonicus_暗腹抖尾地雀
+Cincloramphus cruralis_褐鹨莺
+Cincloramphus macrurus_巴布亚大尾莺
+Cincloramphus mathewsi_棕鹨莺
+Cincloramphus timoriensis_棕顶大尾莺
+Cinclosoma ajax_彩鹑鸫
+Cinclosoma castaneothorax_栗胸鹑鸫
+Cinclosoma punctatum_斑鹑鸫
+Cinclus cinclus_河乌
+Cinclus mexicanus_美洲河乌
+Cinclus pallasii_褐河乌
+Cinnycerthia fulva_茶色鹪鹩
+Cinnycerthia olivascens_夏氏鹪鹩
+Cinnycerthia peruana_棕褐鹪鹩
+Cinnycerthia unirufa_棕鹪鹩
+Cinnyricinclus leucogaster_白腹紫椋鸟
+Cinnyris afer_大双领花蜜鸟
+Cinnyris asiaticus_紫色花蜜鸟
+Cinnyris bifasciatus_紫斑花蜜鸟
+Cinnyris chalybeus_小双领花蜜鸟
+Cinnyris chloropygius_绿腹花蜜鸟
+Cinnyris coccinigastrus_华丽花蜜鸟
+Cinnyris cupreus_铜色花蜜鸟
+Cinnyris erythrocercus_红胸花蜜鸟
+Cinnyris fuscus_暗色花蜜鸟
+Cinnyris gertrudis_西双领花蜜鸟
+Cinnyris habessinicus_辉花蜜鸟
+Cinnyris jugularis_菲律宾花蜜鸟
+Cinnyris lotenius_罗氏花蜜鸟
+Cinnyris mariquensis_马里基花蜜鸟
+Cinnyris mediocris_东非双领花蜜鸟
+Cinnyris nectarinioides_小黑腹花蜜鸟
+Cinnyris osea_阿拉伯橙簇花蜜鸟
+Cinnyris pulchellus_丽色花蜜鸟
+Cinnyris regius_帝王花蜜鸟
+Cinnyris reichenowi_北双领花蜜鸟
+Cinnyris solaris_帝汶花蜜鸟
+Cinnyris sovimanga_斯韦花蜜鸟
+Cinnyris talatala_白腹花蜜鸟
+Cinnyris venustus_杂色花蜜鸟
+Circaetus gallicus_短趾雕
+Circus aeruginosus_白头鹞
+Circus approximans_沼泽鹞
+Circus buffoni_长翅鹞
+Circus cyaneus_白尾鹞
+Circus hudsonius_北鹞
+Circus macrourus_草原鹞
+Circus melanoleucos_鹊鹞
+Circus pygargus_乌灰鹞
+Circus spilonotus_白腹鹞
+Cissa chinensis_蓝绿鹊
+Cissa hypoleuca_印支绿鹊
+Cissa jefferyi_婆罗洲绿鹊
+Cissopis leverianus_鹊色唐纳雀
+Cisticola aberrans_懒扇尾莺
+Cisticola anonymus_噪扇尾莺
+Cisticola aridulus_漠扇尾莺
+Cisticola ayresii_艾氏扇尾莺
+Cisticola brachypterus_短翅扇尾莺
+Cisticola cantans_歌扇尾莺
+Cisticola cherina_马岛扇尾莺
+Cisticola chiniana_巧扇尾莺
+Cisticola chubbi_查氏扇尾莺
+Cisticola cinereolus_淡灰扇尾莺
+Cisticola erythrops_红脸扇尾莺
+Cisticola exilis_金头扇尾莺
+Cisticola fulvicapilla_笛声扇尾莺
+Cisticola haematocephalus_海岸扇尾莺
+Cisticola hunteri_亨氏扇尾莺
+Cisticola juncidis_棕扇尾莺
+Cisticola lais_啸声扇尾莺
+Cisticola lateralis_哨声扇尾莺
+Cisticola marginatus_号声扇尾莺
+Cisticola natalensis_蛙声扇尾莺
+Cisticola nigriloris_黑眉扇尾莺
+Cisticola njombe_颤鸣扇尾莺
+Cisticola pipiens_唧鸣扇尾莺
+Cisticola robustus_强健扇尾莺
+Cisticola subruficapilla_灰背扇尾莺
+Cisticola textrix_云扇尾莺
+Cisticola tinniens_铃声扇尾莺
+Cisticola woosnami_颤声扇尾莺
+Cistothorus apolinari_阿氏沼泽鹪鹩
+Cistothorus palustris_长嘴沼泽鹪鹩
+Cistothorus platensis_短嘴沼泽鹪鹩
+Cistothorus stellaris_北美沼泽鹪鹩
+Clamator coromandus_红翅凤头鹃
+Clamator glandarius_大斑凤头鹃
+Clamator jacobinus_斑翅凤头鹃
+Clamator levaillantii_莱氏凤头鹃
+Clanga clanga_乌雕
+Clanga pomarina_小乌雕
+Clangula hyemalis_长尾鸭
+Claravis pretiosa_蓝地鸠
+Clibanornis dendrocolaptoides_地棘雀
+Clibanornis erythrocephalus_红冠拾叶雀
+Clibanornis rectirostris_栗顶拾叶雀
+Clibanornis rubiginosus_锈色拾叶雀
+Clibanornis rufipectus_圣马塔拾叶雀
+Climacteris picumnus_褐短嘴旋木雀
+Clytoctantes alixii_翘嘴丛蚁鵙
+Clytolaema rubricauda_红玉蜂鸟
+Clytorhynchus vitiensis_斐济鵙嘴鹟
+Cnemoscopus rubrirostris_灰头薮唐纳雀
+Cnemotriccus fuscatus_暗褐霸鹟
+Cnipodectes subbrunneus_褐霸鹟
+Coccopygia melanotis_黑颊黄腹梅花雀
+Coccopygia quartinia_黄腹梅花雀
+Coccothraustes abeillei_黑头锡嘴雀
+Coccothraustes coccothraustes_锡嘴雀
+Coccothraustes vespertinus_黄昏锡嘴雀
+Coccycua cinerea_灰美洲鹃
+Coccycua minuta_小棕鹃
+Coccyzus americanus_黄嘴美洲鹃
+Coccyzus erythropthalmus_黑嘴美洲鹃
+Coccyzus euleri_珠胸美洲鹃
+Coccyzus longirostris_长嘴蜥鹃
+Coccyzus melacoryphus_暗嘴美洲鹃
+Coccyzus merlini_大蜥鹃
+Coccyzus minor_红树美洲鹃
+Coccyzus vieilloti_波多黎各蜥鹃
+Cochlearius cochlearius_船嘴鹭
+Cochoa viridis_绿宽嘴鸫
+Coeligena coeligena_铜色星额蜂鸟
+Coeligena iris_彩虹星额蜂鸟
+Coeligena lutetiae_黄翅星额蜂鸟
+Coeligena wilsoni_褐星额蜂鸟
+Coereba flaveola_曲嘴森莺
+Colaptes atricollis_黑颈扑翅䴕
+Colaptes auratus_北扑翅䴕
+Colaptes auricularis_灰顶啄木鸟
+Colaptes campestris_草原扑翅䴕
+Colaptes chrysoides_黄扑翅䴕
+Colaptes fernandinae_古巴扑翅䴕
+Colaptes melanochloros_绿斑扑翅䴕
+Colaptes pitius_智利扑翅䴕
+Colaptes punctigula_斑胸扑翅䴕
+Colaptes rivolii_红背啄木鸟
+Colaptes rubiginosus_高原啄木鸟
+Colaptes rupicola_安第斯扑翅䴕
+Colibri coruscans_辉紫耳蜂鸟
+Colibri cyanotus_小紫耳蜂鸟
+Colibri delphinae_褐紫耳蜂鸟
+Colibri serrirostris_白腹紫耳蜂鸟
+Colibri thalassinus_绿紫耳蜂鸟
+Colinus cristatus_冠齿鹑
+Colinus nigrogularis_黑喉齿鹑
+Colinus virginianus_山齿鹑
+Colius colius_白背鼠鸟
+Colius striatus_斑鼠鸟
+Collocalia affinis_毛趾金丝燕
+Colluricincla boweri_纹胸鵙鹟
+Colluricincla harmonica_灰鵙鹟
+Colluricincla megarhyncha_棕鵙鹟
+Colluricincla rufogaster_澳洲棕鵙鹟
+Colonia colonus_长尾霸鹟
+Colorhamphus parvirostris_巴塔唧霸鹟
+Columba arquatrix_黄眼鸽
+Columba delegorguei_德氏鸽
+Columba guinea_斑鸽
+Columba iriditorques_铜颈鸽
+Columba janthina_黑林鸽
+Columba larvata_非洲鸽
+Columba livia_原鸽
+Columba oenas_欧鸽
+Columba palumbus_斑尾林鸽
+Columba unicincta_鳞斑灰鸽
+Columba vitiensis_白喉林鸽
+Columbina buckleyi_厄瓜多尔地鸠
+Columbina cruziana_斑嘴地鸠
+Columbina cyanopis_蓝眼地鸠
+Columbina inca_印加地鸠
+Columbina minuta_纯胸地鸠
+Columbina passerina_地鸠
+Columbina picui_白翅地鸠
+Columbina squammata_鳞斑地鸠
+Columbina talpacoti_红地鸠
+Compsothraupis loricata_朱喉唐纳雀
+Conioptilon mcilhennyi_黑脸伞鸟
+Conirostrum albifrons_白顶锥嘴雀
+Conirostrum bicolor_灰黄锥嘴雀
+Conirostrum binghami_巨锥嘴雀
+Conirostrum cinereum_朱红锥嘴雀
+Conirostrum leucogenys_白耳锥嘴雀
+Conirostrum margaritae_丝胸锥嘴雀
+Conirostrum rufum_棕眉锥嘴雀
+Conirostrum sitticolor_蓝背锥嘴雀
+Conirostrum speciosum_栗臀锥嘴雀
+Conirostrum tamarugense_约氏锥嘴雀
 Conocephalus brevipennis_Short-winged Meadow Katydid
 Conocephalus fasciatus_Slender Meadow Katydid
-Conopias albovittatus_White-ringed Flycatcher
-Conopias cinchoneti_Lemon-browed Flycatcher
-Conopias parvus_Yellow-throated Flycatcher
-Conopias trivirgatus_Three-striped Flycatcher
-Conopophaga ardesiaca_Slaty Gnateater
-Conopophaga aurita_Chestnut-belted Gnateater
-Conopophaga castaneiceps_Chestnut-crowned Gnateater
-Conopophaga cearae_Ceara Gnateater
-Conopophaga lineata_Rufous Gnateater
-Conopophaga melanogaster_Black-bellied Gnateater
-Conopophaga melanops_Black-cheeked Gnateater
-Conopophaga peruviana_Ash-throated Gnateater
-Conopophila albogularis_Rufous-banded Honeyeater
-Conostoma aemodium_Great Parrotbill
-Conothraupis speculigera_Black-and-white Tanager
-Contopus caribaeus_Cuban Pewee
-Contopus cinereus_Tropical Pewee (Tropical)
-Contopus cooperi_Olive-sided Flycatcher
-Contopus fumigatus_Smoke-colored Pewee
-Contopus lugubris_Dark Pewee
-Contopus nigrescens_Blackish Pewee
-Contopus pertinax_Greater Pewee
-Contopus sordidulus_Western Wood-Pewee
-Contopus virens_Eastern Wood-Pewee
-Copsychus albiventris_Andaman Shama
-Copsychus albospecularis_Madagascar Magpie-Robin
-Copsychus cebuensis_Black Shama
-Copsychus fulicatus_Indian Robin
-Copsychus luzoniensis_White-browed Shama
-Copsychus malabaricus_白腰鵲鴝
-Copsychus mindanensis_Philippine Magpie-Robin
-Copsychus niger_White-vented Shama
-Copsychus pyrropygus_Rufous-tailed Shama
-Copsychus saularis_鵲鴝
-Coracias abyssinicus_Abyssinian Roller
-Coracias benghalensis_Indian Roller
-Coracias caudatus_Lilac-breasted Roller
-Coracias garrulus_European Roller
+Conopias albovittatus_白环蚊霸鹟
+Conopias cinchoneti_黄眉蚊霸鹟
+Conopias parvus_黄喉蚊霸鹟
+Conopias trivirgatus_三纹蚊霸鹟
+Conopophaga ardesiaca_蓝灰食蚊鸟
+Conopophaga aurita_栗带食蚊鸟
+Conopophaga castaneiceps_栗顶食蚊鸟
+Conopophaga cearae_塞阿拉食蚊鸟
+Conopophaga lineata_棕食蚊鸟
+Conopophaga melanogaster_黑腹食蚊鸟
+Conopophaga melanops_黑颊食蚊鸟
+Conopophaga peruviana_灰喉食蚊鸟
+Conopophila albogularis_棕斑蚊蜜鸟
+Conostoma aemodium_红嘴鸦雀
+Conothraupis speculigera_黑白唐纳雀
+Contopus caribaeus_大安岛绿霸鹟
+Contopus cinereus_南热带绿霸鹟
+Contopus cooperi_绿胁绿霸鹟
+Contopus fumigatus_烟色绿霸鹟
+Contopus lugubris_暗绿霸鹟
+Contopus nigrescens_黑绿霸鹟
+Contopus pertinax_大绿霸鹟
+Contopus sordidulus_西绿霸鹟
+Contopus virens_东绿霸鹟
+Copsychus albiventris_安达曼鹊鸲
+Copsychus albospecularis_马岛鹊鸲
+Copsychus cebuensis_黑鹊鸲
+Copsychus fulicatus_印度鸲
+Copsychus luzoniensis_白眉鹊鸲
+Copsychus malabaricus_白腰鹊鸲
+Copsychus mindanensis_菲律宾鹊鸲
+Copsychus niger_白臀鹊鸲
+Copsychus pyrropygus_橙尾鹊鸲
+Copsychus saularis_鹊鸲
+Coracias abyssinicus_蓝头佛法僧
+Coracias benghalensis_西棕胸佛法僧
+Coracias caudatus_紫胸佛法僧
+Coracias garrulus_蓝胸佛法僧
 Coracina caesia_Gray Cuckooshrike
-Coracina cinerea_Madagascar Cuckooshrike
-Coracina lineata_Barred Cuckooshrike
-Coracina longicauda_Hooded Cuckooshrike
-Coracina macei_花翅山椒鳥
-Coracina novaehollandiae_Black-faced Cuckooshrike
-Coracina papuensis_White-bellied Cuckooshrike
-Coracina pectoralis_White-breasted Cuckooshrike
-Coracina striata_Bar-bellied Cuckooshrike
-Coracopsis nigra_Lesser Vasa Parrot
-Coracopsis vasa_Greater Vasa Parrot
-Coragyps atratus_Black Vulture
-Corapipo altera_White-ruffed Manakin
-Corapipo gutturalis_White-throated Manakin
-Corcorax melanorhamphos_White-winged Chough
-Cormobates leucophaea_White-throated Treecreeper
-Cormobates placens_Papuan Treecreeper
-Corthylio calendula_Ruby-crowned Kinglet
-Corvus albicollis_White-necked Raven
-Corvus albus_Pied Crow
-Corvus brachyrhynchos_American Crow
-Corvus capensis_Cape Crow
-Corvus corax_Common Raven
-Corvus cornix_Hooded Crow
-Corvus corone_小嘴烏鴉
-Corvus coronoides_Australian Raven
-Corvus cryptoleucus_Chihuahuan Raven
-Corvus dauuricus_東方寒鴉
-Corvus enca_Slender-billed Crow
-Corvus florensis_Flores Crow
-Corvus frugilegus_禿鼻鴉
-Corvus hawaiiensis_Hawaiian Crow
-Corvus imparatus_Tamaulipas Crow
-Corvus jamaicensis_Jamaican Crow
-Corvus leucognaphalus_White-necked Crow
-Corvus macrorhynchos_巨嘴鴉
-Corvus mellori_Little Raven
+Coracina cinerea_马岛鹃鵙
+Coracina lineata_黄眼鹃鵙
+Coracina longicauda_黑冠鹃鵙
+Coracina macei_大鹃鵙
+Coracina novaehollandiae_黑脸鹃鵙
+Coracina papuensis_白腹鹃鵙
+Coracina pectoralis_白胸鹃鵙
+Coracina striata_斑腹鹃鵙
+Coracopsis nigra_马岛小鹦鹉
+Coracopsis vasa_马岛鹦鹉
+Coragyps atratus_黑头美洲鹫
+Corapipo altera_中美白皱领娇鹟
+Corapipo gutturalis_白喉娇鹟
+Corcorax melanorhamphos_白翅澳鸦
+Cormobates leucophaea_白喉短嘴旋木雀
+Cormobates placens_短嘴旋木雀
+Corthylio calendula_红冠戴菊
+Corvus albicollis_非洲渡鸦
+Corvus albus_非洲白颈鸦
+Corvus brachyrhynchos_短嘴鸦
+Corvus capensis_海角鸦
+Corvus corax_渡鸦
+Corvus cornix_冠小嘴乌鸦
+Corvus corone_小嘴乌鸦
+Corvus coronoides_澳洲渡鸦
+Corvus cryptoleucus_白颈渡鸦
+Corvus dauuricus_达乌里寒鸦
+Corvus enca_细嘴乌鸦
+Corvus florensis_佛罗乌鸦
+Corvus frugilegus_秃鼻乌鸦
+Corvus hawaiiensis_夏威夷乌鸦
+Corvus imparatus_墨西哥乌鸦
+Corvus jamaicensis_牙买加乌鸦
+Corvus leucognaphalus_美洲白颈鸦
+Corvus macrorhynchos_大嘴乌鸦
+Corvus mellori_小渡鸦
 Corvus monedula_Eurasian Jackdaw
-Corvus nasicus_Cuban Crow
-Corvus orru_Torresian Crow
-Corvus ossifragus_Fish Crow
-Corvus palmarum_Palm Crow
-Corvus rhipidurus_Fan-tailed Raven
-Corvus ruficollis_Brown-necked Raven
-Corvus sinaloae_Sinaloa Crow
-Corvus splendens_家烏鴉
-Corvus tasmanicus_Forest Raven
-Corvus tristis_Gray Crow
-Corvus typicus_Piping Crow
-Corvus validus_Long-billed Crow
-Corydon sumatranus_Dusky Broadbill
-Coryphaspiza melanotis_Black-masked Finch
-Coryphistera alaudina_Lark-like Brushrunner
-Coryphospingus cucullatus_Red-crested Finch
-Coryphospingus pileatus_Pileated Finch
-Corythaeola cristata_Great Blue Turaco
+Corvus nasicus_古巴鸦
+Corvus orru_澳洲鸦
+Corvus ossifragus_鱼鸦
+Corvus palmarum_棕榈鸦
+Corvus rhipidurus_扇尾渡鸦
+Corvus ruficollis_褐颈渡鸦
+Corvus sinaloae_西纳劳乌鸦
+Corvus splendens_家鸦
+Corvus tasmanicus_林渡鸦
+Corvus tristis_灰乌鸦
+Corvus typicus_苏拉威西鸦
+Corvus validus_长嘴乌鸦
+Corydon sumatranus_暗色阔嘴鸟
+Coryphaspiza melanotis_花脸雀
+Coryphistera alaudina_拟鹨灌丛雀
+Coryphospingus cucullatus_红冠雀
+Coryphospingus pileatus_红顶雀
+Corythaeola cristata_蓝蕉鹃
 Corythaixoides concolor_Gray Go-away-bird
-Corythaixoides leucogaster_White-bellied Go-away-bird
-Corythopis delalandi_Southern Antpipit
-Corythopis torquatus_Ringed Antpipit
-Corythornis cristatus_Malachite Kingfisher
-Coscoroba coscoroba_Coscoroba Swan
-Cossypha albicapillus_White-crowned Robin-Chat
+Corythaixoides leucogaster_白腹灰蕉鹃
+Corythopis delalandi_南美蚁鹨
+Corythopis torquatus_环蚁鹨
+Corythornis cristatus_冠翠鸟
+Coscoroba coscoroba_扁嘴天鹅
+Cossypha albicapillus_白顶歌䳭
 Cossypha anomala_Olive-flanked Robin-Chat
 Cossypha archeri_Archer's Robin-Chat
-Cossypha caffra_Cape Robin-Chat
-Cossypha cyanocampter_Blue-shouldered Robin-Chat
-Cossypha dichroa_Chorister Robin-Chat
-Cossypha heuglini_White-browed Robin-Chat
-Cossypha humeralis_White-throated Robin-Chat
-Cossypha natalensis_Red-capped Robin-Chat
-Cossypha niveicapilla_Snowy-crowned Robin-Chat
+Cossypha caffra_黄喉歌䳭
+Cossypha cyanocampter_蓝肩歌䳭
+Cossypha dichroa_南非歌䳭
+Cossypha heuglini_白眉歌䳭
+Cossypha humeralis_白喉歌䳭
+Cossypha natalensis_红顶歌䳭
+Cossypha niveicapilla_白冠歌䳭
 Cossypha polioptera_Gray-winged Robin-Chat
-Cossypha semirufa_Rüppell's Robin-Chat
-Coturnicops noveboracensis_Yellow Rail
-Coturnix coromandelica_Rain Quail
-Coturnix coturnix_Common Quail
-Coturnix delegorguei_Harlequin Quail
-Coturnix japonica_鵪鶉
-Coturnix pectoralis_Stubble Quail
-Coua caerulea_Blue Coua
-Coua coquereli_Coquerel's Coua
-Coua cristata_Crested Coua
-Coua gigas_Giant Coua
-Coua reynaudii_Red-fronted Coua
-Coua ruficeps_Red-capped Coua
-Coua serriana_Red-breasted Coua
-Cracticus cassicus_Hooded Butcherbird
-Cracticus nigrogularis_Pied Butcherbird
-Cracticus quoyi_Black Butcherbird
-Cracticus torquatus_Gray Butcherbird
-Cranioleuca albicapilla_Creamy-crested Spinetail
-Cranioleuca albiceps_Light-crowned Spinetail
-Cranioleuca antisiensis_Line-cheeked Spinetail
-Cranioleuca curtata_Ash-browed Spinetail
-Cranioleuca demissa_Tepui Spinetail
-Cranioleuca erythrops_Red-faced Spinetail
-Cranioleuca gutturata_Speckled Spinetail
-Cranioleuca hellmayri_Streak-capped Spinetail
-Cranioleuca marcapatae_Marcapata Spinetail
-Cranioleuca obsoleta_Olive Spinetail
-Cranioleuca pallida_Pallid Spinetail
-Cranioleuca pyrrhophia_Stripe-crowned Spinetail
-Cranioleuca semicinerea_Gray-headed Spinetail
-Cranioleuca subcristata_Crested Spinetail
-Cranioleuca vulpecula_Parker's Spinetail
-Cranioleuca vulpina_Rusty-backed Spinetail
+Cossypha semirufa_卢氏歌䳭
+Coturnicops noveboracensis_北美花田鸡
+Coturnix coromandelica_黑胸鹌鹑
+Coturnix coturnix_西鹌鹑
+Coturnix delegorguei_花脸鹌鹑
+Coturnix japonica_鹌鹑
+Coturnix pectoralis_澳洲鹌鹑
+Coua caerulea_蓝马岛鹃
+Coua coquereli_科氏马岛鹃
+Coua cristata_凤头马岛鹃
+Coua gigas_大马岛鹃
+Coua reynaudii_红额马岛鹃
+Coua ruficeps_红顶马岛鹃
+Coua serriana_红胸马岛鹃
+Cracticus cassicus_黑头钟鹊
+Cracticus nigrogularis_黑喉钟鹊
+Cracticus quoyi_黑钟鹊
+Cracticus torquatus_灰钟鹊
+Cranioleuca albicapilla_白冠针尾雀
+Cranioleuca albiceps_淡顶针尾雀
+Cranioleuca antisiensis_纹颊针尾雀
+Cranioleuca curtata_灰眉针尾雀
+Cranioleuca demissa_泰普针尾雀
+Cranioleuca erythrops_红脸针尾雀
+Cranioleuca gutturata_斑针尾雀
+Cranioleuca hellmayri_纹冠针尾雀
+Cranioleuca marcapatae_秘鲁针尾雀
+Cranioleuca obsoleta_绿针尾雀
+Cranioleuca pallida_淡色针尾雀
+Cranioleuca pyrrhophia_纹顶针尾雀
+Cranioleuca semicinerea_灰头针尾雀
+Cranioleuca subcristata_冠针尾雀
+Cranioleuca vulpecula_帕氏针尾雀
+Cranioleuca vulpina_锈背针尾雀
 Crateroscelis murina_Rusty Mouse-Warbler
 Crateroscelis robusta_Mountain Mouse-Warbler
-Crax alberti_Blue-billed Curassow
-Crax alector_Black Curassow
-Crax fasciolata_Bare-faced Curassow
-Crax rubra_Great Curassow
-Creagrus furcatus_Swallow-tailed Gull
-Creatophora cinerea_Wattled Starling
-Crex crex_Corn Crake
-Crinifer piscator_Western Plantain-eater
-Criniger barbatus_Western Bearded-Greenbul
-Criniger calurus_Red-tailed Greenbul
-Criniger chloronotus_Eastern Bearded-Greenbul
-Crithagra albogularis_White-throated Canary
-Crithagra atrogularis_Black-throated Canary
-Crithagra buchanani_Southern Grosbeak-Canary
-Crithagra dorsostriata_White-bellied Canary
-Crithagra flaviventris_Yellow Canary
-Crithagra gularis_Streaky-headed Seedeater
-Crithagra hyposticta_Southern Citril
-Crithagra menachensis_Yemen Serin
-Crithagra mozambica_黃額絲雀
-Crithagra reichenowi_Reichenow's Seedeater
-Crithagra scotops_Forest Canary
-Crithagra striolata_Streaky Seedeater
-Crithagra sulphurata_Brimstone Canary
-Crossleyia xanthophrys_Yellow-browed Oxylabes
-Crotophaga ani_Smooth-billed Ani
-Crotophaga major_Greater Ani
-Crotophaga sulcirostris_Groove-billed Ani
-Crypsirina temia_Racket-tailed Treepie
-Cryptillas victorini_Victorin's Warbler
-Cryptoleucopteryx plumbea_Plumbeous Hawk
-Cryptopezus nattereri_Speckle-breasted Antpitta
-Cryptopipo holochlora_Green Manakin
-Cryptospiza reichenovii_Red-faced Crimsonwing
-Cryptosylvicola randrianasoloi_Cryptic Warbler
-Crypturellus atrocapillus_Black-capped Tinamou
-Crypturellus bartletti_Bartlett's Tinamou
-Crypturellus boucardi_Slaty-breasted Tinamou
-Crypturellus cinereus_Cinereous Tinamou
-Crypturellus cinnamomeus_Thicket Tinamou
-Crypturellus duidae_Gray-legged Tinamou
-Crypturellus erythropus_Red-legged Tinamou
-Crypturellus noctivagus_Yellow-legged Tinamou
-Crypturellus obsoletus_Brown Tinamou
-Crypturellus parvirostris_Small-billed Tinamou
-Crypturellus soui_Little Tinamou
-Crypturellus strigulosus_Brazilian Tinamou
-Crypturellus tataupa_Tataupa Tinamou
-Crypturellus transfasciatus_Pale-browed Tinamou
-Crypturellus undulatus_Undulated Tinamou
-Crypturellus variegatus_Variegated Tinamou
-Cuculus canorus_大杜鵑
-Cuculus clamosus_Black Cuckoo
-Cuculus gularis_African Cuckoo
-Cuculus lepidus_Sunda Cuckoo
-Cuculus micropterus_四聲杜鵑
-Cuculus optatus_北方中杜鵑
-Cuculus poliocephalus_小杜鵑
-Cuculus rochii_Madagascar Cuckoo
-Cuculus saturatus_喜馬拉雅中杜鵑
-Cuculus solitarius_Red-chested Cuckoo
-Culicicapa ceylonensis_方尾鶲
-Culicicapa helianthea_Citrine Canary-Flycatcher
-Culicivora caudacuta_Sharp-tailed Tyrant
-Curaeus curaeus_Austral Blackbird
-Curruca boehmi_Banded Parisoma
-Curruca communis_Greater Whitethroat
-Curruca conspicillata_Spectacled Warbler
-Curruca crassirostris_Eastern Orphean Warbler
-Curruca curruca_白喉林鶯
-Curruca hortensis_Western Orphean Warbler
-Curruca iberiae_Western Subalpine Warbler
-Curruca melanocephala_Sardinian Warbler
-Curruca nisoria_Barred Warbler
-Curruca subcoerulea_Chestnut-vented Warbler
-Curruca undata_Dartford Warbler
-Cutia legalleni_Vietnamese Cutia
-Cutia nipalensis_Himalayan Cutia
-Cyanerpes caeruleus_Purple Honeycreeper
-Cyanerpes cyaneus_Red-legged Honeycreeper
-Cyanicterus cyanicterus_Blue-backed Tanager
-Cyanistes caeruleus_Eurasian Blue Tit
-Cyanistes cyanus_Azure Tit
-Cyanistes teneriffae_African Blue Tit
-Cyanocitta cristata_Blue Jay
-Cyanocitta stelleri_Steller's Jay
-Cyanocompsa parellina_Blue Bunting
-Cyanocorax affinis_Black-chested Jay
-Cyanocorax beecheii_Purplish-backed Jay
-Cyanocorax caeruleus_Azure Jay
-Cyanocorax cayanus_Cayenne Jay
-Cyanocorax chrysops_Plush-crested Jay
-Cyanocorax cristatellus_Curl-crested Jay
-Cyanocorax cyanomelas_Purplish Jay
-Cyanocorax cyanopogon_White-naped Jay
-Cyanocorax dickeyi_Tufted Jay
-Cyanocorax melanocyaneus_Bushy-crested Jay
-Cyanocorax mystacalis_White-tailed Jay
-Cyanocorax sanblasianus_San Blas Jay
-Cyanocorax violaceus_Violaceous Jay
-Cyanocorax yncas_Green Jay
-Cyanocorax yucatanicus_Yucatan Jay
+Crax alberti_蓝嘴凤冠雉
+Crax alector_黑凤冠雉
+Crax fasciolata_裸脸凤冠雉
+Crax rubra_大凤冠雉
+Creagrus furcatus_燕尾鸥
+Creatophora cinerea_肉垂椋鸟
+Crex crex_长脚秧鸡
+Crinifer piscator_灰蕉鹃
+Criniger barbatus_西须冠鹎
+Criniger calurus_红尾须冠鹎
+Criniger chloronotus_东须冠鹎
+Crithagra albogularis_白喉丝雀
+Crithagra atrogularis_黑喉丝雀
+Crithagra buchanani_肯尼亚大嘴丝雀
+Crithagra dorsostriata_白腹丝雀
+Crithagra flaviventris_黄丝雀
+Crithagra gularis_纹头丝雀
+Crithagra hyposticta_东非丝雀
+Crithagra menachensis_也门丝雀
+Crithagra mozambica_黄额丝雀
+Crithagra reichenowi_肯尼亚黄腰丝雀
+Crithagra scotops_黄眉林丝雀
+Crithagra striolata_条纹丝雀
+Crithagra sulphurata_硫黄丝雀
+Crossleyia xanthophrys_黄眉马岛莺
+Crotophaga ani_滑嘴犀鹃
+Crotophaga major_大犀鹃
+Crotophaga sulcirostris_沟嘴犀鹃
+Crypsirina temia_盘尾树鹊
+Cryptillas victorini_维氏短翅莺
+Cryptoleucopteryx plumbea_铅色南美鵟
+Cryptopezus nattereri_斑胸蚁鸫
+Cryptopipo holochlora_绿娇鹟
+Cryptospiza reichenovii_红脸朱翅雀
+Cryptosylvicola randrianasoloi_隐马岛莺
+Crypturellus atrocapillus_黑顶穴䳍
+Crypturellus bartletti_巴氏穴䳍
+Crypturellus boucardi_灰胸穴䳍
+Crypturellus cinereus_灰穴䳍
+Crypturellus cinnamomeus_棕穴䳍
+Crypturellus duidae_灰腿穴䳍
+Crypturellus erythropus_红脚穴䳍
+Crypturellus noctivagus_黄腿穴䳍
+Crypturellus obsoletus_褐穴䳍
+Crypturellus parvirostris_小嘴穴䳍
+Crypturellus soui_小穴䳍
+Crypturellus strigulosus_巴西穴䳍
+Crypturellus tataupa_塔陶穴䳍
+Crypturellus transfasciatus_淡眉穴䳍
+Crypturellus undulatus_波斑穴䳍
+Crypturellus variegatus_杂色穴䳍
+Cuculus canorus_大杜鹃
+Cuculus clamosus_黑杜鹃
+Cuculus gularis_非洲杜鹃
+Cuculus lepidus_巽他中杜鹃
+Cuculus micropterus_四声杜鹃
+Cuculus optatus_东方中杜鹃
+Cuculus poliocephalus_小杜鹃
+Cuculus rochii_马岛杜鹃
+Cuculus saturatus_中杜鹃
+Cuculus solitarius_赤胸杜鹃
+Culicicapa ceylonensis_方尾鹟
+Culicicapa helianthea_柠黄仙鹟
+Culicivora caudacuta_尖尾霸鹟
+Curaeus curaeus_南美黑鹂
+Curruca boehmi_斑林莺
+Curruca communis_灰白喉林莺
+Curruca conspicillata_白眶林莺
+Curruca crassirostris_东歌林莺
+Curruca curruca_白喉林莺
+Curruca hortensis_歌林莺
+Curruca iberiae_西亚高山林莺
+Curruca melanocephala_黑头林莺
+Curruca nisoria_横斑林莺
+Curruca subcoerulea_棕臀林莺
+Curruca undata_波纹林莺
+Cutia legalleni_越南姬鹛
+Cutia nipalensis_斑胁姬鹛
+Cyanerpes caeruleus_紫旋蜜雀
+Cyanerpes cyaneus_红脚旋蜜雀
+Cyanicterus cyanicterus_蓝背唐纳雀
+Cyanistes caeruleus_青山雀
+Cyanistes cyanus_灰蓝山雀
+Cyanistes teneriffae_非洲青山雀
+Cyanocitta cristata_冠蓝鸦
+Cyanocitta stelleri_暗冠蓝鸦
+Cyanocompsa parellina_蓝彩鹀
+Cyanocorax affinis_黑胸蓝鸦
+Cyanocorax beecheii_紫背冠鸦
+Cyanocorax caeruleus_青蓝鸦
+Cyanocorax cayanus_白颈蓝鸦
+Cyanocorax chrysops_绒冠蓝鸦
+Cyanocorax cristatellus_卷冠蓝鸦
+Cyanocorax cyanomelas_淡紫蓝鸦
+Cyanocorax cyanopogon_白枕蓝鸦
+Cyanocorax dickeyi_簇蓝鸦
+Cyanocorax melanocyaneus_浓冠鸦
+Cyanocorax mystacalis_白尾蓝鸦
+Cyanocorax sanblasianus_黑蓝冠鸦
+Cyanocorax violaceus_紫蓝鸦
+Cyanocorax yncas_印加绿蓝鸦
+Cyanocorax yucatanicus_尤卡坦蓝鸦
 Cyanoderma ambiguum_Buff-chested Babbler
-Cyanoderma chrysaeum_Golden Babbler
-Cyanoderma erythropterum_Chestnut-winged Babbler
-Cyanoderma melanothorax_Crescent-chested Babbler
-Cyanoderma pyrrhops_Black-chinned Babbler
-Cyanoderma ruficeps_山紅頭
-Cyanoderma rufifrons_Rufous-fronted Babbler
-Cyanolanius madagascarinus_Blue Vanga (Madagascar)
-Cyanoliseus patagonus_Burrowing Parakeet
-Cyanoloxia brissonii_Ultramarine Grosbeak
-Cyanoloxia cyanoides_Blue-black Grosbeak
-Cyanoloxia glaucocaerulea_Glaucous-blue Grosbeak
-Cyanoloxia rothschildii_Amazonian Grosbeak
-Cyanolyca armillata_Black-collared Jay
-Cyanolyca cucullata_Azure-hooded Jay
-Cyanolyca mirabilis_White-throated Jay
-Cyanolyca nanus_Dwarf Jay
-Cyanolyca pulchra_Beautiful Jay
-Cyanolyca pumilo_Black-throated Jay
-Cyanolyca turcosa_Turquoise Jay
-Cyanolyca viridicyanus_White-collared Jay
-Cyanomitra cyanolaema_Blue-throated Brown Sunbird
-Cyanomitra olivacea_Olive Sunbird
-Cyanomitra veroxii_Mouse-colored Sunbird
-Cyanomitra verticalis_Green-headed Sunbird
-Cyanopica cooki_Iberian Magpie
-Cyanopica cyanus_灰喜鵲
-Cyanoptila cumatilis_琉璃藍鶲
-Cyanoptila cyanomelana_白腹琉璃
-Cyanoramphus novaezelandiae_Red-crowned Parakeet
-Cyclarhis gujanensis_Rufous-browed Peppershrike
-Cyclarhis nigrirostris_Black-billed Peppershrike
-Cygnus atratus_黑天鵝
-Cygnus buccinator_Trumpeter Swan
-Cygnus columbianus_小天鵝
-Cygnus cygnus_黃嘴天鵝
-Cygnus melancoryphus_Black-necked Swan
-Cygnus olor_疣鼻天鵝
-Cymbilaimus lineatus_Fasciated Antshrike
-Cymbilaimus sanctaemariae_Bamboo Antshrike
-Cymbirhynchus macrorhynchos_Black-and-red Broadbill
-Cynanthus latirostris_Broad-billed Hummingbird
-Cyornis caerulatus_Sunda Blue Flycatcher
-Cyornis concretus_White-tailed Flycatcher
-Cyornis glaucicomans_中華藍仙鶲
-Cyornis hainanus_海南藍仙鶲
+Cyanoderma chrysaeum_金头穗鹛
+Cyanoderma erythropterum_红翅穗鹛
+Cyanoderma melanothorax_珠颊穗鹛
+Cyanoderma pyrrhops_黑颏穗鹛
+Cyanoderma ruficeps_红头穗鹛
+Cyanoderma rufifrons_红额穗鹛
+Cyanolanius madagascarinus_蓝钩嘴鵙
+Cyanoliseus patagonus_穴鹦哥
+Cyanoloxia brissonii_青彩鹀
+Cyanoloxia cyanoides_蓝黑彩鹀
+Cyanoloxia glaucocaerulea_蓝大彩鹀
+Cyanoloxia rothschildii_亚马孙彩鹀
+Cyanolyca armillata_黑领蓝头鹊
+Cyanolyca cucullata_青蓝头鹊
+Cyanolyca mirabilis_白喉蓝头鹊
+Cyanolyca nanus_小蓝头鹊
+Cyanolyca pulchra_丽蓝头鹊
+Cyanolyca pumilo_黑喉蓝头鹊
+Cyanolyca turcosa_青绿蓝头鹊
+Cyanolyca viridicyanus_白领蓝头鹊
+Cyanomitra cyanolaema_蓝喉花蜜鸟
+Cyanomitra olivacea_绿花蜜鸟
+Cyanomitra veroxii_灰褐花蜜鸟
+Cyanomitra verticalis_绿头花蜜鸟
+Cyanopica cooki_蓝尾灰喜鹊
+Cyanopica cyanus_灰喜鹊
+Cyanoptila cumatilis_琉璃蓝鹟
+Cyanoptila cyanomelana_白腹蓝鹟
+Cyanoramphus novaezelandiae_红额鹦鹉
+Cyclarhis gujanensis_棕眉鵙雀
+Cyclarhis nigrirostris_黑嘴鵙雀
+Cygnus atratus_黑天鹅
+Cygnus buccinator_黑嘴天鹅
+Cygnus columbianus_小天鹅
+Cygnus cygnus_大天鹅
+Cygnus melancoryphus_黑颈天鹅
+Cygnus olor_疣鼻天鹅
+Cymbilaimus lineatus_带斑蚁鵙
+Cymbilaimus sanctaemariae_竹蚁鵙
+Cymbirhynchus macrorhynchos_黑红阔嘴鸟
+Cynanthus latirostris_阔嘴蜂鸟
+Cyornis caerulatus_大嘴仙鹟
+Cyornis concretus_白尾蓝仙鹟
+Cyornis glaucicomans_中华仙鹟
+Cyornis hainanus_海南蓝仙鹟
 Cyornis hoevelli_Blue-fronted Flycatcher
-Cyornis olivaceus_Fulvous-chested Jungle-Flycatcher
-Cyornis omissus_Sulawesi Blue Flycatcher
-Cyornis pallidipes_White-bellied Blue Flycatcher
-Cyornis poliogenys_Pale-chinned Blue Flycatcher
-Cyornis rubeculoides_Blue-throated Flycatcher
-Cyornis rufigastra_Mangrove Blue Flycatcher
-Cyornis sumatrensis_Indochinese Blue Flycatcher
-Cyornis superbus_Bornean Blue Flycatcher
-Cyornis tickelliae_Tickell's Blue Flycatcher
-Cyornis turcosus_Malaysian Blue Flycatcher
-Cyornis umbratilis_Gray-chested Jungle-Flycatcher
-Cyornis unicolor_Pale Blue Flycatcher
-Cyornis whitei_山藍仙鶲
-Cyphorhinus arada_Musician Wren
-Cyphorhinus phaeocephalus_Song Wren
-Cyphorhinus thoracicus_Chestnut-breasted Wren
-Cypseloides niger_Black Swift
-Cypsiurus balasiensis_Asian Palm-Swift
-Cypsiurus parvus_African Palm-Swift
-Cypsnagra hirundinacea_White-rumped Tanager
-Cyrtonyx montezumae_Montezuma Quail
-Cyrtonyx ocellatus_Ocellated Quail
+Cyornis olivaceus_绿背林鹟
+Cyornis omissus_苏拉威西蓝仙鹟
+Cyornis pallidipes_白腹仙鹟
+Cyornis poliogenys_灰颊仙鹟
+Cyornis rubeculoides_蓝喉仙鹟
+Cyornis rufigastra_红树仙鹟
+Cyornis sumatrensis_印支蓝仙鹟
+Cyornis superbus_加里曼丹仙鹟
+Cyornis tickelliae_梯氏仙鹟
+Cyornis turcosus_马来仙鹟
+Cyornis umbratilis_灰胸林鹟
+Cyornis unicolor_纯蓝仙鹟
+Cyornis whitei_山蓝仙鹟
+Cyphorhinus arada_歌鹪鹩
+Cyphorhinus phaeocephalus_鸣鹪鹩
+Cyphorhinus thoracicus_南栗胸歌鹪鹩
+Cypseloides niger_黑雨燕
+Cypsiurus balasiensis_棕雨燕
+Cypsiurus parvus_非洲棕雨燕
+Cypsnagra hirundinacea_白腰唐纳雀
+Cyrtonyx montezumae_彩鹑
+Cyrtonyx ocellatus_眼斑彩鹑
 Cyrtoxipha columbiana_Columbian Trig
-Dacelo gaudichaud_Rufous-bellied Kookaburra
-Dacelo leachii_Blue-winged Kookaburra
-Dacelo novaeguineae_笑翠鳥
-Dacnis cayana_Blue Dacnis
-Dacnis flaviventer_Yellow-bellied Dacnis
-Dacnis lineata_Black-faced Dacnis
-Dacnis venusta_Scarlet-thighed Dacnis
-Dactylortyx thoracicus_Singing Quail
-Daphoenositta chrysoptera_Varied Sittella
-Daption capense_Cape Petrel
-Daptrius ater_Black Caracara
-Dasylophus cumingi_Scale-feathered Malkoha
-Dasyornis brachypterus_Eastern Bristlebird
-Dasyornis broadbenti_Rufous Bristlebird
-Dasyornis longirostris_Western Bristlebird
-Deconychura longicauda_Long-tailed Woodcreeper
-Delichon dasypus_東方毛腳燕
-Delichon urbicum_白腹毛腳燕
-Dendragapus fuliginosus_Sooty Grouse
-Dendragapus obscurus_Dusky Grouse
-Dendrexetastes rufigula_Cinnamon-throated Woodcreeper
-Dendrocincla anabatina_Tawny-winged Woodcreeper
-Dendrocincla fuliginosa_Plain-brown Woodcreeper
-Dendrocincla homochroa_Ruddy Woodcreeper
-Dendrocincla merula_White-chinned Woodcreeper
-Dendrocincla turdina_Plain-winged Woodcreeper
-Dendrocincla tyrannina_Tyrannine Woodcreeper
-Dendrocitta cinerascens_Bornean Treepie
-Dendrocitta formosae_樹鵲
-Dendrocitta leucogastra_White-bellied Treepie
-Dendrocitta vagabunda_Rufous Treepie
-Dendrocolaptes certhia_Amazonian Barred-Woodcreeper
-Dendrocolaptes picumnus_Black-banded Woodcreeper
-Dendrocolaptes platyrostris_Planalto Woodcreeper
-Dendrocolaptes sanctithomae_Northern Barred-Woodcreeper
-Dendrocopos analis_Freckle-breasted Woodpecker
-Dendrocopos darjellensis_Darjeeling Woodpecker
-Dendrocopos himalayensis_Himalayan Woodpecker
-Dendrocopos hyperythrus_Rufous-bellied Woodpecker
-Dendrocopos leucopterus_White-winged Woodpecker
-Dendrocopos leucotos_大赤啄木
-Dendrocopos macei_Fulvous-breasted Woodpecker
-Dendrocopos major_Great Spotted Woodpecker
-Dendrocopos syriacus_Syrian Woodpecker
-Dendrocoptes auriceps_Brown-fronted Woodpecker
-Dendrocoptes medius_Middle Spotted Woodpecker
-Dendrocygna arcuata_Wandering Whistling-Duck
-Dendrocygna autumnalis_Black-bellied Whistling-Duck
-Dendrocygna bicolor_Fulvous Whistling-Duck
-Dendrocygna eytoni_Plumed Whistling-Duck
-Dendrocygna javanica_樹鴨
-Dendrocygna viduata_White-faced Whistling-Duck
-Dendroma erythroptera_Chestnut-winged Foliage-gleaner
-Dendroma rufa_Buff-fronted Foliage-gleaner
-Dendronanthus indicus_山鶺鴒
-Dendroplex picus_Straight-billed Woodcreeper
-Dendrortyx barbatus_Bearded Wood-Partridge
-Dendrortyx leucophrys_Buffy-crowned Wood-Partridge
-Dendrortyx macroura_Long-tailed Wood-Partridge
-Deroptyus accipitrinus_Red-fan Parrot
-Dicaeum aeneum_Midget Flowerpecker
-Dicaeum agile_Thick-billed Flowerpecker
-Dicaeum australe_Red-keeled Flowerpecker
-Dicaeum chrysorrheum_Yellow-vented Flowerpecker
-Dicaeum concolor_Nilgiri Flowerpecker
-Dicaeum cruentatum_Scarlet-backed Flowerpecker
-Dicaeum erythrorhynchos_Pale-billed Flowerpecker
-Dicaeum hirundinaceum_Mistletoebird
-Dicaeum ignipectus_紅胸啄花
-Dicaeum minullum_綠啄花
-Dicaeum pygmaeum_Pygmy Flowerpecker
-Dicaeum trigonostigma_Orange-bellied Flowerpecker
-Dicaeum tristrami_Mottled Flowerpecker
-Dichrozona cincta_Banded Antbird
-Dicrurus adsimilis_Fork-tailed Drongo
-Dicrurus aeneus_小卷尾
-Dicrurus andamanensis_Andaman Drongo
-Dicrurus annectens_鴉嘴卷尾
-Dicrurus atripennis_Shining Drongo
-Dicrurus balicassius_Balicassiao
-Dicrurus bracteatus_Spangled Drongo
-Dicrurus caerulescens_White-bellied Drongo
+Dacelo gaudichaud_棕腹笑翠鸟
+Dacelo leachii_蓝翅笑翠鸟
+Dacelo novaeguineae_笑翠鸟
+Dacnis cayana_蓝锥嘴雀
+Dacnis flaviventer_黄腹锥嘴雀
+Dacnis lineata_黑脸锥嘴雀
+Dacnis venusta_红腿锥嘴雀
+Dactylortyx thoracicus_歌鹑
+Daphoenositta chrysoptera_杂色澳䴓
+Daption capense_花斑鹱
+Daptrius ater_黑巨隼
+Dasylophus cumingi_鳞纹地鹃
+Dasyornis brachypterus_棕刺莺
+Dasyornis broadbenti_短翅刺莺
+Dasyornis longirostris_西刺莺
+Deconychura longicauda_长尾䴕雀
+Delichon dasypus_烟腹毛脚燕
+Delichon urbicum_西方毛脚燕
+Dendragapus fuliginosus_乌镰翅鸡
+Dendragapus obscurus_蓝镰翅鸡
+Dendrexetastes rufigula_红喉䴕雀
+Dendrocincla anabatina_褐翅䴕雀
+Dendrocincla fuliginosa_纯褐䴕雀
+Dendrocincla homochroa_黄䴕雀
+Dendrocincla merula_白颏䴕雀
+Dendrocincla turdina_鸫䴕雀
+Dendrocincla tyrannina_霸䴕雀
+Dendrocitta cinerascens_加里曼丹树鹊
+Dendrocitta formosae_灰树鹊
+Dendrocitta leucogastra_白腹树鹊
+Dendrocitta vagabunda_棕腹树鹊
+Dendrocolaptes certhia_斑䴕雀
+Dendrocolaptes picumnus_黑斑䴕雀
+Dendrocolaptes platyrostris_南美䴕雀
+Dendrocolaptes sanctithomae_北斑䴕雀
+Dendrocopos analis_点胸啄木鸟
+Dendrocopos darjellensis_黄颈啄木鸟
+Dendrocopos himalayensis_喜山啄木鸟
+Dendrocopos hyperythrus_棕腹啄木鸟
+Dendrocopos leucopterus_白翅啄木鸟
+Dendrocopos leucotos_白背啄木鸟
+Dendrocopos macei_茶胸斑啄木鸟
+Dendrocopos major_大斑啄木鸟
+Dendrocopos syriacus_叙利亚啄木鸟
+Dendrocoptes auriceps_褐额啄木鸟
+Dendrocoptes medius_中斑啄木鸟
+Dendrocygna arcuata_斑胸树鸭
+Dendrocygna autumnalis_黑腹树鸭
+Dendrocygna bicolor_茶色树鸭
+Dendrocygna eytoni_尖羽树鸭
+Dendrocygna javanica_栗树鸭
+Dendrocygna viduata_白脸树鸭
+Dendroma erythroptera_栗翅拾叶雀
+Dendroma rufa_黄额拾叶雀
+Dendronanthus indicus_山鹡鸰
+Dendroplex picus_直嘴䴕雀
+Dendrortyx barbatus_须林鹑
+Dendrortyx leucophrys_黄顶林鹑
+Dendrortyx macroura_长尾林鹑
+Deroptyus accipitrinus_鹰头鹦哥
+Dicaeum aeneum_所罗门啄花鸟
+Dicaeum agile_厚嘴啄花鸟
+Dicaeum australe_红纹啄花鸟
+Dicaeum chrysorrheum_黄臀啄花鸟
+Dicaeum concolor_印度纯色啄花鸟
+Dicaeum cruentatum_朱背啄花鸟
+Dicaeum erythrorhynchos_淡嘴啄花鸟
+Dicaeum hirundinaceum_澳洲啄花鸟
+Dicaeum ignipectus_红胸啄花鸟
+Dicaeum minullum_纯色啄花鸟
+Dicaeum pygmaeum_小啄花鸟
+Dicaeum trigonostigma_橙腹啄花鸟
+Dicaeum tristrami_杂色啄花鸟
+Dichrozona cincta_斑纹蚁鹩
+Dicrurus adsimilis_叉尾卷尾
+Dicrurus aeneus_古铜色卷尾
+Dicrurus andamanensis_安达曼卷尾
+Dicrurus annectens_鸦嘴卷尾
+Dicrurus atripennis_辉卷尾
+Dicrurus balicassius_白胁卷尾
+Dicrurus bracteatus_蓝点辉卷尾
+Dicrurus caerulescens_白腹卷尾
 Dicrurus divaricatus_Glossy-backed Drongo
-Dicrurus forficatus_Crested Drongo
-Dicrurus hottentottus_髮冠卷尾
+Dicrurus forficatus_冠卷尾
+Dicrurus hottentottus_发冠卷尾
 Dicrurus leucophaeus_灰卷尾
-Dicrurus ludwigii_Common Square-tailed Drongo
-Dicrurus macrocercus_大卷尾
-Dicrurus montanus_Sulawesi Drongo
-Dicrurus paradiseus_Greater Racket-tailed Drongo
-Dicrurus remifer_Lesser Racket-tailed Drongo
-Diglossa albilatera_White-sided Flowerpiercer
-Diglossa baritula_Cinnamon-bellied Flowerpiercer
-Diglossa brunneiventris_Black-throated Flowerpiercer
-Diglossa caerulescens_Bluish Flowerpiercer
-Diglossa cyanea_Masked Flowerpiercer
-Diglossa glauca_Deep-blue Flowerpiercer
-Diglossa gloriosissima_Chestnut-bellied Flowerpiercer
-Diglossa humeralis_Black Flowerpiercer
-Diglossa indigotica_Indigo Flowerpiercer
-Diglossa lafresnayii_Glossy Flowerpiercer
-Diglossa mystacalis_Moustached Flowerpiercer
-Diglossa plumbea_Slaty Flowerpiercer
-Diglossa sittoides_Rusty Flowerpiercer
-Dinemellia dinemelli_White-headed Buffalo-Weaver
-Dinopium benghalense_Black-rumped Flameback
-Dinopium javanense_Common Flameback
-Dinopium rafflesii_Olive-backed Woodpecker
-Diomedea exulans_Wandering Albatross
-Diopsittaca nobilis_紅肩金剛鸚鵡
-Diuca diuca_Diuca Finch
-Dives dives_Melodious Blackbird
-Dives warczewiczi_Scrub Blackbird
+Dicrurus ludwigii_方尾卷尾
+Dicrurus macrocercus_黑卷尾
+Dicrurus montanus_苏拉威西卷尾
+Dicrurus paradiseus_大盘尾
+Dicrurus remifer_小盘尾
+Diglossa albilatera_白胁刺花鸟
+Diglossa baritula_灰腹刺花鸟
+Diglossa brunneiventris_黑喉刺花鸟
+Diglossa caerulescens_浅蓝刺花鸟
+Diglossa cyanea_花脸刺花鸟
+Diglossa glauca_蓝刺花鸟
+Diglossa gloriosissima_栗腹刺花鸟
+Diglossa humeralis_黑刺花鸟
+Diglossa indigotica_青刺花鸟
+Diglossa lafresnayii_辉黑刺花鸟
+Diglossa mystacalis_须刺花鸟
+Diglossa plumbea_灰刺花鸟
+Diglossa sittoides_锈色刺花鸟
+Dinemellia dinemelli_白头牛文鸟
+Dinopium benghalense_小金背啄木鸟
+Dinopium javanense_金背三趾啄木鸟
+Dinopium rafflesii_绿背三趾啄木鸟
+Diomedea exulans_漂泊信天翁
+Diopsittaca nobilis_红肩金刚鹦鹉
+Diuca diuca_迪卡雀
+Dives dives_艳拟鹂
+Dives warczewiczi_丛拟鹂
 Dog_Dog
-Dolichonyx oryzivorus_Bobolink
-Donacobius atricapilla_Black-capped Donacobius
-Donacospiza albifrons_Long-tailed Reed Finch
-Doryfera ludovicae_Green-fronted Lancebill
-Drepanis coccinea_Iiwi
-Drepanornis albertisi_Black-billed Sicklebill
-Dromas ardeola_Crab-Plover
-Dromococcyx pavoninus_Pavonine Cuckoo
-Dromococcyx phasianellus_Pheasant Cuckoo
-Drymodes brunneopygia_Southern Scrub-Robin
-Drymophila caudata_East Andean Antbird
-Drymophila devillei_Striated Antbird
-Drymophila ferruginea_Ferruginous Antbird
-Drymophila genei_Rufous-tailed Antbird
-Drymophila hellmayri_Santa Marta Antbird
-Drymophila klagesi_Klages's Antbird
-Drymophila malura_Dusky-tailed Antbird
-Drymophila ochropyga_Ochre-rumped Antbird
-Drymophila rubricollis_Bertoni's Antbird
-Drymophila squamata_Scaled Antbird
-Drymophila striaticeps_Streak-headed Antbird
-Drymornis bridgesii_Scimitar-billed Woodcreeper
-Dryobates affinis_Red-stained Woodpecker
-Dryobates albolarvatus_White-headed Woodpecker
-Dryobates arizonae_Arizona Woodpecker
-Dryobates borealis_Red-cockaded Woodpecker
-Dryobates callonotus_Scarlet-backed Woodpecker
-Dryobates cassini_Golden-collared Woodpecker
-Dryobates cathpharius_Crimson-breasted Woodpecker
-Dryobates dignus_Yellow-vented Woodpecker
-Dryobates frontalis_Dot-fronted Woodpecker
-Dryobates fumigatus_Smoky-brown Woodpecker
-Dryobates kirkii_Red-rumped Woodpecker
-Dryobates lignarius_Striped Woodpecker
-Dryobates maculifrons_Yellow-eared Woodpecker
-Dryobates minor_Lesser Spotted Woodpecker
-Dryobates mixtus_Checkered Woodpecker
-Dryobates nigriceps_Bar-bellied Woodpecker
-Dryobates nuttallii_Nuttall's Woodpecker
-Dryobates passerinus_Little Woodpecker
-Dryobates pubescens_Downy Woodpecker
-Dryobates scalaris_Ladder-backed Woodpecker
-Dryobates spilogaster_White-spotted Woodpecker
-Dryobates stricklandi_Strickland's Woodpecker
-Dryobates villosus_Hairy Woodpecker
-Dryocopus javensis_White-bellied Woodpecker
-Dryocopus lineatus_Lineated Woodpecker
-Dryocopus martius_Black Woodpecker
-Dryocopus pileatus_Pileated Woodpecker
-Dryocopus schulzii_Black-bodied Woodpecker
-Dryolimnas cuvieri_White-throated Rail
+Dolichonyx oryzivorus_刺歌雀
+Donacobius atricapilla_黑顶鹪莺
+Donacospiza albifrons_长尾芦雀
+Doryfera ludovicae_绿额矛嘴蜂鸟
+Drepanis coccinea_镰嘴管舌雀
+Drepanornis albertisi_黑嘴镰嘴风鸟
+Dromas ardeola_蟹鸻
+Dromococcyx pavoninus_小雉鹃
+Dromococcyx phasianellus_雉鹃
+Drymodes brunneopygia_栗腰薮鸲
+Drymophila caudata_长尾蚁鸟
+Drymophila devillei_条纹蚁鸟
+Drymophila ferruginea_赤褐蚁鸟
+Drymophila genei_棕尾蚁鸟
+Drymophila hellmayri_圣玛塔蚁鸟
+Drymophila klagesi_克氏蚁鸟
+Drymophila malura_暗尾蚁鸟
+Drymophila ochropyga_赭腰蚁鸟
+Drymophila rubricollis_伯氏蚁鸟
+Drymophila squamata_鳞斑蚁鸟
+Drymophila striaticeps_纹头蚁鸟
+Drymornis bridgesii_弯嘴䴕雀
+Dryobates affinis_红晕啄木鸟
+Dryobates albolarvatus_白头啄木鸟
+Dryobates arizonae_亚利桑那啄木鸟
+Dryobates borealis_红顶啄木鸟
+Dryobates callonotus_朱背啄木鸟
+Dryobates cassini_金领啄木鸟
+Dryobates cathpharius_红枕啄木鸟
+Dryobates dignus_黄臀啄木鸟
+Dryobates frontalis_点额啄木鸟
+Dryobates fumigatus_褐啄木鸟
+Dryobates kirkii_红腰啄木鸟
+Dryobates lignarius_条纹啄木鸟
+Dryobates maculifrons_黄耳啄木鸟
+Dryobates minor_小斑啄木鸟
+Dryobates mixtus_格斑啄木鸟
+Dryobates nigriceps_斑腹啄木鸟
+Dryobates nuttallii_加州啄木鸟
+Dryobates passerinus_小啄木鸟
+Dryobates pubescens_绒啄木鸟
+Dryobates scalaris_纹背啄木鸟
+Dryobates spilogaster_白斑啄木鸟
+Dryobates stricklandi_褐斑啄木鸟
+Dryobates villosus_长嘴啄木鸟
+Dryocopus javensis_白腹黑啄木鸟
+Dryocopus lineatus_细纹黑啄木鸟
+Dryocopus martius_黑啄木鸟
+Dryocopus pileatus_北美黑啄木鸟
+Dryocopus schulzii_南美黑啄木鸟
+Dryolimnas cuvieri_白喉秧鸡
 Dryophytes andersonii_Pine Barrens Treefrog
 Dryophytes arenicolor_Canyon Treefrog
 Dryophytes avivoca_Bird-voiced Treefrog
@@ -2008,2017 +2008,2017 @@ Dryophytes femoralis_Pine Woods Treefrog
 Dryophytes gratiosus_Barking Treefrog
 Dryophytes squirellus_Squirrel Treefrog
 Dryophytes versicolor_Gray Treefrog
-Dryoscopus cubla_Black-backed Puffback
-Dryoscopus gambensis_Northern Puffback
-Dryotriorchis spectabilis_Congo Serpent-Eagle
-Dubusia castaneoventris_Chestnut-bellied Mountain Tanager
-Dubusia taeniata_Buff-breasted Mountain Tanager
-Ducula aenea_Green Imperial-Pigeon
-Ducula badia_Mountain Imperial-Pigeon
-Ducula basilica_Cinnamon-bellied Imperial-Pigeon
-Ducula bicolor_Pied Imperial-Pigeon
-Ducula concinna_Elegant Imperial-Pigeon
-Ducula lacernulata_Dark-backed Imperial-Pigeon
-Ducula latrans_Peale's Imperial-Pigeon
-Ducula pacifica_Pacific Imperial-Pigeon
-Ducula perspicillata_Spectacled Imperial-Pigeon
-Ducula pinon_Pinon's Imperial-Pigeon
-Ducula pistrinaria_Island Imperial-Pigeon
-Ducula poliocephala_Pink-bellied Imperial-Pigeon
-Ducula rubricera_Red-knobbed Imperial-Pigeon
-Ducula spilorrhoa_Torresian Imperial-Pigeon
-Ducula zoeae_Zoe's Imperial-Pigeon
-Dulus dominicus_Palmchat
-Dumetella carolinensis_Gray Catbird
-Dumetia atriceps_Dark-fronted Babbler
-Dumetia hyperythra_Tawny-bellied Babbler
-Dysithamnus leucostictus_White-streaked Antvireo
-Dysithamnus mentalis_Plain Antvireo
-Dysithamnus occidentalis_Bicolored Antvireo
-Dysithamnus plumbeus_Plumbeous Antvireo
-Dysithamnus puncticeps_Spot-crowned Antvireo
-Dysithamnus stictothorax_Spot-breasted Antvireo
-Dysithamnus striaticeps_Streak-crowned Antvireo
-Dysithamnus xanthopterus_Rufous-backed Antvireo
-Eclectus roratus_折衷鸚鵡
-Edolisoma montanum_Black-bellied Cicadabird
-Edolisoma tenuirostre_Common Cicadabird
-Egretta caerulea_Little Blue Heron
-Egretta eulophotes_唐白鷺
-Egretta garzetta_小白鷺
-Egretta gularis_Western Reef-Heron
-Egretta novaehollandiae_白臉鷺
-Egretta rufescens_Reddish Egret
-Egretta sacra_岩鷺
-Egretta thula_Snowy Egret
-Egretta tricolor_Tricolored Heron
-Elachura formosa_Spotted Elachura
-Elaenia albiceps_White-crested Elaenia
-Elaenia brachyptera_Coopmans's Elaenia
-Elaenia chiriquensis_Lesser Elaenia
-Elaenia cristata_Plain-crested Elaenia
-Elaenia fallax_Greater Antillean Elaenia
-Elaenia flavogaster_Yellow-bellied Elaenia
-Elaenia frantzii_Mountain Elaenia
-Elaenia gigas_Mottle-backed Elaenia
-Elaenia martinica_Caribbean Elaenia
-Elaenia mesoleuca_Olivaceous Elaenia
-Elaenia obscura_Highland Elaenia
-Elaenia olivina_Tepui Elaenia
-Elaenia pallatangae_Sierran Elaenia
-Elaenia parvirostris_Small-billed Elaenia
-Elaenia ruficeps_Rufous-crowned Elaenia
-Elaenia sordida_Small-headed Elaenia
-Elaenia spectabilis_Large Elaenia
-Elaenia strepera_Slaty Elaenia
-Elanoides forficatus_Swallow-tailed Kite
-Elanus caeruleus_黑翅鳶
-Elanus leucurus_White-tailed Kite
-Electron carinatum_Keel-billed Motmot
-Electron platyrhynchum_Broad-billed Motmot
-Eleoscytalopus indigoticus_White-breasted Tapaculo
-Eleothreptus anomalus_Sickle-winged Nightjar
+Dryoscopus cubla_黑背蓬背鵙
+Dryoscopus gambensis_蓬背鵙
+Dryotriorchis spectabilis_刚果蛇雕
+Dubusia castaneoventris_栗腹唐纳雀
+Dubusia taeniata_淡胸山裸鼻雀
+Ducula aenea_绿皇鸠
+Ducula badia_山皇鸠
+Ducula basilica_棕腹皇鸠
+Ducula bicolor_斑皇鸠
+Ducula concinna_蓝尾皇鸠
+Ducula lacernulata_黑背皇鸠
+Ducula latrans_皮氏皇鸠
+Ducula pacifica_太平洋皇鸠
+Ducula perspicillata_白眼皇鸠
+Ducula pinon_裸眶皇鸠
+Ducula pistrinaria_灰皇鸠
+Ducula poliocephala_红腹皇鸠
+Ducula rubricera_红疣皇鸠
+Ducula spilorrhoa_澳洲斑皇鸠
+Ducula zoeae_横斑皇鸠
+Dulus dominicus_棕榈䳭
+Dumetella carolinensis_灰嘲鸫
+Dumetia atriceps_黑头鹛
+Dumetia hyperythra_棕腹鹛
+Dysithamnus leucostictus_白纹蚁鵙
+Dysithamnus mentalis_淡色蚁鵙
+Dysithamnus occidentalis_西蚁鵙
+Dysithamnus plumbeus_铅色蚁鵙
+Dysithamnus puncticeps_斑点冠蚁鵙
+Dysithamnus stictothorax_斑胸蚁鵙
+Dysithamnus striaticeps_纹冠蚁鵙
+Dysithamnus xanthopterus_棕背蚁鵙
+Eclectus roratus_红胁绿鹦鹉
+Edolisoma montanum_高山鹃鵙
+Edolisoma tenuirostre_长嘴鹃鵙
+Egretta caerulea_小蓝鹭
+Egretta eulophotes_黄嘴白鹭
+Egretta garzetta_白鹭
+Egretta gularis_西岩鹭
+Egretta novaehollandiae_白脸鹭
+Egretta rufescens_棕颈鹭
+Egretta sacra_岩鹭
+Egretta thula_雪鹭
+Egretta tricolor_三色鹭
+Elachura formosa_丽星鹩鹛
+Elaenia albiceps_白冠拟霸鹟
+Elaenia brachyptera_灰胸小拟霸鹟
+Elaenia chiriquensis_小拟霸鹟
+Elaenia cristata_纯色冠拟霸鹟
+Elaenia fallax_安岛拟霸鹟
+Elaenia flavogaster_黄腹拟霸鹟
+Elaenia frantzii_山拟霸鹟
+Elaenia gigas_斑背拟霸鹟
+Elaenia martinica_加勒比拟霸鹟
+Elaenia mesoleuca_绿拟霸鹟
+Elaenia obscura_高原拟霸鹟
+Elaenia olivina_黄腹岭拟霸鹟
+Elaenia pallatangae_岭拟霸鹟
+Elaenia parvirostris_小嘴拟霸鹟
+Elaenia ruficeps_棕顶拟霸鹟
+Elaenia sordida_巴西拟霸鹟
+Elaenia spectabilis_大拟霸鹟
+Elaenia strepera_灰拟霸鹟
+Elanoides forficatus_燕尾鸢
+Elanus caeruleus_黑翅鸢
+Elanus leucurus_白尾鸢
+Electron carinatum_隆嘴翠鴗
+Electron platyrhynchum_阔嘴翠鴗
+Eleoscytalopus indigoticus_白胸窜鸟
+Eleothreptus anomalus_镰翅夜鹰
 Eleutherodactylus planirostris_Greenhouse Frog
-Elliotomyia chionogaster_White-bellied Hummingbird
-Elminia albonotata_White-tailed Crested-Flycatcher
-Elminia longicauda_African Blue Flycatcher
-Elseyornis melanops_Black-fronted Dotterel
-Emarginata sinuata_Sickle-winged Chat
-Emberiza aureola_金鵐
-Emberiza bruniceps_褐頭鵐
-Emberiza buchanani_Gray-necked Bunting
-Emberiza cabanisi_Cabanis's Bunting
-Emberiza caesia_Cretzschmar's Bunting
-Emberiza calandra_Corn Bunting
-Emberiza capensis_Cape Bunting
-Emberiza chrysophrys_黃眉鵐
-Emberiza cia_Rock Bunting
-Emberiza cineracea_Cinereous Bunting
-Emberiza cioides_草鵐
-Emberiza cirlus_Cirl Bunting
-Emberiza citrinella_Yellowhammer
-Emberiza elegans_黃喉鵐
-Emberiza flaviventris_Golden-breasted Bunting
-Emberiza fucata_赤胸鵐
-Emberiza godlewskii_Godlewski's Bunting
-Emberiza hortulana_圃鵐
-Emberiza impetuani_Lark-like Bunting
-Emberiza lathami_冠鵐
-Emberiza leucocephalos_白頭鵐
-Emberiza melanocephala_黑頭鵐
-Emberiza pallasi_葦鵐
-Emberiza pusilla_小鵐
-Emberiza rustica_田鵐
-Emberiza sahari_House Bunting
-Emberiza schoeniclus_蘆鵐
-Emberiza spodocephala_灰頭黑臉鵐
-Emberiza stewarti_白頂鵐
-Emberiza striolata_Striolated Bunting
-Emberiza sulphurata_野鵐
-Emberiza tahapisi_Cinnamon-breasted Bunting
-Emberiza tristrami_白眉鵐
-Emberiza variabilis_灰鵐
-Emberiza yessoensis_紅頸葦鵐
-Emberizoides herbicola_Wedge-tailed Grass-Finch
-Emberizoides ypiranganus_Lesser Grass-Finch
-Embernagra longicauda_Pale-throated Pampa-Finch
-Embernagra platensis_Great Pampa-Finch
-Eminia lepida_Gray-capped Warbler
-Empidonax affinis_Pine Flycatcher
-Empidonax albigularis_White-throated Flycatcher
-Empidonax alnorum_Alder Flycatcher
-Empidonax atriceps_Black-capped Flycatcher
-Empidonax difficilis_Pacific-slope Flycatcher
-Empidonax flavescens_Yellowish Flycatcher
-Empidonax flaviventris_Yellow-bellied Flycatcher
-Empidonax fulvifrons_Buff-breasted Flycatcher
-Empidonax hammondii_Hammond's Flycatcher
-Empidonax minimus_Least Flycatcher
-Empidonax oberholseri_Dusky Flycatcher
+Elliotomyia chionogaster_白腹蜂鸟
+Elminia albonotata_白尾凤头鹟
+Elminia longicauda_蓝凤头鹟
+Elseyornis melanops_黑额鸻
+Emarginata sinuata_镰翅岩䳭
+Emberiza aureola_黄胸鹀
+Emberiza bruniceps_褐头鹀
+Emberiza buchanani_灰颈鹀
+Emberiza cabanisi_白眉黄腹鹀
+Emberiza caesia_蓝头圃鹀
+Emberiza calandra_黍鹀
+Emberiza capensis_南非岩鹀
+Emberiza chrysophrys_黄眉鹀
+Emberiza cia_淡灰眉岩鹀
+Emberiza cineracea_苍头鹀
+Emberiza cioides_三道眉草鹀
+Emberiza cirlus_黄道眉鹀
+Emberiza citrinella_黄鹀
+Emberiza elegans_黄喉鹀
+Emberiza flaviventris_金胸鹀
+Emberiza fucata_栗耳鹀
+Emberiza godlewskii_灰眉岩鹀
+Emberiza hortulana_圃鹀
+Emberiza impetuani_淡岩鹀
+Emberiza lathami_凤头鹀
+Emberiza leucocephalos_白头鹀
+Emberiza melanocephala_黑头鹀
+Emberiza pallasi_苇鹀
+Emberiza pusilla_小鹀
+Emberiza rustica_田鹀
+Emberiza sahari_家鹀
+Emberiza schoeniclus_芦鹀
+Emberiza spodocephala_灰头鹀
+Emberiza stewarti_白顶鹀
+Emberiza striolata_黑纹鹀
+Emberiza sulphurata_硫黄鹀
+Emberiza tahapisi_朱胸鹀
+Emberiza tristrami_白眉鹀
+Emberiza variabilis_灰鹀
+Emberiza yessoensis_红颈苇鹀
+Emberizoides herbicola_楔尾草鹀
+Emberizoides ypiranganus_小草鹀
+Embernagra longicauda_南美草鹀
+Embernagra platensis_大南美草鹀
+Eminia lepida_灰顶莺
+Empidonax affinis_松纹霸鹟
+Empidonax albigularis_白喉纹霸鹟
+Empidonax alnorum_恺木纹霸鹟
+Empidonax atriceps_黑顶纹霸鹟
+Empidonax difficilis_北美纹霸鹟
+Empidonax flavescens_淡黄纹霸鹟
+Empidonax flaviventris_黄腹纹霸鹟
+Empidonax fulvifrons_黄胸纹霸鹟
+Empidonax hammondii_哈氏纹霸鹟
+Empidonax minimus_小纹霸鹟
+Empidonax oberholseri_暗纹霸鹟
 Empidonax occidentalis_Cordilleran Flycatcher
-Empidonax traillii_Willow Flycatcher
-Empidonax virescens_Acadian Flycatcher
-Empidonax wrightii_Gray Flycatcher
-Empidonomus aurantioatrocristatus_Crowned Slaty Flycatcher
-Empidonomus varius_Variegated Flycatcher
+Empidonax traillii_纹霸鹟
+Empidonax virescens_绿纹霸鹟
+Empidonax wrightii_灰纹霸鹟
+Empidonomus aurantioatrocristatus_冠灰纹霸鹟
+Empidonomus varius_杂色纹霸鹟
 Engine_Engine
-Enicognathus ferrugineus_Austral Parakeet
-Enicognathus leptorhynchus_Slender-billed Parakeet
-Enicurus leschenaulti_White-crowned Forktail
-Enicurus maculatus_Spotted Forktail
-Enicurus schistaceus_Slaty-backed Forktail
-Entomodestes coracinus_Black Solitaire
-Entomodestes leucotis_White-eared Solitaire
-Entomyzon cyanotis_Blue-faced Honeyeater
+Enicognathus ferrugineus_南鹦哥
+Enicognathus leptorhynchus_细嘴鹦哥
+Enicurus leschenaulti_白冠燕尾
+Enicurus maculatus_斑背燕尾
+Enicurus schistaceus_灰背燕尾
+Entomodestes coracinus_黑孤鸫
+Entomodestes leucotis_白耳孤鸫
+Entomyzon cyanotis_蓝脸吸蜜鸟
 Environmental_Environmental
-Eolophus roseicapilla_Galah
-Eophona migratoria_小桑鳲
-Eophona personata_桑鳲
-Eopsaltria australis_Eastern Yellow Robin
-Epimachus fastosus_Black Sicklebill
-Epimachus meyeri_Brown Sicklebill
-Epinecrophylla amazonica_Rio Madeira Stipplethroat
-Epinecrophylla erythrura_Rufous-tailed Stipplethroat
-Epinecrophylla fulviventris_Checker-throated Stipplethroat
-Epinecrophylla gutturalis_Brown-bellied Stipplethroat
-Epinecrophylla haematonota_Rufous-backed Stipplethroat
-Epinecrophylla leucophthalma_White-eyed Stipplethroat
-Epinecrophylla ornata_Ornate Stipplethroat
-Epinecrophylla spodionota_Foothill Stipplethroat
-Epthianura tricolor_Crimson Chat
-Eremomela gregalis_Yellow-rumped Eremomela
-Eremomela icteropygialis_Yellow-bellied Eremomela
-Eremomela pusilla_Senegal Eremomela
-Eremomela scotops_Greencap Eremomela
-Eremophila alpestris_Horned Lark
-Eremopterix griseus_Ashy-crowned Sparrow-Lark
-Eremopterix hova_Madagascar Lark
-Eremopterix nigriceps_Black-crowned Sparrow-Lark
-Erithacus rubecula_European Robin
-Erpornis zantholeuca_綠畫眉
-Erythrocercus holochlorus_Yellow Flycatcher
-Erythrogenys erythrocnemis_大彎嘴
-Erythrogenys erythrogenys_Rusty-cheeked Scimitar-Babbler
-Erythrogenys gravivox_Black-streaked Scimitar-Babbler
-Erythrogenys hypoleucos_Large Scimitar-Babbler
-Erythrogenys mcclellandi_Spot-breasted Scimitar-Babbler
-Erythrogenys swinhoei_Gray-sided Scimitar-Babbler
-Erythropitta arquata_Blue-banded Pitta
-Erythropitta erythrogaster_Blue-breasted Pitta
-Erythropitta granatina_Garnet Pitta
-Erythropitta macklotii_Papuan Pitta
-Erythropitta rufiventris_North Moluccan Pitta
-Erythropitta ussheri_Black-crowned Pitta
-Erythrura trichroa_Blue-faced Parrotfinch
-Esacus magnirostris_Beach Thick-knee
-Esacus recurvirostris_Great Thick-knee
-Estrilda astrild_橫斑梅花雀
-Estrilda melpoda_橙頰梅花雀
-Estrilda nonnula_Black-crowned Waxbill
-Estrilda paludicola_Fawn-breasted Waxbill
-Estrilda troglodytes_Black-rumped Waxbill
-Eubucco bourcierii_Red-headed Barbet
-Eubucco richardsoni_Lemon-throated Barbet
-Euchrepomis callinota_Rufous-rumped Antwren
-Euchrepomis humeralis_Chestnut-shouldered Antwren
-Euchrepomis spodioptila_Ash-winged Antwren
-Eucometis penicillata_Gray-headed Tanager
-Eudocimus albus_White Ibis
-Eudromia elegans_Elegant Crested-Tinamou
-Eudynamys melanorhynchus_Black-billed Koel
-Eudynamys orientalis_Pacific Koel
-Eudynamys scolopaceus_噪鵑
-Eudyptes chrysocome_Southern Rockhopper Penguin
-Eudyptula minor_Little Penguin
-Eugenes fulgens_Rivoli's Hummingbird
-Eugenes spectabilis_Talamanca Hummingbird
-Eugralla paradoxa_Ochre-flanked Tapaculo
-Eumomota superciliosa_Turquoise-browed Motmot
-Eumyias albicaudatus_Nilgiri Flycatcher
-Eumyias indigo_Indigo Flycatcher
-Eumyias panayensis_Turquoise Flycatcher
-Eumyias thalassinus_銅藍鶲
+Eolophus roseicapilla_粉红凤头鹦鹉
+Eophona migratoria_黑尾蜡嘴雀
+Eophona personata_黑头蜡嘴雀
+Eopsaltria australis_东黄鸲鹟
+Epimachus fastosus_黑镰嘴风鸟
+Epimachus meyeri_褐镰嘴风鸟
+Epinecrophylla amazonica_马德拉斑喉蚁鹩
+Epinecrophylla erythrura_棕尾蚁鹩
+Epinecrophylla fulviventris_格喉蚁鹩
+Epinecrophylla gutturalis_褐腹蚁鹩
+Epinecrophylla haematonota_斑喉蚁鹩
+Epinecrophylla leucophthalma_白眼蚁鹩
+Epinecrophylla ornata_丽蚁鹩
+Epinecrophylla spodionota_低山蚁鹩
+Epthianura tricolor_绯红澳䳭
+Eremomela gregalis_绿孤莺
+Eremomela icteropygialis_黄嘴孤莺
+Eremomela pusilla_绿背孤莺
+Eremomela scotops_绿顶孤莺
+Eremophila alpestris_角百灵
+Eremopterix griseus_灰顶雀百灵
+Eremopterix hova_马岛雀百灵
+Eremopterix nigriceps_黑顶雀百灵
+Erithacus rubecula_欧亚鸲
+Erpornis zantholeuca_白腹凤鹛
+Erythrocercus holochlorus_黄红鹟
+Erythrogenys erythrocnemis_台湾斑胸钩嘴鹛
+Erythrogenys erythrogenys_锈脸钩嘴鹛
+Erythrogenys gravivox_斑胸钩嘴鹛
+Erythrogenys hypoleucos_长嘴钩嘴鹛
+Erythrogenys mcclellandi_印度斑胸钩嘴鹛
+Erythrogenys swinhoei_华南斑胸钩嘴鹛
+Erythropitta arquata_蓝斑八色鸫
+Erythropitta erythrogaster_红胸八色鸫
+Erythropitta granatina_榴红八色鸫
+Erythropitta macklotii_巴布亚八色鸫
+Erythropitta rufiventris_北摩鹿加八色鸫
+Erythropitta ussheri_黑头八色鸫
+Erythrura trichroa_蓝脸鹦雀
+Esacus magnirostris_澳洲石鸻
+Esacus recurvirostris_大石鸻
+Estrilda astrild_梅花雀
+Estrilda melpoda_橙颊梅花雀
+Estrilda nonnula_黑顶梅花雀
+Estrilda paludicola_黄胸梅花雀
+Estrilda troglodytes_黑腰梅花雀
+Eubucco bourcierii_红头拟啄木鸟
+Eubucco richardsoni_黄喉拟啄木鸟
+Euchrepomis callinota_棕腰蚁鹩
+Euchrepomis humeralis_栗肩蚁鹩
+Euchrepomis spodioptila_灰翅蚁鹩
+Eucometis penicillata_灰头唐纳雀
+Eudocimus albus_美洲白鹮
+Eudromia elegans_凤头䳍
+Eudynamys melanorhynchus_黑嘴噪鹃
+Eudynamys orientalis_太平洋噪鹃
+Eudynamys scolopaceus_噪鹃
+Eudyptes chrysocome_凤头黄眉企鹅
+Eudyptula minor_小企鹅
+Eugenes fulgens_大蜂鸟
+Eugenes spectabilis_高地大蜂鸟
+Eugralla paradoxa_赭胁窜鸟
+Eumomota superciliosa_绿眉翠鴗
+Eumyias albicaudatus_印度仙鹟
+Eumyias indigo_青仙鹟
+Eumyias panayensis_岛仙鹟
+Eumyias thalassinus_铜蓝鹟
 Eunemobius carolinus_Carolina Ground Cricket
 Eunemobius confusus_Confused Ground Cricket
-Euodice cantans_African Silverbill
-Euodice malabarica_白喉文鳥
-Eupetes macrocerus_Malaysian Rail-babbler
-Eupetomena cirrochloris_Sombre Hummingbird
-Eupetomena macroura_Swallow-tailed Hummingbird
-Euphagus carolinus_Rusty Blackbird
-Euphagus cyanocephalus_Brewer's Blackbird
-Eupherusa eximia_Stripe-tailed Hummingbird
-Euphonia affinis_Scrub Euphonia
-Euphonia anneae_Tawny-capped Euphonia
-Euphonia cayennensis_Golden-sided Euphonia
-Euphonia chalybea_Green-throated Euphonia
-Euphonia chlorotica_Purple-throated Euphonia
-Euphonia chrysopasta_Golden-bellied Euphonia
-Euphonia concinna_Velvet-fronted Euphonia
-Euphonia finschi_Finsch's Euphonia
-Euphonia fulvicrissa_Fulvous-vented Euphonia
-Euphonia gouldi_Olive-backed Euphonia
-Euphonia hirundinacea_Yellow-throated Euphonia
-Euphonia imitans_Spot-crowned Euphonia
-Euphonia laniirostris_Thick-billed Euphonia
-Euphonia luteicapilla_Yellow-crowned Euphonia
-Euphonia mesochrysa_Bronze-green Euphonia
-Euphonia minuta_White-vented Euphonia
-Euphonia pectoralis_Chestnut-bellied Euphonia
-Euphonia plumbea_Plumbeous Euphonia
-Euphonia rufiventris_Rufous-bellied Euphonia
-Euphonia trinitatis_Trinidad Euphonia
-Euphonia violacea_Violaceous Euphonia
-Euphonia xanthogaster_Orange-bellied Euphonia
-Euplectes afer_Yellow-crowned Bishop
-Euplectes ardens_Red-collared Widowbird (Red-collared)
-Euplectes capensis_Yellow Bishop
-Euplectes franciscanus_Northern Red Bishop
-Euplectes hordeaceus_Black-winged Bishop
-Euplectes orix_南紅寡婦鳥
-Euplectes progne_Long-tailed Widowbird
+Euodice cantans_银嘴文鸟
+Euodice malabarica_白喉文鸟
+Eupetes macrocerus_白眉长颈鸫
+Eupetomena cirrochloris_暗色刀翅蜂鸟
+Eupetomena macroura_燕尾刀翅蜂鸟
+Euphagus carolinus_锈色黑鹂
+Euphagus cyanocephalus_蓝头黑鹂
+Eupherusa eximia_纹尾蜂鸟
+Euphonia affinis_薮歌雀
+Euphonia anneae_黄顶歌雀
+Euphonia cayennensis_金胁歌雀
+Euphonia chalybea_绿喉歌雀
+Euphonia chlorotica_紫喉歌雀
+Euphonia chrysopasta_金腹歌雀
+Euphonia concinna_绒额歌雀
+Euphonia finschi_芬氏歌雀
+Euphonia fulvicrissa_褐臀歌雀
+Euphonia gouldi_绿背歌雀
+Euphonia hirundinacea_黄喉歌雀
+Euphonia imitans_斑冠歌雀
+Euphonia laniirostris_厚嘴歌雀
+Euphonia luteicapilla_黄冠歌雀
+Euphonia mesochrysa_铜绿歌雀
+Euphonia minuta_白臀歌雀
+Euphonia pectoralis_栗腹歌雀
+Euphonia plumbea_铅灰歌雀
+Euphonia rufiventris_棕腹歌雀
+Euphonia trinitatis_特立尼达歌雀
+Euphonia violacea_紫歌雀
+Euphonia xanthogaster_橙腹歌雀
+Euplectes afer_黄顶巧织雀
+Euplectes ardens_红领巧织雀
+Euplectes capensis_黄巧织雀
+Euplectes franciscanus_橙巧织雀
+Euplectes hordeaceus_黑翅巧织雀
+Euplectes orix_红巧织雀
+Euplectes progne_长尾巧织雀
 Eupodotis afra_Black Bustard
 Eupodotis afraoides_White-quilled Bustard
-Eupodotis caerulescens_Blue Bustard
+Eupodotis caerulescens_蓝鸨
 Eupodotis ruficrista_Red-crested Bustard
-Eupodotis senegalensis_White-bellied Bustard
+Eupodotis senegalensis_白腹鸨
 Eupodotis vigorsii_Karoo Bustard
-Eupsittula aurea_Peach-fronted Parakeet
-Eupsittula cactorum_Cactus Parakeet
-Eupsittula canicularis_Orange-fronted Parakeet
-Eupsittula nana_Olive-throated Parakeet
-Eupsittula pertinax_Brown-throated Parakeet
-Euptilotis neoxenus_Eared Quetzal
-Eurillas ansorgei_Ansorge's Greenbul
-Eurillas curvirostris_Plain Greenbul
-Eurillas latirostris_Yellow-whiskered Greenbul
-Eurillas virens_Little Greenbul
-Eurocephalus ruppelli_White-rumped Shrike
-Eurostopodus argus_Spotted Nightjar
-Eurostopodus mystacalis_White-throated Nightjar
-Eurylaimus javanicus_Banded Broadbill
-Eurylaimus ochromalus_Black-and-yellow Broadbill
-Eurypyga helias_Sunbittern
-Eurystomus glaucurus_Broad-billed Roller
-Eurystomus orientalis_佛法僧
-Euscarthmus fulviceps_Fulvous-headed Pygmy-Tyrant
-Euscarthmus meloryphus_Rufous-crowned Pygmy-Tyrant
-Euscarthmus rufomarginatus_Rufous-sided Pygmy-Tyrant
-Eutoxeres aquila_White-tipped Sicklebill
-Falco amurensis_紅腳隼
-Falco berigora_Brown Falcon
+Eupsittula aurea_粉额鹦哥
+Eupsittula cactorum_仙人掌鹦哥
+Eupsittula canicularis_橙额鹦哥
+Eupsittula nana_绿喉鹦哥
+Eupsittula pertinax_褐喉鹦哥
+Euptilotis neoxenus_角咬鹃
+Eurillas ansorgei_安氏绿鹎
+Eurillas curvirostris_纯色绿鹎
+Eurillas latirostris_黄须绿鹎
+Eurillas virens_小绿鹎
+Eurocephalus ruppelli_白腰林鵙
+Eurostopodus argus_斑毛腿夜鹰
+Eurostopodus mystacalis_白喉毛腿夜鹰
+Eurylaimus javanicus_带斑阔嘴鸟
+Eurylaimus ochromalus_黑黄阔嘴鸟
+Eurypyga helias_日鳽
+Eurystomus glaucurus_阔嘴三宝鸟
+Eurystomus orientalis_三宝鸟
+Euscarthmus fulviceps_褐脸丛霸鹟
+Euscarthmus meloryphus_褐顶丛霸鹟
+Euscarthmus rufomarginatus_棕胁侏霸鹟
+Eutoxeres aquila_白尾尖镰嘴蜂鸟
+Falco amurensis_红脚隼
+Falco berigora_褐隼
 Falco columbarius_灰背隼
-Falco deiroleucus_Orange-breasted Falcon
-Falco femoralis_Aplomado Falcon
-Falco mexicanus_Prairie Falcon
-Falco naumanni_黃爪隼
-Falco peregrinus_遊隼
-Falco rufigularis_Bat Falcon
-Falco rusticolus_Gyrfalcon
-Falco sparverius_American Kestrel
+Falco deiroleucus_橙胸隼
+Falco femoralis_黄眉隼
+Falco mexicanus_草原隼
+Falco naumanni_黄爪隼
+Falco peregrinus_游隼
+Falco rufigularis_食蝠隼
+Falco rusticolus_矛隼
+Falco sparverius_美洲隼
 Falco subbuteo_燕隼
-Falco tinnunculus_紅隼
-Falco vespertinus_Red-footed Falcon
-Falculea palliata_Sickle-billed Vanga
-Falcunculus frontatus_Shrike-tits
-Ferminia cerverai_Zapata Wren
-Ficedula albicilla_紅喉鶲
-Ficedula albicollis_Collared Flycatcher
-Ficedula basilanica_Little Slaty Flycatcher
-Ficedula dumetoria_Rufous-chested Flycatcher
-Ficedula elisae_綠背姬鶲
-Ficedula erithacus_鏽胸藍姬鶲
-Ficedula hodgsoni_Pygmy Flycatcher
-Ficedula hyperythra_黃胸青鶲
-Ficedula hypoleuca_European Pied Flycatcher
-Ficedula mugimaki_白眉黃鶲
-Ficedula narcissina_黃眉黃鶲
-Ficedula nigrorufa_Black-and-orange Flycatcher
-Ficedula parva_紅胸鶲
-Ficedula ruficauda_Rusty-tailed Flycatcher
-Ficedula semitorquata_Semicollared Flycatcher
-Ficedula strophiata_橙胸姬鶲
-Ficedula subrubra_Kashmir Flycatcher
-Ficedula superciliaris_Ultramarine Flycatcher
-Ficedula tricolor_Slaty-blue Flycatcher
-Ficedula westermanni_Little Pied Flycatcher
-Ficedula zanthopygia_白眉鶲
+Falco tinnunculus_红隼
+Falco vespertinus_西红脚隼
+Falculea palliata_弯嘴鵙
+Falcunculus frontatus_东鵙雀鹟
+Ferminia cerverai_扎巴鹪鹩
+Ficedula albicilla_红喉姬鹟
+Ficedula albicollis_白领姬鹟
+Ficedula basilanica_小灰姬鹟
+Ficedula dumetoria_棕胸姬鹟
+Ficedula elisae_绿背姬鹟
+Ficedula erithacus_锈胸蓝姬鹟
+Ficedula hodgsoni_侏蓝姬鹟
+Ficedula hyperythra_棕胸蓝姬鹟
+Ficedula hypoleuca_斑姬鹟
+Ficedula mugimaki_鸲姬鹟
+Ficedula narcissina_黄眉姬鹟
+Ficedula nigrorufa_黑棕姬鹟
+Ficedula parva_红胸姬鹟
+Ficedula ruficauda_栗尾姬鹟
+Ficedula semitorquata_半领姬鹟
+Ficedula strophiata_橙胸姬鹟
+Ficedula subrubra_印巴姬鹟
+Ficedula superciliaris_白眉蓝姬鹟
+Ficedula tricolor_灰蓝姬鹟
+Ficedula westermanni_小斑姬鹟
+Ficedula zanthopygia_白眉姬鹟
 Fireworks_Fireworks
-Florisuga fusca_Black Jacobin
-Florisuga mellivora_White-necked Jacobin
-Fluvicola albiventer_Black-backed Water-Tyrant
-Fluvicola nengeta_Masked Water-Tyrant
-Fluvicola pica_Pied Water-Tyrant
-Formicarius analis_Black-faced Antthrush
-Formicarius colma_Rufous-capped Antthrush
-Formicarius moniliger_Mayan Antthrush
-Formicarius nigricapillus_Black-headed Antthrush
-Formicarius rufifrons_Rufous-fronted Antthrush
-Formicarius rufipectus_Rufous-breasted Antthrush
-Formicivora acutirostris_Marsh Antwren
-Formicivora erythronotos_Black-hooded Antwren
-Formicivora grantsaui_Sincora Antwren
-Formicivora grisea_White-fringed Antwren
-Formicivora iheringi_Narrow-billed Antwren
-Formicivora melanogaster_Black-bellied Antwren
-Formicivora rufa_Rusty-backed Antwren
-Formicivora serrana_Serra Antwren
-Forpus coelestis_Pacific Parrotlet
-Forpus conspicillatus_Spectacled Parrotlet
-Forpus cyanopygius_Mexican Parrotlet
-Forpus modestus_Dusky-billed Parrotlet
-Forpus passerinus_Green-rumped Parrotlet
-Forpus xanthopterygius_Cobalt-rumped Parrotlet
-Foudia madagascariensis_Red Fody
-Foudia rubra_Mauritius Fody
-Foulehaio carunculatus_Eastern Wattled-Honeyeater
-Foulehaio procerior_Western Wattled-Honeyeater
-Francolinus francolinus_Black Francolin
-Francolinus pictus_Painted Francolin
-Francolinus pintadeanus_Chinese Francolin
-Fraseria caerulescens_Ashy Flycatcher
-Fraseria griseigularis_Gray-throated Tit-Flycatcher
-Fraseria ocreata_African Forest-Flycatcher
-Fraseria plumbea_Gray Tit-Flycatcher
-Fratercula arctica_Atlantic Puffin
-Frederickena fulva_Fulvous Antshrike
-Frederickena unduliger_Undulated Antshrike
-Frederickena viridis_Black-throated Antshrike
-Fregata andrewsi_聖誕島軍艦鳥
-Fregata ariel_白斑軍艦鳥
-Fregata magnificens_Magnificent Frigatebird
-Fregata minor_軍艦鳥
-Fringilla coelebs_Common Chaffinch
-Fringilla montifringilla_花雀
-Fulica alai_Hawaiian Coot
-Fulica americana_American Coot
-Fulica ardesiaca_Slate-colored Coot
-Fulica armillata_Red-gartered Coot
-Fulica atra_白冠雞
-Fulica cristata_Red-knobbed Coot
-Fulica gigantea_Giant Coot
-Fulica rufifrons_Red-fronted Coot
-Fulmarus glacialis_暴風鸌
-Fulvetta formosana_褐頭花翼
-Fulvetta ruficapilla_Spectacled Fulvetta
-Fulvetta vinipectus_White-browed Fulvetta
-Furnarius cristatus_Crested Hornero
-Furnarius figulus_Wing-banded Hornero
-Furnarius leucopus_Pale-legged Hornero
-Furnarius minor_Lesser Hornero
-Furnarius rufus_Rufous Hornero
-Galbalcyrhynchus leucotis_White-eared Jacamar
-Galbalcyrhynchus purusianus_Purus Jacamar
-Galbula albirostris_Yellow-billed Jacamar
-Galbula chalcothorax_Purplish Jacamar
-Galbula cyanescens_Bluish-fronted Jacamar
-Galbula cyanicollis_Blue-cheeked Jacamar
-Galbula dea_Paradise Jacamar
-Galbula galbula_Green-tailed Jacamar
-Galbula leucogastra_Bronzy Jacamar
-Galbula pastazae_Coppery-chested Jacamar
-Galbula ruficauda_Rufous-tailed Jacamar
-Galbula tombacea_White-chinned Jacamar
-Galerida cristata_Crested/Maghreb Lark
-Galerida deva_Tawny Lark
-Galerida magnirostris_Large-billed Lark
-Galerida malabarica_Malabar Lark
-Galerida theklae_Thekla's Lark
-Gallicrex cinerea_董雞
-Gallinago andina_Puna Snipe
-Gallinago delicata_Wilson's Snipe
-Gallinago gallinago_田鷸
-Gallinago hardwickii_大地鷸
-Gallinago imperialis_Imperial Snipe
-Gallinago jamesoni_Jameson's Snipe
-Gallinago magellanica_Magellanic Snipe
-Gallinago media_Great Snipe
-Gallinago megala_中地鷸
-Gallinago nobilis_Noble Snipe
-Gallinago paraguaiae_Paraguayan Snipe
-Gallinago stenura_針尾鷸
-Gallinago undulata_Giant Snipe
-Gallinula chloropus_紅冠水雞
-Gallinula galeata_Common Gallinule
-Gallinula tenebrosa_Dusky Moorhen
-Gallirallus australis_Weka
-Gallirallus philippensis_Buff-banded Rail
-Gallirallus torquatus_Barred Rail
-Galloperdix bicalcarata_Sri Lanka Spurfowl
-Galloperdix spadicea_Red Spurfowl
-Gallus gallus_Red Junglefowl
-Gallus lafayettii_Sri Lanka Junglefowl
-Gallus sonneratii_Gray Junglefowl
-Gallus varius_Green Junglefowl
-Gampsonyx swainsonii_Pearl Kite
-Gampsorhynchus rufulus_White-hooded Babbler
-Gampsorhynchus torquatus_Collared Babbler
-Garrulax canorus_大陸畫眉
-Garrulax leucolophus_White-crested Laughingthrush
-Garrulax milleti_Black-hooded Laughingthrush
-Garrulax monileger_Lesser Necklaced Laughingthrush
-Garrulax palliatus_Sunda Laughingthrush
-Garrulax strepitans_White-necked Laughingthrush
-Garrulax taewanus_台灣畫眉
-Garrulus glandarius_松鴉
-Garrulus lanceolatus_Black-headed Jay
-Garrulus lidthi_Lidth's Jay
+Florisuga fusca_黑蜂鸟
+Florisuga mellivora_白颈蜂鸟
+Fluvicola albiventer_黑背水霸鹟
+Fluvicola nengeta_花脸水霸鹟
+Fluvicola pica_斑水霸鹟
+Formicarius analis_黑脸蚁鸫
+Formicarius colma_棕顶蚁鸫
+Formicarius moniliger_玛雅蚁鸫
+Formicarius nigricapillus_黑头蚁鸫
+Formicarius rufifrons_棕额蚁鸫
+Formicarius rufipectus_棕胸蚁鸫
+Formicivora acutirostris_巴拉那蚁鹩
+Formicivora erythronotos_黑巾蚁鹩
+Formicivora grantsaui_格氏蚁鹩
+Formicivora grisea_南白胁蚁鹩
+Formicivora iheringi_狭嘴蚁鹩
+Formicivora melanogaster_黑腹蚁鹩
+Formicivora rufa_锈背蚁鹩
+Formicivora serrana_赛亚蚁鹩
+Forpus coelestis_太平洋鹦哥
+Forpus conspicillatus_蓝眶鹦哥
+Forpus cyanopygius_蓝腰鹦哥
+Forpus modestus_乌嘴鹦哥
+Forpus passerinus_绿腰鹦哥
+Forpus xanthopterygius_蓝翅鹦哥
+Foudia madagascariensis_红织雀
+Foudia rubra_毛里求斯织雀
+Foulehaio carunculatus_肉垂吸蜜鸟
+Foulehaio procerior_西肉垂吸蜜鸟
+Francolinus francolinus_黑鹧鸪
+Francolinus pictus_花彩鹧鸪
+Francolinus pintadeanus_中华鹧鸪
+Fraseria caerulescens_灰鹟
+Fraseria griseigularis_灰喉雀鹟
+Fraseria ocreata_非洲森鹟
+Fraseria plumbea_灰雀鹟
+Fratercula arctica_北极海鹦
+Frederickena fulva_茶色蚁鵙
+Frederickena unduliger_波纹蚁鵙
+Frederickena viridis_黑喉蚁鵙
+Fregata andrewsi_白腹军舰鸟
+Fregata ariel_白斑军舰鸟
+Fregata magnificens_华丽军舰鸟
+Fregata minor_黑腹军舰鸟
+Fringilla coelebs_苍头燕雀
+Fringilla montifringilla_燕雀
+Fulica alai_夏威夷骨顶
+Fulica americana_美洲骨顶
+Fulica ardesiaca_安第斯骨顶
+Fulica armillata_黄腿骨顶
+Fulica atra_白骨顶
+Fulica cristata_红瘤白骨顶
+Fulica gigantea_大骨顶
+Fulica rufifrons_红额骨顶
+Fulmarus glacialis_暴雪鹱
+Fulvetta formosana_玉山雀鹛
+Fulvetta ruficapilla_棕头雀鹛
+Fulvetta vinipectus_白眉雀鹛
+Furnarius cristatus_冠灶鸟
+Furnarius figulus_白斑灶鸟
+Furnarius leucopus_淡腿灶鸟
+Furnarius minor_小灶鸟
+Furnarius rufus_棕灶鸟
+Galbalcyrhynchus leucotis_白耳鹟䴕
+Galbalcyrhynchus purusianus_栗鹟䴕
+Galbula albirostris_黄嘴鹟䴕
+Galbula chalcothorax_紫鹟䴕
+Galbula cyanescens_蓝额鹟䴕
+Galbula cyanicollis_蓝颈鹟䴕
+Galbula dea_黑腹鹟䴕
+Galbula galbula_绿尾鹟䴕
+Galbula leucogastra_铜色鹟䴕
+Galbula pastazae_铜胸鹟䴕
+Galbula ruficauda_棕尾鹟䴕
+Galbula tombacea_白颏鹟䴕
+Galerida cristata_凤头百灵
+Galerida deva_塞氏凤头百灵
+Galerida magnirostris_长嘴凤头百灵
+Galerida malabarica_马拉巴凤头百灵
+Galerida theklae_短嘴凤头百灵
+Gallicrex cinerea_董鸡
+Gallinago andina_山沙锥
+Gallinago delicata_美洲沙锥
+Gallinago gallinago_扇尾沙锥
+Gallinago hardwickii_拉氏沙锥
+Gallinago imperialis_暗褐沙锥
+Gallinago jamesoni_安第斯沙锥
+Gallinago magellanica_麦哲伦沙锥
+Gallinago media_斑腹沙锥
+Gallinago megala_大沙锥
+Gallinago nobilis_长嘴沙锥
+Gallinago paraguaiae_南美沙锥
+Gallinago stenura_针尾沙锥
+Gallinago undulata_巨沙锥
+Gallinula chloropus_黑水鸡
+Gallinula galeata_美洲黑水鸡
+Gallinula tenebrosa_暗色水鸡
+Gallirallus australis_新西兰秧鸡
+Gallirallus philippensis_红眼斑秧鸡
+Gallirallus torquatus_横斑秧鸡
+Galloperdix bicalcarata_斯里兰卡鸡鹑
+Galloperdix spadicea_赤鸡鹑
+Gallus gallus_红原鸡
+Gallus lafayettii_蓝喉原鸡
+Gallus sonneratii_灰原鸡
+Gallus varius_绿原鸡
+Gampsonyx swainsonii_小鸢
+Gampsorhynchus rufulus_白头鵙鹛
+Gampsorhynchus torquatus_领鵙鹛
+Garrulax canorus_画眉
+Garrulax leucolophus_白冠噪鹛
+Garrulax milleti_黑冠噪鹛
+Garrulax monileger_小黑领噪鹛
+Garrulax palliatus_灰褐噪鹛
+Garrulax strepitans_白颈噪鹛
+Garrulax taewanus_台湾画眉
+Garrulus glandarius_松鸦
+Garrulus lanceolatus_黑头松鸦
+Garrulus lidthi_琉球松鸦
 Gastrophryne carolinensis_Eastern Narrow-mouthed Toad
 Gastrophryne olivacea_Great Plains Narrow-mouthed Toad
-Gavia adamsii_白嘴潛鳥
-Gavia arctica_黑喉潛鳥
-Gavia immer_Common Loon
-Gavia pacifica_太平洋潛鳥
-Gavia stellata_紅喉潛鳥
-Gavicalis fasciogularis_Mangrove Honeyeater
-Gavicalis virescens_Singing Honeyeater
-Gecinulus grantia_Pale-headed Woodpecker
-Gecinulus viridis_Bamboo Woodpecker
-Gelochelidon nilotica_鷗嘴燕鷗
-Geocerthia serrana_Striated Earthcreeper
-Geococcyx californianus_Greater Roadrunner
-Geococcyx velox_Lesser Roadrunner
-Geoffroyus geoffroyi_Red-cheeked Parrot
-Geoffroyus heteroclitus_Singing Parrot
-Geokichla citrina_橙頭地鶇
-Geokichla gurneyi_Orange Ground-Thrush
-Geokichla guttata_Spotted Ground-Thrush
-Geokichla peronii_Orange-banded Thrush
-Geokichla piaggiae_Abyssinian Ground-Thrush
-Geokichla sibirica_白眉地鶇
-Geokichla spiloptera_Spot-winged Thrush
-Geopelia humeralis_Bar-shouldered Dove
-Geopelia placida_Peaceful Dove
-Geopelia striata_斑馬鳩
-Geositta antarctica_Short-billed Miner
-Geositta cunicularia_Common Miner
-Geositta punensis_Puna Miner
-Geositta rufipennis_Rufous-banded Miner
-Geositta tenuirostris_Slender-billed Miner
-Geospizopsis plebejus_Ash-breasted Sierra Finch
-Geospizopsis unicolor_Plumbeous Sierra Finch
-Geothlypis aequinoctialis_Masked Yellowthroat (Masked)
-Geothlypis beldingi_Belding's Yellowthroat
-Geothlypis formosa_Kentucky Warbler
-Geothlypis nelsoni_Hooded Yellowthroat
-Geothlypis philadelphia_Mourning Warbler
-Geothlypis poliocephala_Gray-crowned Yellowthroat
-Geothlypis rostrata_Bahama Yellowthroat
-Geothlypis semiflava_Olive-crowned Yellowthroat
-Geothlypis speciosa_Black-polled Yellowthroat
-Geothlypis tolmiei_MacGillivray's Warbler
-Geothlypis trichas_Common Yellowthroat
-Geotrygon chrysia_Key West Quail-Dove
-Geotrygon montana_Ruddy Quail-Dove
-Geotrygon violacea_Violaceous Quail-Dove
-Geranoaetus albicaudatus_White-tailed Hawk
-Geranoaetus melanoleucus_Black-chested Buzzard-Eagle
-Geranoaetus polyosoma_Variable Hawk
-Geranospiza caerulescens_Crane Hawk
-Geronticus eremita_Northern Bald Ibis
-Gerygone chloronota_Green-backed Gerygone
-Gerygone flavolateralis_Fan-tailed Gerygone
-Gerygone fusca_Western Gerygone
-Gerygone igata_Gray Gerygone
-Gerygone levigaster_Mangrove Gerygone
-Gerygone magnirostris_Large-billed Gerygone
-Gerygone mouki_Brown Gerygone
-Gerygone olivacea_White-throated Gerygone
-Gerygone palpebrosa_Fairy Gerygone
-Gerygone sulphurea_Golden-bellied Gerygone
-Glareola lactea_Small Pratincole
-Glareola maldivarum_燕鴴
-Glareola pratincola_Collared Pratincole
-Glaucestrilda caerulescens_Lavender Waxbill
-Glaucidium bolivianum_Yungas Pygmy-Owl
-Glaucidium brasilianum_Ferruginous Pygmy-Owl
-Glaucidium capense_African Barred Owlet
-Glaucidium castanopterum_Javan Owlet
-Glaucidium castanotum_Chestnut-backed Owlet
-Glaucidium costaricanum_Costa Rican Pygmy-Owl
-Glaucidium cuculoides_Asian Barred Owlet
-Glaucidium gnoma_Northern Pygmy-Owl
-Glaucidium griseiceps_Central American Pygmy-Owl
-Glaucidium hardyi_Amazonian Pygmy-Owl
-Glaucidium jardinii_Andean Pygmy-Owl
-Glaucidium minutissimum_Least Pygmy-Owl
-Glaucidium nana_Austral Pygmy-Owl
-Glaucidium nubicola_Cloud-forest Pygmy-Owl
-Glaucidium palmarum_Colima Pygmy-Owl
-Glaucidium parkeri_Subtropical Pygmy-Owl
-Glaucidium passerinum_Eurasian Pygmy-Owl
-Glaucidium perlatum_Pearl-spotted Owlet
-Glaucidium peruanum_Peruvian Pygmy-Owl
-Glaucidium radiatum_Jungle Owlet
-Glaucidium sanchezi_Tamaulipas Pygmy-Owl
-Glaucidium siju_Cuban Pygmy-Owl
-Glaucidium tephronotum_Red-chested Owlet
-Glaucis dohrnii_Hook-billed Hermit
-Glaucis hirsutus_Rufous-breasted Hermit
-Gliciphila melanops_Tawny-crowned Honeyeater
-Glossopsitta concinna_Musk Lorikeet
-Glyphorynchus spirurus_Wedge-billed Woodcreeper
-Gnorimopsar chopi_Chopi Blackbird
-Gorsachius melanolophus_黑冠麻鷺
-Gracula indica_Southern Hill Myna
-Gracula ptilogenys_Sri Lanka Myna
-Gracula religiosa_九官鳥
-Gracupica contra_印度鵲椋鳥
-Gracupica nigricollis_黑領椋鳥
-Grallaria albigula_White-throated Antpitta
-Grallaria alleni_Moustached Antpitta
-Grallaria andicolus_Stripe-headed Antpitta
-Grallaria bangsi_Santa Marta Antpitta
-Grallaria blakei_Chestnut Antpitta
-Grallaria cajamarcae_Cajamarca Antpitta
-Grallaria capitalis_Bay Antpitta
-Grallaria carrikeri_Pale-billed Antpitta
-Grallaria dignissima_Ochre-striped Antpitta
-Grallaria erythroleuca_Red-and-white Antpitta
-Grallaria erythrotis_Rufous-faced Antpitta
-Grallaria flavotincta_Yellow-breasted Antpitta
-Grallaria gigantea_Giant Antpitta
-Grallaria gravesi_Chachapoyas Antpitta
-Grallaria griseonucha_Gray-naped Antpitta
-Grallaria guatimalensis_Scaled Antpitta
-Grallaria haplonota_Plain-backed Antpitta
-Grallaria hypoleuca_White-bellied Antpitta
-Grallaria kaestneri_Cundinamarca Antpitta
-Grallaria milleri_Brown-banded Antpitta
-Grallaria nuchalis_Chestnut-naped Antpitta
-Grallaria occabambae_Urubamba Antpitta
-Grallaria przewalskii_Rusty-tinged Antpitta
-Grallaria quitensis_Tawny Antpitta
-Grallaria ridgelyi_Jocotoco Antpitta
-Grallaria ruficapilla_Chestnut-crowned Antpitta
-Grallaria rufocinerea_Bicolored Antpitta
-Grallaria rufula_Muisca Antpitta
-Grallaria saturata_Equatorial Antpitta
-Grallaria squamigera_Undulated Antpitta
-Grallaria urraoensis_Urrao Antpitta
-Grallaria varia_Variegated Antpitta
-Grallaria watkinsi_Watkins's Antpitta
-Grallaricula cucullata_Hooded Antpitta
-Grallaricula ferrugineipectus_Rusty-breasted Antpitta
-Grallaricula flavirostris_Ochre-breasted Antpitta
-Grallaricula leymebambae_Leymebamba Antpitta
-Grallaricula lineifrons_Crescent-faced Antpitta
-Grallaricula nana_Slate-crowned Antpitta
-Grallaricula ochraceifrons_Ochre-fronted Antpitta
-Grallaricula peruviana_Peruvian Antpitta
-Grallina cyanoleuca_Magpie-lark
-Grammatoptila striata_Striated Laughingthrush
-Granatellus pelzelni_Rose-breasted Chat
-Granatellus sallaei_Gray-throated Chat
-Granatellus venustus_Red-breasted Chat
-Granatina ianthinogaster_Purple Grenadier
-Grantiella picta_Painted Honeyeater
-Graydidascalus brachyurus_Short-tailed Parrot
-Grus americana_Whooping Crane
-Grus grus_灰鶴
-Grus japonensis_丹頂鶴
-Grus monacha_白頭鶴
-Grus nigricollis_Black-necked Crane
+Gavia adamsii_黄嘴潜鸟
+Gavia arctica_黑喉潜鸟
+Gavia immer_普通潜鸟
+Gavia pacifica_太平洋潜鸟
+Gavia stellata_红喉潜鸟
+Gavicalis fasciogularis_饰颈吸蜜鸟
+Gavicalis virescens_歌吸蜜鸟
+Gecinulus grantia_竹啄木鸟
+Gecinulus viridis_苍头竹啄木鸟
+Gelochelidon nilotica_鸥嘴噪鸥
+Geocerthia serrana_条纹爬地雀
+Geococcyx californianus_走鹃
+Geococcyx velox_小走鹃
+Geoffroyus geoffroyi_红脸鹦鹉
+Geoffroyus heteroclitus_歌鹦鹉
+Geokichla citrina_橙头地鸫
+Geokichla gurneyi_橙色地鸫
+Geokichla guttata_斑地鸫
+Geokichla peronii_橙斑地鸫
+Geokichla piaggiae_阿比西尼亚地鸫
+Geokichla sibirica_白眉地鸫
+Geokichla spiloptera_斑翅地鸫
+Geopelia humeralis_斑肩姬地鸠
+Geopelia placida_戈氏姬地鸠
+Geopelia striata_斑姬地鸠
+Geositta antarctica_短嘴掘穴雀
+Geositta cunicularia_掘穴雀
+Geositta punensis_高山掘穴雀
+Geositta rufipennis_棕斑掘穴雀
+Geositta tenuirostris_细嘴掘穴雀
+Geospizopsis plebejus_灰胸岭雀鹀
+Geospizopsis unicolor_铅色岭雀鹀
+Geothlypis aequinoctialis_黑颊黄喉地莺
+Geothlypis beldingi_贝氏黄喉地莺
+Geothlypis formosa_黄腹地莺
+Geothlypis nelsoni_纳氏黄喉地莺
+Geothlypis philadelphia_黑胸地莺
+Geothlypis poliocephala_灰冠黄喉地莺
+Geothlypis rostrata_巴哈马黄喉地莺
+Geothlypis semiflava_绿冠黄喉地莺
+Geothlypis speciosa_黑顶黄喉地莺
+Geothlypis tolmiei_灰头地莺
+Geothlypis trichas_黄喉地莺
+Geotrygon chrysia_绿顶鹑鸠
+Geotrygon montana_红鹑鸠
+Geotrygon violacea_紫鹑鸠
+Geranoaetus albicaudatus_白尾鵟
+Geranoaetus melanoleucus_鵟雕
+Geranoaetus polyosoma_红背鵟
+Geranospiza caerulescens_鹤鹰
+Geronticus eremita_隐鹮
+Gerygone chloronota_灰头噪刺莺
+Gerygone flavolateralis_扇尾噪刺莺
+Gerygone fusca_西噪刺莺
+Gerygone igata_灰噪刺莺
+Gerygone levigaster_棕胸噪刺莺
+Gerygone magnirostris_沼泽噪刺莺
+Gerygone mouki_褐噪刺莺
+Gerygone olivacea_白喉噪刺莺
+Gerygone palpebrosa_黑头噪刺莺
+Gerygone sulphurea_黄胸噪刺莺
+Glareola lactea_灰燕鸻
+Glareola maldivarum_普通燕鸻
+Glareola pratincola_领燕鸻
+Glaucestrilda caerulescens_淡蓝梅花雀
+Glaucidium bolivianum_玻利维亚鸺鹠
+Glaucidium brasilianum_棕鸺鹠
+Glaucidium capense_斑鸺鹠
+Glaucidium castanopterum_栗翅鸺鹠
+Glaucidium castanotum_栗背鸺鹠
+Glaucidium costaricanum_哥斯达黎加鸺鹠
+Glaucidium cuculoides_斑头鸺鹠
+Glaucidium gnoma_山鸺鹠
+Glaucidium griseiceps_中美鸺鹠
+Glaucidium hardyi_亚马逊鸺鹠
+Glaucidium jardinii_安第斯鸺鹠
+Glaucidium minutissimum_巴西鸺鹠
+Glaucidium nana_南鸺鹠
+Glaucidium nubicola_厄瓜多尔鸺鹠
+Glaucidium palmarum_科利马鸺鹠
+Glaucidium parkeri_派克鸺鹠
+Glaucidium passerinum_花头鸺鹠
+Glaucidium perlatum_珠斑鸺鹠
+Glaucidium peruanum_秘鲁鸺鹠
+Glaucidium radiatum_丛林鸺鹠
+Glaucidium sanchezi_塔州鸺鹠
+Glaucidium siju_古巴鸺鹠
+Glaucidium tephronotum_红胸鸺鹠
+Glaucis dohrnii_钩嘴铜色蜂鸟
+Glaucis hirsutus_棕胸铜色蜂鸟
+Gliciphila melanops_茶冠澳蜜鸟
+Glossopsitta concinna_红耳绿鹦鹉
+Glyphorynchus spirurus_楔嘴䴕雀
+Gnorimopsar chopi_巴西拟鹂
+Gorsachius melanolophus_黑冠鳽
+Gracula indica_南鹩哥
+Gracula ptilogenys_斯里兰卡鹩哥
+Gracula religiosa_鹩哥
+Gracupica contra_斑椋鸟
+Gracupica nigricollis_黑领椋鸟
+Grallaria albigula_白喉蚁鸫
+Grallaria alleni_须蚁鸫
+Grallaria andicolus_纹头蚁鸫
+Grallaria bangsi_圣马塔蚁鸫
+Grallaria blakei_栗蚁鸫
+Grallaria cajamarcae_卡哈蚁鸫
+Grallaria capitalis_枣红蚁鸫
+Grallaria carrikeri_灰嘴蚁鸫
+Grallaria dignissima_赭纹蚁鸫
+Grallaria erythroleuca_红白蚁鸫
+Grallaria erythrotis_棕脸蚁鸫
+Grallaria flavotincta_黄胸蚁鸫
+Grallaria gigantea_巨蚁鸫
+Grallaria gravesi_查查波亚蚁鸫
+Grallaria griseonucha_灰颈蚁鸫
+Grallaria guatimalensis_鳞斑蚁鸫
+Grallaria haplonota_纯背蚁鸫
+Grallaria hypoleuca_褐背蚁鸫
+Grallaria kaestneri_昆迪蚁鸫
+Grallaria milleri_褐斑蚁鸫
+Grallaria nuchalis_栗枕蚁鸫
+Grallaria occabambae_乌省蚁鸫
+Grallaria przewalskii_普氏蚁鸫
+Grallaria quitensis_褐蚁鸫
+Grallaria ridgelyi_若克蚁鸫
+Grallaria ruficapilla_栗顶蚁鸫
+Grallaria rufocinerea_双色蚁鸫
+Grallaria rufula_棕蚁鸫
+Grallaria saturata_赤道蚁鸫
+Grallaria squamigera_波纹蚁鸫
+Grallaria urraoensis_灰腹蚁鸫
+Grallaria varia_杂色蚁鸫
+Grallaria watkinsi_沃氏蚁鸫
+Grallaricula cucullata_巾冠蚁鸫
+Grallaricula ferrugineipectus_锈胸蚁鸫
+Grallaricula flavirostris_赭胸蚁鸫
+Grallaricula leymebambae_红褐胸蚁鸫
+Grallaricula lineifrons_月脸蚁鸫
+Grallaricula nana_蓝顶蚁鸫
+Grallaricula ochraceifrons_赭额蚁鸫
+Grallaricula peruviana_秘鲁蚁鸫
+Grallina cyanoleuca_鹊鹩
+Grammatoptila striata_条纹噪鹛
+Granatellus pelzelni_玫胸䳭莺
+Granatellus sallaei_灰喉䳭莺
+Granatellus venustus_红胸䳭莺
+Granatina ianthinogaster_紫蓝饰雀
+Grantiella picta_彩蚊蜜鸟
+Graydidascalus brachyurus_短尾鹦哥
+Grus americana_美洲鹤
+Grus grus_灰鹤
+Grus japonensis_丹顶鹤
+Grus monacha_白头鹤
+Grus nigricollis_黑颈鹤
 Gryllus assimilis_Gryllus assimilis
 Gryllus fultoni_Southern Wood Cricket
 Gryllus pennsylvanicus_Fall Field Cricket
 Gryllus rubens_Southeastern Field Cricket
-Guaruba guarouba_Golden Parakeet
-Gubernatrix cristata_Yellow Cardinal
-Gubernetes yetapa_Streamer-tailed Tyrant
-Guira guira_Guira Cuckoo
+Guaruba guarouba_金鹦哥
+Gubernatrix cristata_黑冠黄雀鹀
+Gubernetes yetapa_飘带尾霸鹟
+Guira guira_圭拉鹃
 Gun_Gun
-Guttera pucherani_Crested Guineafowl (Kenya)
-Gygis alba_白燕鷗
-Gymnasio nudipes_Puerto Rican Owl
-Gymnobucco bonapartei_Gray-throated Barbet
-Gymnobucco calvus_Naked-faced Barbet
-Gymnocichla nudiceps_Bare-crowned Antbird
-Gymnomystax mexicanus_Oriole Blackbird
-Gymnomyza brunneirostris_Duetting Giant-Honeyeater
-Gymnomyza samoensis_Mao
-Gymnopithys bicolor_Bicolored Antbird
-Gymnopithys leucaspis_White-cheeked Antbird
-Gymnopithys rufigula_Rufous-throated Antbird
-Gymnorhina tibicen_Australian Magpie
-Gymnorhinus cyanocephalus_Pinyon Jay
-Gymnoris dentata_Sahel Bush Sparrow
-Gymnoris pyrgita_Yellow-spotted Bush Sparrow
-Gymnoris superciliaris_Yellow-throated Bush Sparrow
-Gymnoris xanthocollis_Yellow-throated Sparrow
-Gyps fulvus_Eurasian Griffon
-Gyps himalayensis_Himalayan Griffon
-Gypsophila brevicaudata_Streaked Wren-Babbler
-Gypsophila rufipectus_Rusty-breasted Wren-Babbler
+Guttera pucherani_冠珠鸡
+Gygis alba_白燕鸥
+Gymnasio nudipes_珠眉角鸮
+Gymnobucco bonapartei_灰喉拟啄木鸟
+Gymnobucco calvus_裸颊拟啄木鸟
+Gymnocichla nudiceps_裸顶蚁鸟
+Gymnomystax mexicanus_黄头拟鹂
+Gymnomyza brunneirostris_褐嘴裸吸蜜鸟
+Gymnomyza samoensis_黑胸裸吸蜜鸟
+Gymnopithys bicolor_双色蚁鸟
+Gymnopithys leucaspis_白颊蚁鸟
+Gymnopithys rufigula_棕喉蚁鸟
+Gymnorhina tibicen_澳洲钟鹊
+Gymnorhinus cyanocephalus_蓝头鸦
+Gymnoris dentata_小石雀
+Gymnoris pyrgita_黄斑石雀
+Gymnoris superciliaris_黄喉石雀
+Gymnoris xanthocollis_栗肩石雀
+Gyps fulvus_兀鹫
+Gyps himalayensis_高山兀鹫
+Gypsophila brevicaudata_短尾鹪鹛
+Gypsophila rufipectus_苏门答腊鹪鹛
 Habia atrimaxillaris_Black-cheeked Ant-Tanager
 Habia cristata_Crested Ant-Tanager
 Habia fuscicauda_Red-throated Ant-Tanager
 Habia gutturalis_Sooty Ant-Tanager
-Habia rubica_Red-crowned Ant-Tanager
-Haematopus ater_Blackish Oystercatcher
-Haematopus bachmani_Black Oystercatcher
-Haematopus finschi_South Island Oystercatcher
-Haematopus fuliginosus_Sooty Oystercatcher
-Haematopus leucopodus_Magellanic Oystercatcher
-Haematopus longirostris_Pied Oystercatcher
-Haematopus ostralegus_蠣鴴
-Haematopus palliatus_American Oystercatcher
-Haematopus unicolor_Variable Oystercatcher
-Haematortyx sanguiniceps_Crimson-headed Partridge
-Haemorhous cassinii_Cassin's Finch
-Haemorhous mexicanus_House Finch
-Haemorhous purpureus_Purple Finch
-Hafferia fortis_Sooty Antbird
-Hafferia immaculata_Blue-lored Antbird
-Hafferia zeledoni_Zeledon's Antbird
-Halcyon albiventris_Brown-hooded Kingfisher
-Halcyon badia_Chocolate-backed Kingfisher
-Halcyon chelicuti_Striped Kingfisher
+Habia rubica_红头蚁唐纳雀
+Haematopus ater_南美黑蛎鹬
+Haematopus bachmani_北美黑蛎鹬
+Haematopus finschi_南岛斑蛎鹬
+Haematopus fuliginosus_澳洲黑蛎鹬
+Haematopus leucopodus_智利蛎鹬
+Haematopus longirostris_澳洲斑蛎鹬
+Haematopus ostralegus_蛎鹬
+Haematopus palliatus_美洲斑蛎鹬
+Haematopus unicolor_新西兰蛎鹬
+Haematortyx sanguiniceps_红头林鹧鸪
+Haemorhous cassinii_卡氏朱雀
+Haemorhous mexicanus_家朱雀
+Haemorhous purpureus_紫朱雀
+Hafferia fortis_乌蚁鸟
+Hafferia immaculata_纯色蚁鸟
+Hafferia zeledoni_泽氏蚁鸟
+Halcyon albiventris_褐头翡翠
+Halcyon badia_栗背翡翠
+Halcyon chelicuti_斑翡翠
 Halcyon coromanda_赤翡翠
-Halcyon gularis_Brown-breasted Kingfisher
-Halcyon leucocephala_Gray-headed Kingfisher
-Halcyon malimbica_Blue-breasted Kingfisher
-Halcyon pileata_黑頭翡翠
-Halcyon senegalensis_Woodland Kingfisher
-Halcyon smyrnensis_蒼翡翠
-Haliaeetus albicilla_白尾海鵰
+Halcyon gularis_褐胸翡翠
+Halcyon leucocephala_灰头翡翠
+Halcyon malimbica_蓝胸翡翠
+Halcyon pileata_蓝翡翠
+Halcyon senegalensis_非洲林翡翠
+Halcyon smyrnensis_白胸翡翠
+Haliaeetus albicilla_白尾海雕
 Haliaeetus humilis_Lesser Fish-Eagle
 Haliaeetus ichthyaetus_Gray-headed Fish-Eagle
-Haliaeetus leucocephalus_Bald Eagle
-Haliaeetus leucogaster_白腹海鵰
-Haliaeetus pelagicus_虎頭海鵰
+Haliaeetus leucocephalus_白头海雕
+Haliaeetus leucogaster_White-bellied Sea-Eagle
+Haliaeetus pelagicus_虎头海雕
 Haliaeetus vocifer_African Fish-Eagle
-Haliastur indus_栗鳶
-Haliastur sphenurus_Whistling Kite
-Hapalocrex flaviventer_Yellow-breasted Crake
-Hapalopsittaca amazonina_Rusty-faced Parrot
-Hapalopsittaca fuertesi_Indigo-winged Parrot
-Hapaloptila castanea_White-faced Nunbird
-Haplophaedia aureliae_Greenish Puffleg
-Haplospiza unicolor_Uniform Finch
-Harpactes ardens_Philippine Trogon
-Harpactes diardii_Diard's Trogon
-Harpactes duvaucelii_Scarlet-rumped Trogon
-Harpactes erythrocephalus_Red-headed Trogon
-Harpactes fasciatus_Malabar Trogon
-Harpactes kasumba_Red-naped Trogon
-Harpactes oreskios_Orange-breasted Trogon
-Harpactes orrhophaeus_Cinnamon-rumped Trogon
-Harpactes wardi_Ward's Trogon
-Harpagus bidentatus_Double-toothed Kite
-Harpagus diodon_Rufous-thighed Kite
-Harpia harpyja_Harpy Eagle
-Harpyopsis novaeguineae_New Guinea Eagle
-Hedydipna collaris_Collared Sunbird
-Hedydipna metallica_Nile Valley Sunbird
-Hedydipna platura_Pygmy Sunbird
-Heliangelus amethysticollis_Amethyst-throated Sunangel (Amethyst-throated)
-Heliangelus exortis_Tourmaline Sunangel
-Heliangelus viola_Purple-throated Sunangel
-Helicolestes hamatus_Slender-billed Kite
-Heliobletus contaminatus_Sharp-billed Treehunter
-Heliodoxa jacula_Green-crowned Brilliant
-Heliodoxa leadbeateri_Violet-fronted Brilliant
-Heliodoxa rubinoides_Fawn-breasted Brilliant
-Heliomaster constantii_Plain-capped Starthroat
-Heliomaster longirostris_Long-billed Starthroat
-Heliornis fulica_Sungrebe
-Heliothryx auritus_Black-eared Fairy
-Hellmayrea gularis_White-browed Spinetail
-Helmitheros vermivorum_Worm-eating Warbler
-Helopsaltes certhiola_小蝗鶯
-Helopsaltes ochotensis_北蝗鶯
-Helopsaltes pryeri_Marsh Grassbird
-Hemicircus canente_Heart-spotted Woodpecker
-Hemicircus concretus_Gray-and-buff Woodpecker
-Hemignathus wilsoni_Akiapolaau
-Hemiprocne comata_Whiskered Treeswift
-Hemiprocne coronata_Crested Treeswift
-Hemiprocne longipennis_Gray-rumped Treeswift
-Hemiprocne mystacea_Moustached Treeswift
-Hemipus hirundinaceus_Black-winged Flycatcher-shrike
-Hemipus picatus_Bar-winged Flycatcher-shrike
-Hemithraupis flavicollis_Yellow-backed Tanager
-Hemithraupis guira_Guira Tanager
-Hemithraupis ruficapilla_Rufous-headed Tanager
-Hemitriccus cinnamomeipectus_Cinnamon-breasted Tody-Tyrant
-Hemitriccus cohnhafti_Acre Tody-Tyrant
-Hemitriccus diops_Drab-breasted Pygmy-Tyrant
-Hemitriccus flammulatus_Flammulated Pygmy-Tyrant
-Hemitriccus furcatus_Fork-tailed Pygmy-Tyrant
-Hemitriccus granadensis_Black-throated Tody-Tyrant
-Hemitriccus griseipectus_White-bellied Tody-Tyrant
-Hemitriccus inornatus_Pelzeln's Tody-Tyrant
-Hemitriccus iohannis_Johannes's Tody-Tyrant
-Hemitriccus margaritaceiventer_Pearly-vented Tody-Tyrant
-Hemitriccus minimus_Zimmer's Tody-Tyrant
-Hemitriccus minor_Snethlage's Tody-Tyrant
-Hemitriccus nidipendulus_Hangnest Tody-Tyrant
-Hemitriccus obsoletus_Brown-breasted Pygmy-Tyrant
-Hemitriccus orbitatus_Eye-ringed Tody-Tyrant
-Hemitriccus rufigularis_Buff-throated Tody-Tyrant
-Hemitriccus spodiops_Yungas Tody-Tyrant
-Hemitriccus striaticollis_Stripe-necked Tody-Tyrant
-Hemitriccus zosterops_White-eyed Tody-Tyrant
-Hemixos castanonotus_栗背短腳鵯
-Hemixos cinereus_Cinereous Bulbul
-Hemixos flavala_Ashy Bulbul
-Henicorhina anachoreta_Hermit Wood-Wren
-Henicorhina leucophrys_Gray-breasted Wood-Wren
-Henicorhina leucoptera_Bar-winged Wood-Wren
-Henicorhina leucosticta_White-breasted Wood-Wren
-Henicorhina negreti_Munchique Wood-Wren
-Herpetotheres cachinnans_Laughing Falcon
-Herpsilochmus atricapillus_Black-capped Antwren
-Herpsilochmus axillaris_Yellow-breasted Antwren
-Herpsilochmus dorsimaculatus_Spot-backed Antwren
-Herpsilochmus dugandi_Dugand's Antwren
-Herpsilochmus frater_Rusty-winged Antwren
-Herpsilochmus gentryi_Ancient Antwren
-Herpsilochmus longirostris_Large-billed Antwren
-Herpsilochmus motacilloides_Creamy-bellied Antwren
-Herpsilochmus parkeri_Ash-throated Antwren
-Herpsilochmus pectoralis_Pectoral Antwren
-Herpsilochmus pileatus_Bahia Antwren
-Herpsilochmus roraimae_Roraiman Antwren
-Herpsilochmus rufimarginatus_Rufous-margined Antwren
-Herpsilochmus sellowi_Caatinga Antwren
-Herpsilochmus stictocephalus_Todd's Antwren
-Herpsilochmus sticturus_Spot-tailed Antwren
-Heterocercus aurantiivertex_Orange-crowned Manakin
-Heterocercus flavivertex_Yellow-crowned Manakin
-Heterocercus linteatus_Flame-crowned Manakin
-Heteromyias albispecularis_Ashy Robin
-Heteromyias cinereifrons_Gray-headed Robin
-Heterophasia auricularis_白耳畫眉
-Heterophasia capistrata_Rufous Sibia
-Heterophasia desgodinsi_Black-headed Sibia
-Heterophasia gracilis_Gray Sibia
-Heterophasia melanoleuca_Black-backed Sibia
-Heterophasia picaoides_Long-tailed Sibia
-Heterophasia pulchella_Beautiful Sibia
-Heterospingus xanthopygius_Scarlet-browed Tanager
-Hieraaetus pennatus_靴隼鵰
-Hierococcyx bocki_Dark Hawk-Cuckoo
-Hierococcyx fugax_Malaysian Hawk-Cuckoo
-Hierococcyx hyperythrus_北方鷹鵑
-Hierococcyx nisicolor_棕腹鷹鵑
-Hierococcyx pectoralis_Philippine Hawk-Cuckoo
-Hierococcyx sparverioides_鷹鵑
-Hierococcyx vagans_Moustached Hawk-Cuckoo
-Hierococcyx varius_Common Hawk-Cuckoo
-Himantopus himantopus_高蹺鴴
-Himantopus leucocephalus_Pied Stilt
-Himantopus mexicanus_Black-necked Stilt
-Himatione sanguinea_Apapane
-Hippolais icterina_Icterine Warbler
-Hippolais languida_Upcher's Warbler
-Hippolais olivetorum_Olive-tree Warbler
-Hippolais polyglotta_Melodious Warbler
-Hirundapus caudacutus_白喉針尾雨燕
-Hirundapus giganteus_Brown-backed Needletail
-Hirundinea ferruginea_Cliff Flycatcher
-Hirundo angolensis_Angola Swallow
-Hirundo neoxena_Welcome Swallow
+Haliastur indus_栗鸢
+Haliastur sphenurus_啸鸢
+Hapalocrex flaviventer_黄胸田鸡
+Hapalopsittaca amazonina_锈脸鹦哥
+Hapalopsittaca fuertesi_红肩鹦哥
+Hapaloptila castanea_白脸䴕
+Haplophaedia aureliae_淡绿蓬腿蜂鸟
+Haplospiza unicolor_纯灰雀鹀
+Harpactes ardens_粉胸咬鹃
+Harpactes diardii_紫顶咬鹃
+Harpactes duvaucelii_红腰咬鹃
+Harpactes erythrocephalus_红头咬鹃
+Harpactes fasciatus_黑头咬鹃
+Harpactes kasumba_红枕咬鹃
+Harpactes oreskios_橙胸咬鹃
+Harpactes orrhophaeus_橙腰咬鹃
+Harpactes wardi_红腹咬鹃
+Harpagus bidentatus_双齿鸢
+Harpagus diodon_棕腿齿鸢
+Harpia harpyja_角雕
+Harpyopsis novaeguineae_新几内亚角雕
+Hedydipna collaris_环颈直嘴太阳鸟
+Hedydipna metallica_尼罗直嘴太阳鸟
+Hedydipna platura_小直嘴太阳鸟
+Heliangelus amethysticollis_辉喉领蜂鸟
+Heliangelus exortis_暗绿领蜂鸟
+Heliangelus viola_紫喉领蜂鸟
+Helicolestes hamatus_黑臀食螺鸢
+Heliobletus contaminatus_尖嘴树猎雀
+Heliodoxa jacula_绿顶辉蜂鸟
+Heliodoxa leadbeateri_紫额辉蜂鸟
+Heliodoxa rubinoides_棕胸辉蜂鸟
+Heliomaster constantii_纯顶星喉蜂鸟
+Heliomaster longirostris_长嘴星喉蜂鸟
+Heliornis fulica_日䴘
+Heliothryx auritus_黑耳仙蜂鸟
+Hellmayrea gularis_白眉针尾雀
+Helmitheros vermivorum_食虫森莺
+Helopsaltes certhiola_小蝗莺
+Helopsaltes ochotensis_北蝗莺
+Helopsaltes pryeri_斑背大尾莺
+Hemicircus canente_黑冠啄木鸟
+Hemicircus concretus_灰黄啄木鸟
+Hemignathus wilsoni_镰嘴雀
+Hemiprocne comata_小须凤头雨燕
+Hemiprocne coronata_凤头雨燕
+Hemiprocne longipennis_灰腰凤头雨燕
+Hemiprocne mystacea_须凤头雨燕
+Hemipus hirundinaceus_黑翅鹟鵙
+Hemipus picatus_褐背鹟鵙
+Hemithraupis flavicollis_黄背裸鼻雀
+Hemithraupis guira_吉拉裸鼻雀
+Hemithraupis ruficapilla_红头裸鼻雀
+Hemitriccus cinnamomeipectus_棕胸哑霸鹟
+Hemitriccus cohnhafti_阿克雷哑霸鹟
+Hemitriccus diops_淡褐胸侏霸鹟
+Hemitriccus flammulatus_红侏霸鹟
+Hemitriccus furcatus_叉尾哑霸鹟
+Hemitriccus granadensis_黑喉哑霸鹟
+Hemitriccus griseipectus_白腹哑霸鹟
+Hemitriccus inornatus_佩氏哑霸鹟
+Hemitriccus iohannis_乔氏哑霸鹟
+Hemitriccus margaritaceiventer_斑臀哑霸鹟
+Hemitriccus minimus_奇氏哑霸鹟
+Hemitriccus minor_小哑霸鹟
+Hemitriccus nidipendulus_悬巢哑霸鹟
+Hemitriccus obsoletus_褐胸侏霸鹟
+Hemitriccus orbitatus_橄榄色哑霸鹟
+Hemitriccus rufigularis_黄喉哑霸鹟
+Hemitriccus spodiops_玻利维亚哑霸鹟
+Hemitriccus striaticollis_纹颈哑霸鹟
+Hemitriccus zosterops_白眼哑霸鹟
+Hemixos castanonotus_栗背短脚鹎
+Hemixos cinereus_灰黑短脚鹎
+Hemixos flavala_灰短脚鹎
+Henicorhina anachoreta_隐林鹩
+Henicorhina leucophrys_灰胸林鹩
+Henicorhina leucoptera_斑翅林鹩
+Henicorhina leucosticta_白胸林鹩
+Henicorhina negreti_斑腹林鹩
+Herpetotheres cachinnans_笑隼
+Herpsilochmus atricapillus_黑顶蚁鹩
+Herpsilochmus axillaris_黄胸蚁鹩
+Herpsilochmus dorsimaculatus_斑背蚁鹩
+Herpsilochmus dugandi_杜氏蚁鹩
+Herpsilochmus frater_北棕翅蚁鹩
+Herpsilochmus gentryi_原蚁鹩
+Herpsilochmus longirostris_大嘴蚁鹩
+Herpsilochmus motacilloides_白腹蚁鹩
+Herpsilochmus parkeri_灰喉蚁鹩
+Herpsilochmus pectoralis_饰胸蚁鹩
+Herpsilochmus pileatus_乌顶蚁鹩
+Herpsilochmus roraimae_罗来曼蚁鹩
+Herpsilochmus rufimarginatus_棕翅蚁鹩
+Herpsilochmus sellowi_卡廷加蚁鹩
+Herpsilochmus stictocephalus_托氏蚁鹩
+Herpsilochmus sticturus_点斑尾蚁鹩
+Heterocercus aurantiivertex_橙顶娇鹟
+Heterocercus flavivertex_黄顶娇鹟
+Heterocercus linteatus_赤顶娇鹟
+Heteromyias albispecularis_地丛鹟
+Heteromyias cinereifrons_灰头丛鹟
+Heterophasia auricularis_白耳奇鹛
+Heterophasia capistrata_黑顶奇鹛
+Heterophasia desgodinsi_黑头奇鹛
+Heterophasia gracilis_灰奇鹛
+Heterophasia melanoleuca_黑背奇鹛
+Heterophasia picaoides_长尾奇鹛
+Heterophasia pulchella_丽色奇鹛
+Heterospingus xanthopygius_红眉唐纳雀
+Hieraaetus pennatus_靴隼雕
+Hierococcyx bocki_暗色鹰鹃
+Hierococcyx fugax_马来棕腹鹰鹃
+Hierococcyx hyperythrus_北棕腹鹰鹃
+Hierococcyx nisicolor_棕腹鹰鹃
+Hierococcyx pectoralis_菲律宾鹰鹃
+Hierococcyx sparverioides_大鹰鹃
+Hierococcyx vagans_小鹰鹃
+Hierococcyx varius_普通鹰鹃
+Himantopus himantopus_黑翅长脚鹬
+Himantopus leucocephalus_澳洲长脚鹬
+Himantopus mexicanus_黑颈长脚鹬
+Himatione sanguinea_白臀蜜雀
+Hippolais icterina_绿篱莺
+Hippolais languida_淡色篱莺
+Hippolais olivetorum_橄榄篱莺
+Hippolais polyglotta_歌篱莺
+Hirundapus caudacutus_白喉针尾雨燕
+Hirundapus giganteus_褐背针尾雨燕
+Hirundinea ferruginea_峭壁霸鹟
+Hirundo angolensis_安哥拉燕
+Hirundo neoxena_迎燕
 Hirundo rustica_家燕
-Hirundo smithii_Wire-tailed Swallow
-Hirundo tahitica_洋燕
-Histrionicus histrionicus_Harlequin Duck
-Histurgops ruficauda_Rufous-tailed Weaver
-Horizocerus albocristatus_White-crested Hornbill
-Horornis acanthizoides_深山鶯
-Horornis annae_Palau Bush Warbler
-Horornis brunnescens_Hume's Bush Warbler
-Horornis canturians_遠東樹鶯
-Horornis diphone_日本樹鶯
-Horornis flavolivaceus_Aberrant Bush Warbler
-Horornis fortipes_小鶯
-Horornis ruficapilla_Fiji Bush Warbler
-Horornis seebohmi_Philippine Bush Warbler
+Hirundo smithii_线尾燕
+Hirundo tahitica_塔岛燕
+Histrionicus histrionicus_丑鸭
+Histurgops ruficauda_棕尾织雀
+Horizocerus albocristatus_西白冠弯嘴犀鸟
+Horornis acanthizoides_黄腹树莺
+Horornis annae_帕劳树莺
+Horornis brunnescens_喜山黄腹树莺
+Horornis canturians_远东树莺
+Horornis diphone_日本树莺
+Horornis flavolivaceus_异色树莺
+Horornis fortipes_强脚树莺
+Horornis ruficapilla_斐济树莺
+Horornis seebohmi_菲律宾树莺
 Horornis vulcanius_Sunda Bush Warbler
 Human non-vocal_Human non-vocal
 Human vocal_Human vocal
 Human whistle_Human whistle
-Hydrobates castro_哈考氏叉尾海燕
+Hydrobates castro_斑腰叉尾海燕
 Hydrobates leucorhous_白腰叉尾海燕
 Hydrobates monorhis_黑叉尾海燕
-Hydrobates pelagicus_European Storm-Petrel
+Hydrobates pelagicus_暴风海燕
 Hydrobates tristrami_褐翅叉尾海燕
-Hydrocoloeus minutus_小鷗
+Hydrocoloeus minutus_小鸥
 Hydrophasianus chirurgus_水雉
-Hydroprogne caspia_裏海燕鷗
-Hydropsalis cayennensis_White-tailed Nightjar
-Hydropsalis climacocerca_Ladder-tailed Nightjar
-Hydropsalis maculicaudus_Spot-tailed Nightjar
-Hydropsalis torquata_Scissor-tailed Nightjar
-Hydrornis baudii_Blue-headed Pitta
-Hydrornis caeruleus_Giant Pitta
-Hydrornis cyaneus_Blue Pitta
-Hydrornis elliotii_Bar-bellied Pitta
-Hydrornis irena_Malayan Banded-Pitta
-Hydrornis nipalensis_Blue-naped Pitta
-Hydrornis oatesi_Rusty-naped Pitta
-Hydrornis schwaneri_Bornean Banded-Pitta
-Hydrornis soror_Blue-rumped Pitta
-Hylacola cauta_Shy Heathwren
-Hylexetastes perrotii_Red-billed Woodcreeper
-Hylexetastes stresemanni_Bar-bellied Woodcreeper
-Hylexetastes uniformis_Uniform Woodcreeper
-Hylia prasina_Green Hylia
+Hydroprogne caspia_红嘴巨燕鸥
+Hydropsalis cayennensis_白尾夜鹰
+Hydropsalis climacocerca_梯尾夜鹰
+Hydropsalis maculicaudus_白斑尾夜鹰
+Hydropsalis torquata_剪尾夜鹰
+Hydrornis baudii_蓝头八色鸫
+Hydrornis caeruleus_大蓝八色鸫
+Hydrornis cyaneus_蓝八色鸫
+Hydrornis elliotii_斑腹八色鸫
+Hydrornis irena_马来蓝尾八色鸫
+Hydrornis nipalensis_蓝枕八色鸫
+Hydrornis oatesi_栗头八色鸫
+Hydrornis schwaneri_婆罗蓝尾八色鸫
+Hydrornis soror_蓝背八色鸫
+Hylacola cauta_怯地刺莺
+Hylexetastes perrotii_红嘴䴕雀
+Hylexetastes stresemanni_斑腹䴕雀
+Hylexetastes uniformis_纯色䴕雀
+Hylia prasina_绿莺
 Hyliola regilla_Pacific Chorus Frog
-Hylocharis chrysura_Gilded Hummingbird
-Hylocharis sapphirina_Rufous-throated Sapphire
-Hylocichla mustelina_Wood Thrush
-Hylomanes momotula_Tody Motmot
-Hylopezus macularius_Spotted Antpitta
-Hylopezus ochroleucus_White-browed Antpitta
-Hylopezus paraensis_Snethlage's Antpitta
-Hylopezus perspicillatus_Streak-chested Antpitta
-Hylopezus whittakeri_Alta Floresta Antpitta
-Hylophilus amaurocephalus_Gray-eyed Greenlet
-Hylophilus brunneiceps_Brown-headed Greenlet
-Hylophilus flavipes_Scrub Greenlet
-Hylophilus olivaceus_Olivaceous Greenlet
-Hylophilus pectoralis_Ashy-headed Greenlet
-Hylophilus poicilotis_Rufous-crowned Greenlet
-Hylophilus semicinereus_Gray-chested Greenlet
-Hylophilus thoracicus_Lemon-chested Greenlet
-Hylophylax naevioides_Spotted Antbird
-Hylophylax naevius_Spot-backed Antbird
-Hylophylax punctulatus_Dot-backed Antbird
-Hylorchilus navai_Nava's Wren
-Hylorchilus sumichrasti_Sumichrast's Wren
-Hymenops perspicillatus_Spectacled Tyrant
-Hypargos niveoguttatus_Peters's Twinspot
-Hypergerus atriceps_Oriole Warbler
-Hypnelus ruficollis_Russet-throated Puffbird
-Hypocnemis cantator_Guianan Warbling-Antbird
-Hypocnemis flavescens_Imeri Warbling-Antbird
-Hypocnemis hypoxantha_Yellow-browed Antbird
-Hypocnemis ochrogyna_Rondonia Warbling-Antbird
-Hypocnemis peruviana_Peruvian Warbling-Antbird
-Hypocnemis striata_Spix's Warbling-Antbird
-Hypocnemis subflava_Yellow-breasted Warbling-Antbird
-Hypocnemoides maculicauda_Band-tailed Antbird
-Hypocnemoides melanopogon_Black-chinned Antbird
-Hypocolius ampelinus_Hypocolius
-Hypoedaleus guttatus_Spot-backed Antshrike
-Hypopyrrhus pyrohypogaster_Red-bellied Grackle
-Hypothymis azurea_黑枕藍鶲
-Hypothymis puella_Pale-blue Monarch
-Hypsipetes amaurotis_棕耳鵯
-Hypsipetes everetti_Yellowish Bulbul
-Hypsipetes ganeesa_Square-tailed Bulbul
-Hypsipetes leucocephalus_紅嘴黑鵯
-Hypsipetes madagascariensis_Malagasy Bulbul
-Hypsipetes olivaceus_Mauritius Bulbul
-Hypsipetes philippinus_Philippine Bulbul
-Ianthocincla maxima_Giant Laughingthrush
-Ianthocincla ocellata_Spotted Laughingthrush
-Ianthocincla rufogularis_Rufous-chinned Laughingthrush
-Ibidorhyncha struthersii_Ibisbill
-Ibycter americanus_Red-throated Caracara
-Ichthyaetus audouinii_Audouin's Gull
-Ichthyaetus melanocephalus_Mediterranean Gull
-Icteria virens_Yellow-breasted Chat
-Icterus abeillei_Black-backed Oriole
-Icterus auratus_Orange Oriole
-Icterus auricapillus_Orange-crowned Oriole
-Icterus bullockii_Bullock's Oriole
-Icterus cayanensis_Epaulet Oriole
-Icterus chrysater_Yellow-backed Oriole
-Icterus croconotus_Orange-backed Troupial
-Icterus cucullatus_Hooded Oriole
-Icterus galbula_Baltimore Oriole
-Icterus graceannae_White-edged Oriole
-Icterus graduacauda_Audubon's Oriole
-Icterus gularis_Altamira Oriole
-Icterus icterus_Venezuelan Troupial
-Icterus jamacaii_Campo Troupial
-Icterus leucopteryx_Jamaican Oriole
-Icterus mesomelas_Yellow-tailed Oriole
-Icterus nigrogularis_Yellow Oriole
-Icterus parisorum_Scott's Oriole
-Icterus pectoralis_Spot-breasted Oriole
-Icterus portoricensis_Puerto Rican Oriole
-Icterus prosthemelas_Black-cowled Oriole
-Icterus pustulatus_Streak-backed Oriole
-Icterus pyrrhopterus_Variable Oriole
-Icterus spurius_Orchard Oriole
-Icterus wagleri_Black-vented Oriole
-Ictinaetus malaiensis_林鵰
-Ictinia mississippiensis_Mississippi Kite
-Ictinia plumbea_Plumbeous Kite
-Iduna caligata_靴籬鶯
-Iduna natalensis_African Yellow-Warbler
-Iduna opaca_Western Olivaceous Warbler
-Iduna pallida_Eastern Olivaceous Warbler
-Iduna rama_Sykes's Warbler
-Iduna similis_Mountain Yellow-Warbler
-Ifrita kowaldi_Blue-capped Ifrita
-Ilicura militaris_Pin-tailed Manakin
-Illadopsis albipectus_Scaly-breasted Illadopsis
-Illadopsis cleaveri_Blackcap Illadopsis
-Illadopsis fulvescens_Brown Illadopsis
-Illadopsis puveli_Puvel's Illadopsis
-Illadopsis pyrrhoptera_Mountain Illadopsis
-Illadopsis rufipennis_Pale-breasted Illadopsis
-Incaspiza laeta_Buff-bridled Inca-Finch
-Incaspiza ortizi_Gray-winged Inca-Finch
-Incaspiza personata_Rufous-backed Inca-Finch
+Hylocharis chrysura_金红嘴蜂鸟
+Hylocharis sapphirina_棕喉红嘴蜂鸟
+Hylocichla mustelina_棕林鸫
+Hylomanes momotula_短尾翠鴗
+Hylopezus macularius_斑蚁鸫
+Hylopezus ochroleucus_白眉蚁鸫
+Hylopezus paraensis_帕拉蚁鸫
+Hylopezus perspicillatus_纹胸蚁鸫
+Hylopezus whittakeri_上弗洛雷斯塔蚁鸫
+Hylophilus amaurocephalus_灰眼绿莺雀
+Hylophilus brunneiceps_褐头绿莺雀
+Hylophilus flavipes_灌丛绿莺雀
+Hylophilus olivaceus_橄榄绿莺雀
+Hylophilus pectoralis_灰颈绿莺雀
+Hylophilus poicilotis_棕顶绿莺雀
+Hylophilus semicinereus_灰胸绿莺雀
+Hylophilus thoracicus_里约绿莺雀
+Hylophylax naevioides_点斑蚁鸟
+Hylophylax naevius_斑背蚁鸟
+Hylophylax punctulatus_点斑背蚁鸟
+Hylorchilus navai_内氏鹪鹩
+Hylorchilus sumichrasti_细嘴鹪鹩
+Hymenops perspicillatus_斑眼霸鹟
+Hypargos niveoguttatus_朱胸斑雀
+Hypergerus atriceps_鹂莺
+Hypnelus ruficollis_黄喉蓬头䴕
+Hypocnemis cantator_歌蚁鸟
+Hypocnemis flavescens_淡胸歌蚁鸟
+Hypocnemis hypoxantha_黄眉歌蚁鸟
+Hypocnemis ochrogyna_赭背歌蚁鸟
+Hypocnemis peruviana_秘鲁歌蚁鸟
+Hypocnemis striata_斯氏歌蚁鸟
+Hypocnemis subflava_黄胸歌蚁鸟
+Hypocnemoides maculicauda_斑尾蚁鸟
+Hypocnemoides melanopogon_黑颏蚁鸟
+Hypocolius ampelinus_灰连雀
+Hypoedaleus guttatus_斑背蚁鵙
+Hypopyrrhus pyrohypogaster_红腹拟鹩哥
+Hypothymis azurea_黑枕王鹟
+Hypothymis puella_灰蓝王鹟
+Hypsipetes amaurotis_栗耳短脚鹎
+Hypsipetes everetti_黄鹎
+Hypsipetes ganeesa_方尾黑鹎
+Hypsipetes leucocephalus_黑短脚鹎
+Hypsipetes madagascariensis_马岛短脚鹎
+Hypsipetes olivaceus_毛里求斯短脚鹎
+Hypsipetes philippinus_菲律宾短脚鹎
+Ianthocincla maxima_大噪鹛
+Ianthocincla ocellata_眼纹噪鹛
+Ianthocincla rufogularis_棕颏噪鹛
+Ibidorhyncha struthersii_鹮嘴鹬
+Ibycter americanus_红喉巨隼
+Ichthyaetus audouinii_奥氏鸥
+Ichthyaetus melanocephalus_地中海鸥
+Icteria virens_黄胸大䳭莺
+Icterus abeillei_黑背拟鹂
+Icterus auratus_墨西哥橙拟鹂
+Icterus auricapillus_橙冠拟鹂
+Icterus bullockii_布氏拟鹂
+Icterus cayanensis_黄肩黑拟鹂
+Icterus chrysater_黄背拟鹂
+Icterus croconotus_橙背拟鹂
+Icterus cucullatus_巾冠拟鹂
+Icterus galbula_橙腹拟鹂
+Icterus graceannae_白翅斑拟鹂
+Icterus graduacauda_黑头拟鹂
+Icterus gularis_橙拟鹂
+Icterus icterus_普通拟鹂
+Icterus jamacaii_草原拟鹂
+Icterus leucopteryx_牙买加拟鹂
+Icterus mesomelas_黄尾拟鹂
+Icterus nigrogularis_黄拟鹂
+Icterus parisorum_斯氏拟鹂
+Icterus pectoralis_斑胸拟鹂
+Icterus portoricensis_波多黎各拟鹂
+Icterus prosthemelas_黑顶拟鹂
+Icterus pustulatus_红头拟鹂
+Icterus pyrrhopterus_杂色黑拟鹂
+Icterus spurius_圃拟鹂
+Icterus wagleri_黑臀拟鹂
+Ictinaetus malaiensis_林雕
+Ictinia mississippiensis_密西西比灰鸢
+Ictinia plumbea_南美灰鸢
+Iduna caligata_靴篱莺
+Iduna natalensis_黄捕蝇莺
+Iduna opaca_西草绿篱莺
+Iduna pallida_草绿篱莺
+Iduna rama_赛氏篱莺
+Iduna similis_山捕蝇莺
+Ifrita kowaldi_蓝顶鹛鸫
+Ilicura militaris_针尾娇鹟
+Illadopsis albipectus_白胸非洲雅鹛
+Illadopsis cleaveri_黑冠非洲雅鹛
+Illadopsis fulvescens_褐非洲雅鹛
+Illadopsis puveli_浦氏非洲雅鹛
+Illadopsis pyrrhoptera_山非洲雅鹛
+Illadopsis rufipennis_苍胸非洲雅鹛
+Incaspiza laeta_黄纹印加雀
+Incaspiza ortizi_灰翅印加雀
+Incaspiza personata_棕背印加雀
 Incilius valliceps_Gulf Coast Toad
-Indicator indicator_Greater Honeyguide
-Indicator minor_Thick-billed/Lesser Honeyguide
-Indicator variegatus_Scaly-throated Honeyguide
-Inezia caudata_Pale-tipped Tyrannulet
-Inezia inornata_Plain Tyrannulet
-Inezia subflava_Amazonian Tyrannulet
-Inezia tenuirostris_Slender-billed Tyrannulet
-Iodopleura isabellae_White-browed Purpletuft
-Iodopleura pipra_Buff-throated Purpletuft
-Iole crypta_Buff-vented Bulbul
-Iole indica_Yellow-browed Bulbul
-Iole propinqua_Gray-eyed Bulbul
-Iole viridescens_Olive Bulbul
-Irania gutturalis_White-throated Robin
-Irena cyanogastra_Philippine Fairy-bluebird
-Irena puella_Asian Fairy-bluebird
-Iridosornis analis_Yellow-throated Tanager
-Iridosornis porphyrocephalus_Purplish-mantled Tanager
-Iridosornis rufivertex_Golden-crowned Tanager
-Isleria guttata_Rufous-bellied Antwren
-Isleria hauxwelli_Plain-throated Antwren
-Ithaginis cruentus_Blood Pheasant
-Ixobrychus cinnamomeus_栗小鷺
-Ixobrychus dubius_Black-backed Bittern
-Ixobrychus eurhythmus_秋小鷺
-Ixobrychus exilis_Least Bittern
-Ixobrychus flavicollis_黃頸黑鷺
-Ixobrychus involucris_Stripe-backed Bittern
-Ixobrychus minutus_Little Bittern
-Ixobrychus sinensis_黃小鷺
-Ixonotus guttatus_Spotted Greenbul
-Ixoreus naevius_Varied Thrush
-Ixos malaccensis_Streaked Bulbul
-Ixos mcclellandii_Mountain Bulbul
-Ixothraupis guttata_Speckled Tanager
-Ixothraupis punctata_Spotted Tanager
-Ixothraupis rufigula_Rufous-throated Tanager
-Ixothraupis varia_Dotted Tanager
-Jabiru mycteria_Jabiru
-Jacamaralcyon tridactyla_Three-toed Jacamar
-Jacamerops aureus_Great Jacamar
-Jacana jacana_Wattled Jacana
-Jacana spinosa_Northern Jacana
-Junco hyemalis_Dark-eyed Junco
-Junco phaeonotus_Yellow-eyed Junco
-Jynx ruficollis_Rufous-necked Wryneck
-Jynx torquilla_地啄木
-Kakamega poliothorax_Gray-chested Babbler
-Kaupifalco monogrammicus_Lizard Buzzard
-Kenopia striata_Striped Wren-Babbler
-Ketupa blakistoni_Blakiston's Fish-Owl
-Ketupa ketupu_Buffy Fish-Owl
-Ketupa zeylonensis_Brown Fish-Owl
-Klais guimeti_Violet-headed Hummingbird
-Kleinothraupis atropileus_Black-capped Hemispingus
-Kleinothraupis parodii_Parodi's Hemispingus
-Knipolegus aterrimus_White-winged Black-Tyrant
-Knipolegus hudsoni_Hudson's Black-Tyrant
-Knipolegus orenocensis_Riverside Tyrant
-Knipolegus poecilurus_Rufous-tailed Tyrant
-Kurochkinegramma hypogrammicum_Purple-naped Spiderhunter
-Lacedo pulchella_Banded Kingfisher
-Lafresnaya lafresnayi_Mountain Velvetbreast
-Lagonosticta rhodopareia_Jameson's Firefinch
-Lagonosticta rubricata_African Firefinch
-Lagonosticta senegala_Red-billed Firefinch
-Lagopus lagopus_Willow Ptarmigan
-Lagopus leucura_White-tailed Ptarmigan
-Lagopus muta_Rock Ptarmigan
-Lalage aurea_Rufous-bellied Triller
-Lalage fimbriata_Lesser Cuckooshrike
-Lalage leucomela_Varied Triller
-Lalage leucopyga_Long-tailed Triller
-Lalage maculosa_Polynesian Triller
-Lalage melanoptera_Black-headed Cuckooshrike
-Lalage melaschistos_黑翅山椒鳥
-Lalage nigra_黑原鵑鵙
-Lalage tricolor_White-winged Triller
-Lampornis amethystinus_Amethyst-throated Mountain-gem
-Lampornis clemenciae_Blue-throated Mountain-gem
-Lampornis sybillae_Green-breasted Mountain-gem
-Lampornis viridipallens_Green-throated Mountain-gem
-Lampropsar tanagrinus_Velvet-fronted Grackle
-Lamprospiza melanoleuca_Red-billed Pied Tanager
-Lamprotornis australis_Burchell's Starling
-Lamprotornis bicolor_African Pied Starling
-Lamprotornis caudatus_長尾麗椋鳥
-Lamprotornis chalybaeus_Greater Blue-eared Starling
-Lamprotornis chloropterus_Lesser Blue-eared Starling
-Lamprotornis hildebrandti_Hildebrandt's Starling
-Lamprotornis mevesii_Meves's Starling
-Lamprotornis nitens_Cape Starling
-Lamprotornis purpuroptera_Rüppell's Starling
-Lamprotornis splendidus_Splendid Starling
-Lamprotornis superbus_栗頭麗椋鳥
-Lamprotornis unicolor_Ashy Starling
-Laniarius aethiopicus_Ethiopian Boubou
-Laniarius atrococcineus_Crimson-breasted Gonolek
-Laniarius atroflavus_Yellow-breasted Boubou
-Laniarius barbarus_Yellow-crowned Gonolek
-Laniarius bicolor_Gabon Boubou
-Laniarius erythrogaster_Black-headed Gonolek
-Laniarius ferrugineus_Southern Boubou
-Laniarius fuelleborni_Fülleborn's Boubou
-Laniarius funebris_Slate-colored Boubou
-Laniarius luehderi_Lühder's Bushshrike
-Laniarius major_Tropical Boubou
-Laniarius mufumbiri_Papyrus Gonolek
-Laniarius poensis_Western Boubou
-Laniarius sublacteus_Zanzibar Boubou
-Laniisoma elegans_Shrike-like Cotinga
-Lanio aurantius_Black-throated Shrike-Tanager
-Lanio fulvus_Fulvous Shrike-Tanager
-Lanio leucothorax_White-throated Shrike-Tanager
-Lanio versicolor_White-winged Shrike-Tanager
-Laniocera hypopyrra_Cinereous Mourner
-Laniocera rufescens_Speckled Mourner
-Lanius borealis_Northern Shrike
-Lanius bucephalus_紅頭伯勞
-Lanius cabanisi_Long-tailed Fiscal
-Lanius collaris_Southern Fiscal
-Lanius collurio_紅背伯勞
-Lanius collurioides_栗背伯勞
-Lanius corvinus_Yellow-billed Shrike
-Lanius cristatus_紅尾伯勞
-Lanius excubitor_西方灰伯勞
-Lanius humeralis_Northern Fiscal
-Lanius isabellinus_荒漠伯勞
-Lanius ludovicianus_Loggerhead Shrike
-Lanius meridionalis_Iberian Gray Shrike
-Lanius minor_Lesser Gray Shrike
-Lanius nubicus_Masked Shrike
-Lanius phoenicuroides_Red-tailed Shrike
-Lanius schach_棕背伯勞
-Lanius senator_Woodchat Shrike
-Lanius sphenocercus_楔尾伯勞
-Lanius tephronotus_灰背伯勞
-Lanius tigrinus_虎紋伯勞
-Lanius vittatus_Bay-backed Shrike
-Larosterna inca_Inca Tern
-Larus argentatus_銀鷗
-Larus belcheri_Belcher's Gull
-Larus brachyrhynchus_Short-billed Gull
-Larus cachinnans_裏海銀鷗
-Larus californicus_California Gull
-Larus canus_歐亞海鷗
-Larus crassirostris_黑尾鷗
-Larus delawarensis_Ring-billed Gull
-Larus dominicanus_Kelp Gull
-Larus fuscus_小黑背鷗
-Larus glaucescens_Glaucous-winged Gull
-Larus glaucoides_Iceland Gull
-Larus heermanni_Heermann's Gull
-Larus hyperboreus_北極鷗
-Larus livens_Yellow-footed Gull
-Larus marinus_Great Black-backed Gull
-Larus michahellis_Yellow-legged Gull
-Larus occidentalis_Western Gull
-Larus schistisagus_灰背鷗
-Larvivora akahige_日本歌鴝
-Larvivora brunnea_Indian Blue Robin
-Larvivora cyane_藍歌鴝
-Larvivora komadori_琉球歌鴝
-Larvivora sibilans_紅尾歌鴝
-Laterallus albigularis_White-throated Crake
-Laterallus exilis_Gray-breasted Crake
-Laterallus jamaicensis_Black Rail
-Laterallus leucopyrrhus_Red-and-white Crake
-Laterallus levraudi_Rusty-flanked Crake
-Laterallus melanophaius_Rufous-sided Crake
-Laterallus ruber_Ruddy Crake
-Laterallus xenopterus_Rufous-faced Crake
-Lathamus discolor_Swift Parrot
-Lathrotriccus euleri_Euler's Flycatcher
-Lathrotriccus griseipectus_Gray-breasted Flycatcher
-Laticilla cinerascens_Swamp Grass Babbler
-Legatus leucophaius_Piratic Flycatcher
-Leiopicus mahrattensis_Yellow-crowned Woodpecker
-Leioptila annectens_Rufous-backed Sibia
-Leiothlypis celata_Orange-crowned Warbler
-Leiothlypis crissalis_Colima Warbler
-Leiothlypis luciae_Lucy's Warbler
-Leiothlypis peregrina_Tennessee Warbler
-Leiothlypis ruficapilla_Nashville Warbler
-Leiothlypis virginiae_Virginia's Warbler
-Leiothrix argentauris_銀耳相思鳥
-Leiothrix lutea_紅嘴相思鳥
-Leistes bellicosus_Peruvian Meadowlark
-Leistes loyca_Long-tailed Meadowlark
-Leistes militaris_Red-breasted Meadowlark
-Leistes superciliaris_白眉黑雀
-Lepidocolaptes affinis_Spot-crowned Woodcreeper
-Lepidocolaptes albolineatus_Guianan Woodcreeper
-Lepidocolaptes angustirostris_Narrow-billed Woodcreeper
-Lepidocolaptes duidae_Duida Woodcreeper
-Lepidocolaptes falcinellus_Scalloped Woodcreeper
-Lepidocolaptes fatimalimae_Inambari Woodcreeper
-Lepidocolaptes fuscicapillus_Dusky-capped Woodcreeper
-Lepidocolaptes lacrymiger_Montane Woodcreeper
-Lepidocolaptes leucogaster_White-striped Woodcreeper
-Lepidocolaptes souleyetii_Streak-headed Woodcreeper
-Lepidocolaptes squamatus_Scaled Woodcreeper
-Lepidothrix coronata_Blue-crowned Manakin
-Lepidothrix iris_Opal-crowned Manakin
-Lepidothrix isidorei_Blue-rumped Manakin
-Lepidothrix nattereri_Snow-capped Manakin
-Lepidothrix serena_White-fronted Manakin
-Lepidothrix suavissima_Orange-bellied Manakin
-Leptasthenura aegithaloides_Plain-mantled Tit-Spinetail
-Leptasthenura andicola_Andean Tit-Spinetail
-Leptasthenura fuliginiceps_Brown-capped Tit-Spinetail
-Leptasthenura pileata_Rusty-crowned Tit-Spinetail
-Leptasthenura platensis_Tufted Tit-Spinetail
-Leptasthenura setaria_Araucaria Tit-Spinetail
-Leptasthenura striata_Streaked Tit-Spinetail
-Leptasthenura striolata_Striolated Tit-Spinetail
-Leptasthenura xenothorax_White-browed Tit-Spinetail
-Leptocoma aspasia_Black Sunbird
-Leptocoma brasiliana_Van Hasselt's Sunbird
-Leptocoma calcostetha_Copper-throated Sunbird
-Leptocoma minima_Crimson-backed Sunbird
-Leptocoma sperata_Purple-throated Sunbird
-Leptocoma zeylonica_Purple-rumped Sunbird
-Leptodon cayanensis_Gray-headed Kite
-Leptopoecile sophiae_White-browed Tit-Warbler
-Leptopogon amaurocephalus_Sepia-capped Flycatcher
-Leptopogon rufipectus_Rufous-breasted Flycatcher
-Leptopogon superciliaris_Slaty-capped Flycatcher
-Leptopogon taczanowskii_Inca Flycatcher
-Leptoptilos crumenifer_Marabou Stork
-Leptosittaca branickii_Golden-plumed Parakeet
-Leptosomus discolor_Cuckoo-roller
-Leptotila cassinii_Gray-chested Dove
-Leptotila conoveri_Tolima Dove
-Leptotila jamaicensis_Caribbean Dove
-Leptotila megalura_Large-tailed Dove
-Leptotila ochraceiventris_Ochre-bellied Dove
-Leptotila pallida_Pallid Dove
-Leptotila plumbeiceps_Gray-headed Dove
-Leptotila rufaxilla_Gray-fronted Dove
-Leptotila verreauxi_White-tipped Dove
-Lesbia nuna_Green-tailed Trainbearer
-Lesbia victoriae_Black-tailed Trainbearer
-Leucippus fallax_Buffy Hummingbird
-Leucochloris albicollis_White-throated Hummingbird
-Leucogeranus leucogeranus_白鶴
-Leucolia violiceps_Violet-crowned Hummingbird
-Leucophaeus atricilla_笑鷗
-Leucophaeus modestus_Gray Gull
-Leucophaeus pipixcan_弗氏鷗
-Leucophaeus scoresbii_Dolphin Gull
-Leucopternis kuhli_White-browed Hawk
-Leucopternis melanops_Black-faced Hawk
-Leucopternis semiplumbeus_Semiplumbeous Hawk
-Leucosarcia melanoleuca_Wonga Pigeon
-Leucosticte atrata_Black Rosy-Finch
-Leucosticte australis_Brown-capped Rosy-Finch
-Leucosticte tephrocotis_Gray-crowned Rosy-Finch
-Lewinia pectoralis_Lewin's Rail
-Lewinia striata_灰胸秧雞
-Lichenostomus cratitius_Purple-gaped Honeyeater
-Lichenostomus melanops_Yellow-tufted Honeyeater
-Lichmera incana_Dark-brown Honeyeater
-Lichmera indistincta_Brown Honeyeater
-Lichmera indistincta_Brown Honeyeater
-Lichmera squamata_White-tufted Honeyeater
-Limnoctites rectirostris_Straight-billed Reedhaunter
-Limnoctites sulphuriferus_Sulphur-bearded Reedhaunter
-Limnodromus griseus_Short-billed Dowitcher
-Limnodromus scolopaceus_長嘴半蹼鷸
-Limnodromus semipalmatus_半蹼鷸
-Limnornis curvirostris_Curve-billed Reedhaunter
-Limnothlypis swainsonii_Swainson's Warbler
-Limosa fedoa_Marbled Godwit
-Limosa haemastica_Hudsonian Godwit
-Limosa lapponica_斑尾鷸
-Limosa limosa_黑尾鷸
-Linaria cannabina_赤胸朱頂雀
-Linaria flavirostris_Twite
-Linaria yemenensis_Yemen Linnet
-Liocichla phoenicea_Red-faced Liocichla
-Liocichla ripponi_Scarlet-faced Liocichla
-Liocichla steerii_黃胸藪眉
-Lioparus chrysotis_Golden-breasted Fulvetta
-Liosceles thoracicus_Rusty-belted Tapaculo
-Lipaugus ater_Black-and-gold Cotinga
-Lipaugus fuscocinereus_Dusky Piha
-Lipaugus lanioides_Cinnamon-vented Piha
-Lipaugus unirufus_Rufous Piha
-Lipaugus vociferans_Screaming Piha
-Lipaugus weberi_Chestnut-capped Piha
+Indicator indicator_黑喉响蜜䴕
+Indicator minor_北非响蜜䴕
+Indicator variegatus_鳞喉响蜜䴕
+Inezia caudata_白眼姬霸鹟
+Inezia inornata_纯色姬霸鹟
+Inezia subflava_亚马孙姬霸鹟
+Inezia tenuirostris_细嘴姬霸鹟
+Iodopleura isabellae_白眉紫须伞鸟
+Iodopleura pipra_黄喉紫须伞鸟
+Iole crypta_棕臀短脚鹎
+Iole indica_黄眉鹎
+Iole propinqua_灰眼短脚鹎
+Iole viridescens_黄眉绿鹎
+Irania gutturalis_白喉鸲
+Irena cyanogastra_蓝腹和平鸟
+Irena puella_和平鸟
+Iridosornis analis_黄喉彩裸鼻雀
+Iridosornis porphyrocephalus_紫背彩裸鼻雀
+Iridosornis rufivertex_金顶彩裸鼻雀
+Isleria guttata_棕腹蚁鹩
+Isleria hauxwelli_淡喉蚁鹩
+Ithaginis cruentus_血雉
+Ixobrychus cinnamomeus_栗苇鳽
+Ixobrychus dubius_黑背苇鳽
+Ixobrychus eurhythmus_Schrenck's Bittern
+Ixobrychus exilis_姬苇鳽
+Ixobrychus flavicollis_黑鳽
+Ixobrychus involucris_纹背苇鳽
+Ixobrychus minutus_小苇鳽
+Ixobrychus sinensis_黄苇鳽
+Ixonotus guttatus_斑鹎
+Ixoreus naevius_杂色鸫
+Ixos malaccensis_纹羽鹎
+Ixos mcclellandii_绿翅短脚鹎
+Ixothraupis guttata_点斑靓唐纳雀
+Ixothraupis punctata_斑靓唐纳雀
+Ixothraupis rufigula_棕喉靓唐纳雀
+Ixothraupis varia_蓝翅靓唐纳雀
+Jabiru mycteria_裸颈鹳
+Jacamaralcyon tridactyla_三趾鹟䴕
+Jacamerops aureus_大鹟䴕
+Jacana jacana_肉垂水雉
+Jacana spinosa_美洲水雉
+Junco hyemalis_暗眼灯草鹀
+Junco phaeonotus_墨西哥灯草鹀
+Jynx ruficollis_红胸蚁䴕
+Jynx torquilla_蚁䴕
+Kakamega poliothorax_灰胸雅鹛
+Kaupifalco monogrammicus_食蜥鵟
+Kenopia striata_纹鹪鹛
+Ketupa blakistoni_毛腿雕鸮
+Ketupa ketupu_马来渔鸮
+Ketupa zeylonensis_褐渔鸮
+Klais guimeti_紫头蜂鸟
+Kleinothraupis atropileus_黑顶拟雀
+Kleinothraupis parodii_帕氏拟雀
+Knipolegus aterrimus_白翅黑霸鹟
+Knipolegus hudsoni_哈氏黑霸鹟
+Knipolegus orenocensis_滨霸鹟
+Knipolegus poecilurus_棕尾霸鹟
+Kurochkinegramma hypogrammicum_蓝枕花蜜鸟
+Lacedo pulchella_横斑翠鸟
+Lafresnaya lafresnayi_绒胸蜂鸟
+Lagonosticta rhodopareia_红腹火雀
+Lagonosticta rubricata_灰顶火雀
+Lagonosticta senegala_红嘴火雀
+Lagopus lagopus_柳雷鸟
+Lagopus leucura_白尾雷鸟
+Lagopus muta_岩雷鸟
+Lalage aurea_金腹鸣鹃鵙
+Lalage fimbriata_缨鹃鵙
+Lalage leucomela_杂色鸣鹃鵙
+Lalage leucopyga_长尾鸣鹃鵙
+Lalage maculosa_斑鸣鹃鵙
+Lalage melanoptera_黑头鹃鵙
+Lalage melaschistos_暗灰鹃鵙
+Lalage nigra_黑鸣鹃鵙
+Lalage tricolor_白翅鸣鹃鵙
+Lampornis amethystinus_辉紫喉宝石蜂鸟
+Lampornis clemenciae_蓝喉宝石蜂鸟
+Lampornis sybillae_绿胸宝石蜂鸟
+Lampornis viridipallens_绿喉宝石蜂鸟
+Lampropsar tanagrinus_绒额拟鹩哥
+Lamprospiza melanoleuca_红嘴唐纳雀
+Lamprotornis australis_巨辉椋鸟
+Lamprotornis bicolor_非洲丽椋鸟
+Lamprotornis caudatus_长尾丽椋鸟
+Lamprotornis chalybaeus_蓝耳丽椋鸟
+Lamprotornis chloropterus_小蓝耳辉椋鸟
+Lamprotornis hildebrandti_希氏丽椋鸟
+Lamprotornis mevesii_米氏辉椋鸟
+Lamprotornis nitens_红肩辉椋鸟
+Lamprotornis purpuroptera_卢氏丽椋鸟
+Lamprotornis splendidus_彩辉椋鸟
+Lamprotornis superbus_栗头丽椋鸟
+Lamprotornis unicolor_灰丽椋鸟
+Laniarius aethiopicus_埃塞黑鵙
+Laniarius atrococcineus_红胸黑鵙
+Laniarius atroflavus_黄胸黑鵙
+Laniarius barbarus_非洲黑鵙
+Laniarius bicolor_双色黑鵙
+Laniarius erythrogaster_黑头黑鵙
+Laniarius ferrugineus_锈色黑鵙
+Laniarius fuelleborni_福氏黑鵙
+Laniarius funebris_暗色黑鵙
+Laniarius luehderi_卢氏黑鵙
+Laniarius major_热带黑鵙
+Laniarius mufumbiri_穆氏黑鵙
+Laniarius poensis_山地黑鵙
+Laniarius sublacteus_东岸黑鵙
+Laniisoma elegans_鵙伞鸟
+Lanio aurantius_黑喉唐纳鵙
+Lanio fulvus_暗黄唐纳鵙
+Lanio leucothorax_白喉唐纳鵙
+Lanio versicolor_白翅唐纳鵙
+Laniocera hypopyrra_栗翅斑伞鸟
+Laniocera rufescens_点斑伞鸟
+Lanius borealis_灰伯劳
+Lanius bucephalus_牛头伯劳
+Lanius cabanisi_东非长尾伯劳
+Lanius collaris_领伯劳
+Lanius collurio_红背伯劳
+Lanius collurioides_栗背伯劳
+Lanius corvinus_黄嘴鹊鵙
+Lanius cristatus_红尾伯劳
+Lanius excubitor_西方灰伯劳
+Lanius humeralis_北领伯劳
+Lanius isabellinus_荒漠伯劳
+Lanius ludovicianus_呆头伯劳
+Lanius meridionalis_伊比利亚灰伯劳
+Lanius minor_黑额伯劳
+Lanius nubicus_云斑伯劳
+Lanius phoenicuroides_棕尾伯劳
+Lanius schach_棕背伯劳
+Lanius senator_林䳭伯劳
+Lanius sphenocercus_楔尾伯劳
+Lanius tephronotus_灰背伯劳
+Lanius tigrinus_虎纹伯劳
+Lanius vittatus_褐背伯劳
+Larosterna inca_印加燕鸥
+Larus argentatus_银鸥
+Larus belcheri_斑尾鸥
+Larus brachyrhynchus_美洲海鸥
+Larus cachinnans_里海银鸥
+Larus californicus_加州鸥
+Larus canus_普通海鸥
+Larus crassirostris_黑尾鸥
+Larus delawarensis_环嘴鸥
+Larus dominicanus_黑背鸥
+Larus fuscus_小黑背鸥
+Larus glaucescens_灰翅鸥
+Larus glaucoides_冰岛鸥
+Larus heermanni_红嘴灰鸥
+Larus hyperboreus_北极鸥
+Larus livens_黄脚鸥
+Larus marinus_大黑背鸥
+Larus michahellis_黄腿银鸥
+Larus occidentalis_西美鸥
+Larus schistisagus_灰背鸥
+Larvivora akahige_日本歌鸲
+Larvivora brunnea_栗腹歌鸲
+Larvivora cyane_蓝歌鸲
+Larvivora komadori_琉球歌鸲
+Larvivora sibilans_红尾歌鸲
+Laterallus albigularis_白喉田鸡
+Laterallus exilis_灰胸田鸡
+Laterallus jamaicensis_黑田鸡
+Laterallus leucopyrrhus_红白田鸡
+Laterallus levraudi_锈胁田鸡
+Laterallus melanophaius_棕胁田鸡
+Laterallus ruber_红田鸡
+Laterallus xenopterus_棕脸田鸡
+Lathamus discolor_红尾绿鹦鹉
+Lathrotriccus euleri_南美纹霸鹟
+Lathrotriccus griseipectus_灰胸纹霸鹟
+Laticilla cinerascens_沼泽山鹪鹛
+Legatus leucophaius_强霸鹟
+Leiopicus mahrattensis_黄冠斑啄木鸟
+Leioptila annectens_栗背奇鹛
+Leiothlypis celata_橙冠虫森莺
+Leiothlypis crissalis_黄腰虫森莺
+Leiothlypis luciae_赤腰虫森莺
+Leiothlypis peregrina_灰冠虫森莺
+Leiothlypis ruficapilla_黄喉虫森莺
+Leiothlypis virginiae_黄胸虫森莺
+Leiothrix argentauris_银耳相思鸟
+Leiothrix lutea_红嘴相思鸟
+Leistes bellicosus_红胸草地鹨
+Leistes loyca_长尾草地鹨
+Leistes militaris_彭巴草地鹨
+Leistes superciliaris_白眉草地鹨
+Lepidocolaptes affinis_斑顶䴕雀
+Lepidocolaptes albolineatus_线纹䴕雀
+Lepidocolaptes angustirostris_窄嘴䴕雀
+Lepidocolaptes duidae_杜山䴕雀
+Lepidocolaptes falcinellus_扇形䴕雀
+Lepidocolaptes fatimalimae_伊河䴕雀
+Lepidocolaptes fuscicapillus_暗冠䴕雀
+Lepidocolaptes lacrymiger_山䴕雀
+Lepidocolaptes leucogaster_白纹䴕雀
+Lepidocolaptes souleyetii_纹头䴕雀
+Lepidocolaptes squamatus_鳞斑䴕雀
+Lepidothrix coronata_蓝冠娇鹟
+Lepidothrix iris_乳白冠娇鹟
+Lepidothrix isidorei_蓝腰娇鹟
+Lepidothrix nattereri_白顶娇鹟
+Lepidothrix serena_白额娇鹟
+Lepidothrix suavissima_特普伊娇鹟
+Leptasthenura aegithaloides_纯背针尾雀
+Leptasthenura andicola_安第斯针尾雀
+Leptasthenura fuliginiceps_褐顶针尾雀
+Leptasthenura pileata_锈顶针尾雀
+Leptasthenura platensis_须针尾雀
+Leptasthenura setaria_南美针尾雀
+Leptasthenura striata_纹针尾雀
+Leptasthenura striolata_条纹针尾雀
+Leptasthenura xenothorax_秘鲁白眉针尾雀
+Leptocoma aspasia_黑花蜜鸟
+Leptocoma brasiliana_蓝肩花蜜鸟
+Leptocoma calcostetha_铜喉花蜜鸟
+Leptocoma minima_小花蜜鸟
+Leptocoma sperata_紫喉花蜜鸟
+Leptocoma zeylonica_紫腰花蜜鸟
+Leptodon cayanensis_灰头美洲鸢
+Leptopoecile sophiae_花彩雀莺
+Leptopogon amaurocephalus_棕顶窄嘴霸鹟
+Leptopogon rufipectus_棕胸窄嘴霸鹟
+Leptopogon superciliaris_灰顶窄嘴霸鹟
+Leptopogon taczanowskii_印加窄嘴霸鹟
+Leptoptilos crumenifer_非洲秃鹳
+Leptosittaca branickii_金羽鹦哥
+Leptosomus discolor_鹃三宝鸟
+Leptotila cassinii_灰胸棕翅鸠
+Leptotila conoveri_托利棕翅鸠
+Leptotila jamaicensis_白腹棕翅鸠
+Leptotila megalura_大尾棕翅鸠
+Leptotila ochraceiventris_赭腹棕翅鸠
+Leptotila pallida_苍棕翅鸠
+Leptotila plumbeiceps_灰头棕翅鸠
+Leptotila rufaxilla_灰额棕翅鸠
+Leptotila verreauxi_白额棕翅鸠
+Lesbia nuna_绿带尾蜂鸟
+Lesbia victoriae_黑带尾蜂鸟
+Leucippus fallax_淡黄蜂鸟
+Leucochloris albicollis_白喉蜂鸟
+Leucogeranus leucogeranus_白鹤
+Leucolia violiceps_紫冠蜂鸟
+Leucophaeus atricilla_笑鸥
+Leucophaeus modestus_灰鸥
+Leucophaeus pipixcan_弗氏鸥
+Leucophaeus scoresbii_豚鸥
+Leucopternis kuhli_白眉南美鵟
+Leucopternis melanops_黑脸南美鵟
+Leucopternis semiplumbeus_淡灰南美鵟
+Leucosarcia melanoleuca_巨地鸠
+Leucosticte atrata_黑岭雀
+Leucosticte australis_褐顶岭雀
+Leucosticte tephrocotis_灰头岭雀
+Lewinia pectoralis_卢氏秧鸡
+Lewinia striata_灰胸秧鸡
+Lichenostomus cratitius_紫颊纹吸蜜鸟
+Lichenostomus melanops_黄冠吸蜜鸟
+Lichmera incana_银耳岩吸蜜鸟
+Lichmera indistincta_褐岩吸蜜鸟
+Lichmera indistincta_褐岩吸蜜鸟
+Lichmera squamata_白簇岩吸蜜鸟
+Limnoctites rectirostris_直嘴芦雀
+Limnoctites sulphuriferus_黄须针尾雀
+Limnodromus griseus_短嘴半蹼鹬
+Limnodromus scolopaceus_长嘴半蹼鹬
+Limnodromus semipalmatus_半蹼鹬
+Limnornis curvirostris_弯嘴芦雀
+Limnothlypis swainsonii_斯氏森莺
+Limosa fedoa_云斑塍鹬
+Limosa haemastica_棕塍鹬
+Limosa lapponica_斑尾塍鹬
+Limosa limosa_黑尾塍鹬
+Linaria cannabina_赤胸朱顶雀
+Linaria flavirostris_黄嘴朱顶雀
+Linaria yemenensis_也门朱顶雀
+Liocichla phoenicea_灰头薮鹛
+Liocichla ripponi_红翅薮鹛
+Liocichla steerii_黄痣薮鹛
+Lioparus chrysotis_金胸雀鹛
+Liosceles thoracicus_锈纹窜鸟
+Lipaugus ater_黑黄伞鸟
+Lipaugus fuscocinereus_暗色伞鸟
+Lipaugus lanioides_红肛伞鸟
+Lipaugus unirufus_棕伞鸟
+Lipaugus vociferans_尖声伞鸟
+Lipaugus weberi_栗顶伞鸟
 Lithobates catesbeianus_American Bullfrog
 Lithobates clamitans_Green Frog
 Lithobates palustris_Pickerel Frog
 Lithobates sylvaticus_Wood Frog
-Lochmias nematura_Sharp-tailed Streamcreeper
-Locustella alishanensis_台灣叢樹鶯
-Locustella caudata_Long-tailed Bush Warbler
-Locustella davidi_Baikal Bush Warbler
-Locustella fluviatilis_River Warbler
-Locustella lanceolata_矛斑蝗鶯
-Locustella luscinioides_Savi's Warbler
-Locustella luteoventris_Brown Bush Warbler
-Locustella mandelli_赤褐蝗鶯
-Locustella montis_Javan Bush Warbler
-Locustella naevia_Common Grasshopper-Warbler
-Locustella tacsanowskia_Chinese Bush Warbler
-Locustella thoracica_Spotted Bush Warbler
-Lonchura atricapilla_黑頭文鳥
-Lonchura castaneothorax_Chestnut-breasted Munia
-Lonchura kelaarti_Black-throated Munia
-Lonchura leucogastroides_Javan Munia
-Lonchura maja_白頭文鳥
-Lonchura malacca_Tricolored Munia
-Lonchura punctulata_斑文鳥
-Lonchura striata_白腰文鳥
-Lophaetus occipitalis_Long-crested Eagle
-Lophoceros alboterminatus_Crowned Hornbill
-Lophoceros camurus_Red-billed Dwarf Hornbill
-Lophoceros fasciatus_African Pied Hornbill
-Lophoceros hemprichii_Hemprich's Hornbill
-Lophoceros nasutus_African Gray Hornbill
-Lophochroa leadbeateri_Pink Cockatoo
-Lophodytes cucullatus_Hooded Merganser
-Lophonetta specularioides_Crested Duck
-Lophophanes cristatus_Crested Tit
-Lophophanes dichrous_Gray-crested Tit
-Lophophorus impejanus_Himalayan Monal
-Lophorina superba_Greater Lophorina
-Lophostrix cristata_Crested Owl
-Lophotriccus eulophotes_Long-crested Pygmy-Tyrant
-Lophotriccus galeatus_Helmeted Pygmy-Tyrant
-Lophotriccus pileatus_Scale-crested Pygmy-Tyrant
-Lophotriccus vitiosus_Double-banded Pygmy-Tyrant
-Lophotriorchis kienerii_Rufous-bellied Eagle
-Lophura leucomelanos_Kalij Pheasant
-Loriculus beryllinus_Sri Lanka Hanging-Parrot
-Loriculus galgulus_Blue-crowned Hanging-Parrot
-Loriculus philippensis_Philippine Hanging-Parrot
-Loriculus vernalis_Vernal Hanging-Parrot
-Loriotus cristatus_Flame-crested Tanager
-Loriotus luctuosus_White-shouldered Tanager
-Lorius chlorocercus_Yellow-bibbed Lory
-Lorius lory_Black-capped Lory
-Loxia curvirostra_紅交嘴雀
-Loxia leucoptera_White-winged Crossbill
-Loxia pytyopsittacus_Parrot Crossbill
-Loxia scotica_Scottish Crossbill
-Loxia sinesciuris_Cassia Crossbill
-Loxigilla noctis_Lesser Antillean Bullfinch
-Loxioides bailleui_Palila
-Loxops caeruleirostris_Akekee
-Loxops coccineus_Hawaii Akepa
-Loxops mana_Hawaii Creeper
-Lullula arborea_Wood Lark
-Lurocalis rufiventris_Rufous-bellied Nighthawk
-Lurocalis semitorquatus_Short-tailed Nighthawk
-Luscinia luscinia_Thrush Nightingale
-Luscinia megarhynchos_Common Nightingale
-Luscinia phaenicuroides_White-bellied Redstart
-Luscinia svecica_藍喉鴝
-Lybius bidentatus_Double-toothed Barbet
-Lybius guifsobalito_Black-billed Barbet
-Lybius torquatus_Black-collared Barbet
-Lybius vieilloti_Vieillot's Barbet
-Lycocorax pyrrhopterus_Paradise-crow
-Lymnocryptes minimus_小鷸
-Lyncornis macrotis_Great Eared-Nightjar
-Lyncornis temminckii_Malaysian Eared-Nightjar
-Lyrurus tetrix_Black Grouse
-Machaerirhynchus flaviventer_Yellow-breasted Boatbill
-Machaerirhynchus nigripectus_Black-breasted Boatbill
-Machaeropterus deliciosus_Club-winged Manakin
-Machaeropterus pyrocephalus_Fiery-capped Manakin
-Machaeropterus regulus_Kinglet Manakin
-Machaeropterus striolatus_Striolated Manakin
-Macheiramphus alcinus_Bat Hawk
-Machetornis rixosa_Cattle Tyrant
-Machlolophus aplonotus_Indian Yellow Tit
-Machlolophus holsti_黃山雀
-Machlolophus nuchalis_White-naped Tit
-Machlolophus spilonotus_黃頰山雀
-Machlolophus xanthogenys_Himalayan Black-lored Tit
-Mackenziaena leachii_Large-tailed Antshrike
-Mackenziaena severa_Tufted Antshrike
-Macroagelaius imthurni_Golden-tufted Grackle
-Macroagelaius subalaris_Mountain Grackle
-Macronus ptilosus_Fluffy-backed Tit-Babbler
-Macronus striaticeps_Brown Tit-Babbler
-Macronyx capensis_Orange-throated Longclaw
-Macronyx croceus_Yellow-throated Longclaw
-Macronyx fuelleborni_Fülleborn's Longclaw
-Macropygia amboinensis_Amboyna Cuckoo-Dove
-Macropygia doreya_Sultan's Cuckoo-Dove
-Macropygia mackinlayi_Mackinlay's Cuckoo-Dove
-Macropygia phasianella_Brown Cuckoo-Dove
-Macropygia ruficeps_Little Cuckoo-Dove
-Macropygia tenuirostris_長尾鳩
-Macropygia unchall_斑尾鵑鳩
-Macrosphenus concolor_Gray Longbill
-Macrosphenus flavicans_Yellow Longbill
-Macrosphenus kempi_Kemp's Longbill
-Magumma parva_Anianiau
-Malacocincla abbotti_Abbott's Babbler
-Malacocincla sepiaria_Horsfield's Babbler
-Malaconotus blanchoti_Gray-headed Bushshrike
-Malacopteron affine_Sooty-capped Babbler
-Malacopteron cinereum_Scaly-crowned Babbler
-Malacopteron magnirostre_Moustached Babbler
-Malacopteron magnum_Rufous-crowned Babbler
-Malacoptila fulvogularis_Black-streaked Puffbird
-Malacoptila fusca_White-chested Puffbird
-Malacoptila mystacalis_Moustached Puffbird
-Malacoptila panamensis_White-whiskered Puffbird
-Malacoptila rufa_Rufous-necked Puffbird
-Malacoptila semicincta_Semicollared Puffbird
-Malacoptila striata_Crescent-chested Puffbird
-Malacorhynchus membranaceus_Pink-eared Duck
-Malcorus pectoralis_Rufous-eared Warbler
-Malia grata_Malia
-Malimbus nitens_Blue-billed Malimbe
-Malindangia mcgregori_McGregor's Cuckooshrike
-Malurus alboscapulatus_White-shouldered Fairywren
-Malurus amabilis_Lovely Fairywren
-Malurus assimilis_Purple-backed Fairywren
-Malurus cyaneus_Superb Fairywren
-Malurus cyanocephalus_Emperor Fairywren
-Malurus elegans_Red-winged Fairywren
-Malurus lamberti_Variegated Fairywren
-Malurus leucopterus_White-winged Fairywren
-Malurus melanocephalus_Red-backed Fairywren
-Malurus splendens_Splendid Fairywren
-Manacus aurantiacus_Orange-collared Manakin
-Manacus candei_White-collared Manakin
-Manacus manacus_White-bearded Manakin
-Manacus vitellinus_Golden-collared Manakin
-Manorina flavigula_Yellow-throated Miner
-Manorina melanocephala_Noisy Miner
-Manorina melanophrys_Bell Miner
-Mareca americana_葡萄胸鴨
-Mareca falcata_羅文鴨
-Mareca penelope_赤頸鴨
-Mareca sibilatrix_Chiloe Wigeon
-Mareca strepera_赤膀鴨
-Margarops fuscatus_Pearly-eyed Thrasher
-Margarornis rubiginosus_Ruddy Treerunner
-Margarornis squamiger_Pearled Treerunner
-Masius chrysopterus_Golden-winged Manakin
-Mazaria propinqua_White-bellied Spinetail
-Mecocerculus hellmayri_Buff-banded Tyrannulet
-Mecocerculus leucophrys_White-throated Tyrannulet
-Mecocerculus minor_Sulphur-bellied Tyrannulet
-Mecocerculus poecilocercus_White-tailed Tyrannulet
-Mecocerculus stictopterus_White-banded Tyrannulet
-Megaceryle alcyon_Belted Kingfisher
-Megaceryle lugubris_Crested Kingfisher
-Megaceryle maxima_Giant Kingfisher
-Megaceryle torquata_Ringed Kingfisher
-Megalurus palustris_Striated Grassbird
-Megapodius cumingii_Tabon Scrubfowl
-Megapodius eremita_Melanesian Scrubfowl
-Megapodius freycinet_Dusky Scrubfowl-
-Megapodius reinwardt_Orange-footed Scrubfowl
-Megarynchus pitangua_Boat-billed Flycatcher
-Megascops albogularis_White-throated Screech-Owl
-Megascops asio_Eastern Screech-Owl
-Megascops atricapilla_Black-capped Screech-Owl
-Megascops centralis_Choco Screech-Owl
-Megascops choliba_Tropical Screech-Owl
-Megascops clarkii_Bare-shanked Screech-Owl
-Megascops cooperi_Pacific Screech-Owl
-Megascops gilesi_Santa Marta Screech-Owl
-Megascops guatemalae_Middle American Screech-Owl
-Megascops hoyi_Montane Forest Screech-Owl
-Megascops ingens_Rufescent Screech-Owl
-Megascops kennicottii_Western Screech-Owl
-Megascops koepckeae_Koepcke's Screech-Owl
-Megascops petersoni_Cinnamon Screech-Owl
-Megascops roboratus_Peruvian Screech-Owl
-Megascops roraimae_Foothill Screech-Owl
-Megascops sanctaecatarinae_Long-tufted Screech-Owl
-Megascops seductus_Balsas Screech-Owl
-Megascops trichopsis_Whiskered Screech-Owl
-Megascops watsonii_Tawny-bellied Screech-Owl
-Megastictus margaritatus_Pearly Antshrike
-Megaxenops parnaguae_Great Xenops
-Meiglyptes tristis_Buff-rumped Woodpecker
-Meiglyptes tukki_Buff-necked Woodpecker
-Melaenornis edolioides_Northern Black-Flycatcher
-Melaenornis fischeri_White-eyed Slaty-Flycatcher
-Melaenornis pammelaina_Southern Black-Flycatcher
-Melaenornis silens_Fiscal Flycatcher
-Melampitta lugubris_Lesser Melampitta
-Melanerpes aurifrons_Golden-fronted Woodpecker
-Melanerpes cactorum_White-fronted Woodpecker
-Melanerpes candidus_White Woodpecker
-Melanerpes carolinus_Red-bellied Woodpecker
-Melanerpes chrysauchen_Golden-naped Woodpecker
-Melanerpes chrysogenys_Golden-cheeked Woodpecker
-Melanerpes cruentatus_Yellow-tufted Woodpecker
-Melanerpes erythrocephalus_Red-headed Woodpecker
-Melanerpes flavifrons_Yellow-fronted Woodpecker
-Melanerpes formicivorus_Acorn Woodpecker
-Melanerpes hoffmannii_Hoffmann's Woodpecker
-Melanerpes hypopolius_Gray-breasted Woodpecker
-Melanerpes lewis_Lewis's Woodpecker
-Melanerpes portoricensis_Puerto Rican Woodpecker
-Melanerpes pucherani_Black-cheeked Woodpecker
-Melanerpes pygmaeus_Yucatan Woodpecker
-Melanerpes radiolatus_Jamaican Woodpecker
-Melanerpes rubricapillus_Red-crowned Woodpecker
-Melanerpes striatus_Hispaniolan Woodpecker
-Melanerpes superciliaris_West Indian Woodpecker
-Melanerpes uropygialis_Gila Woodpecker
-Melaniparus afer_Gray Tit
-Melaniparus albiventris_White-bellied Tit
-Melaniparus cinerascens_Ashy Tit
-Melaniparus funereus_Dusky Tit
-Melaniparus leucomelas_White-winged Black-Tit
-Melaniparus niger_Southern Black-Tit
-Melaniparus rufiventris_Rufous-bellied Tit
-Melaniparus thruppi_Somali Tit
-Melanitta americana_Black Scoter
-Melanitta fusca_Velvet Scoter
-Melanitta nigra_Common Scoter
-Melanitta perspicillata_Surf Scoter
-Melanochlora sultanea_Sultan Tit
-Melanocorypha calandra_Calandra Lark
-Melanocorypha maxima_Tibetan Lark
-Melanodera melanodera_White-bridled Finch
-Melanodera xanthogramma_Yellow-bridled Finch
-Melanodryas cucullata_Hooded Robin
-Melanodryas vittata_Dusky Robin
-Melanopareia elegans_Elegant Crescentchest
-Melanopareia maranonica_Marañon Crescentchest
-Melanopareia maximiliani_Olive-crowned Crescentchest
-Melanopareia torquata_Collared Crescentchest
-Melanoptila glabrirostris_Black Catbird
-Melanorectes nigrescens_Black Pitohui
-Melanospiza bicolor_Black-faced Grassquit
-Melanotis caerulescens_Blue Mockingbird
-Melanotis hypoleucus_Blue-and-white Mockingbird
-Meleagris gallopavo_火雞
-Meleagris ocellata_Ocellated Turkey
-Meliarchus sclateri_Makira Honeyeater
-Melidectes belfordi_Belford's Melidectes
-Melidectes rufocrissalis_Yellow-browed Melidectes
-Melidora macrorrhina_Hook-billed Kingfisher
-Meliphaga lewinii_Lewin's Honeyeater
-Meliphaga notata_Yellow-spotted Honeyeater
-Melithreptus affinis_Black-headed Honeyeater
-Melithreptus albogularis_White-throated Honeyeater
-Melithreptus brevirostris_Brown-headed Honeyeater
-Melithreptus chloropsis_Gilbert's Honeyeater
-Melithreptus gularis_Black-chinned Honeyeater
-Melithreptus lunatus_White-naped Honeyeater
-Melithreptus validirostris_Strong-billed Honeyeater
-Mellisuga helenae_Bee Hummingbird
-Mellisuga minima_Vervain Hummingbird
-Melocichla mentalis_Moustached Grass-Warbler
-Melopsittacus undulatus_虎皮鸚鵡
-Melopyrrha portoricensis_Puerto Rican Bullfinch
-Melopyrrha violacea_Greater Antillean Bullfinch
-Melospiza georgiana_Swamp Sparrow
-Melospiza lincolnii_Lincoln's Sparrow
-Melospiza melodia_Song Sparrow
-Melozone aberti_Abert's Towhee
-Melozone albicollis_White-throated Towhee
-Melozone biarcuata_White-faced Ground-Sparrow
-Melozone cabanisi_Cabanis's Ground-Sparrow
-Melozone crissalis_California Towhee
-Melozone fusca_Canyon Towhee
-Melozone kieneri_Rusty-crowned Ground-Sparrow
-Melozone leucotis_White-eared Ground-Sparrow
-Menura alberti_Albert's Lyrebird
-Menura novaehollandiae_Superb Lyrebird
-Mergellus albellus_白秋沙
-Mergus merganser_川秋沙
-Mergus serrator_紅胸秋沙
-Merops albicollis_White-throated Bee-eater
-Merops apiaster_European Bee-eater
-Merops bullockoides_White-fronted Bee-eater
-Merops bulocki_Red-throated Bee-eater
-Merops hirundineus_Swallow-tailed Bee-eater
-Merops leschenaulti_Chestnut-headed Bee-eater
-Merops oreobates_Cinnamon-chested Bee-eater
-Merops orientalis_Green Bee-eater (Russet-crowned)
+Lochmias nematura_尖尾溪雀
+Locustella alishanensis_台湾短翅蝗莺
+Locustella caudata_长尾短翅蝗莺
+Locustella davidi_北短翅蝗莺
+Locustella fluviatilis_河蝗莺
+Locustella lanceolata_矛斑蝗莺
+Locustella luscinioides_鸲蝗莺
+Locustella luteoventris_棕褐短翅蝗莺
+Locustella mandelli_高山短翅蝗莺
+Locustella montis_爪哇短翅蝗莺
+Locustella naevia_黑斑蝗莺
+Locustella tacsanowskia_中华短翅蝗莺
+Locustella thoracica_斑胸短翅蝗莺
+Lonchura atricapilla_栗腹文鸟
+Lonchura castaneothorax_栗胸文鸟
+Lonchura kelaarti_红胸文鸟
+Lonchura leucogastroides_黑喉文鸟
+Lonchura maja_白头文鸟
+Lonchura malacca_黑头文鸟
+Lonchura punctulata_斑文鸟
+Lonchura striata_白腰文鸟
+Lophaetus occipitalis_长冠鹰雕
+Lophoceros alboterminatus_冕弯嘴犀鸟
+Lophoceros camurus_红弯嘴犀鸟
+Lophoceros fasciatus_斑尾弯嘴犀鸟
+Lophoceros hemprichii_亨氏弯嘴犀鸟
+Lophoceros nasutus_黑嘴弯嘴犀鸟
+Lophochroa leadbeateri_彩冠凤头鹦鹉
+Lophodytes cucullatus_棕胁秋沙鸭
+Lophonetta specularioides_冠鸭
+Lophophanes cristatus_凤头山雀
+Lophophanes dichrous_褐冠山雀
+Lophophorus impejanus_棕尾虹雉
+Lophorina superba_华美极乐鸟
+Lophostrix cristata_冠鸮
+Lophotriccus eulophotes_长冠侏霸鹟
+Lophotriccus galeatus_盔侏霸鹟
+Lophotriccus pileatus_鳞冠侏霸鹟
+Lophotriccus vitiosus_双斑侏霸鹟
+Lophotriorchis kienerii_棕腹隼雕
+Lophura leucomelanos_黑鹇
+Loriculus beryllinus_斯里兰卡短尾鹦鹉
+Loriculus galgulus_蓝顶短尾鹦鹉
+Loriculus philippensis_菲律宾短尾鹦鹉
+Loriculus vernalis_短尾鹦鹉
+Loriotus cristatus_火冠黑唐纳雀
+Loriotus luctuosus_白肩黑唐纳雀
+Lorius chlorocercus_黄领鹦鹉
+Lorius lory_黑顶鹦鹉
+Loxia curvirostra_红交嘴雀
+Loxia leucoptera_白翅交嘴雀
+Loxia pytyopsittacus_鹦交嘴雀
+Loxia scotica_苏格兰交嘴雀
+Loxia sinesciuris_喀细亚交嘴雀
+Loxigilla noctis_小安德牛雀
+Loxioides bailleui_黄胸管舌雀
+Loxops caeruleirostris_考岛管舌雀
+Loxops coccineus_红管舌雀
+Loxops mana_夏威夷悬木雀
+Lullula arborea_林百灵
+Lurocalis rufiventris_棕腹夜鹰
+Lurocalis semitorquatus_半领夜鹰
+Luscinia luscinia_欧歌鸲
+Luscinia megarhynchos_新疆歌鸲
+Luscinia phaenicuroides_白腹短翅鸲
+Luscinia svecica_蓝喉歌鸲
+Lybius bidentatus_双齿拟啄木鸟
+Lybius guifsobalito_黑嘴拟啄木鸟
+Lybius torquatus_黑领拟啄木鸟
+Lybius vieilloti_维氏拟啄木鸟
+Lycocorax pyrrhopterus_褐翅极乐鸟
+Lymnocryptes minimus_姬鹬
+Lyncornis macrotis_毛腿耳夜鹰
+Lyncornis temminckii_马来毛腿夜鹰
+Lyrurus tetrix_黑琴鸡
+Machaerirhynchus flaviventer_黄胸船嘴鹟
+Machaerirhynchus nigripectus_黑胸船嘴鹟
+Machaeropterus deliciosus_梅花翅娇鹟
+Machaeropterus pyrocephalus_朱顶娇鹟
+Machaeropterus regulus_纹娇鹟
+Machaeropterus striolatus_紫纹娇鹟
+Macheiramphus alcinus_食蝠鸢
+Machetornis rixosa_牛霸鹟
+Machlolophus aplonotus_印度眼纹黄山雀
+Machlolophus holsti_台湾黄山雀
+Machlolophus nuchalis_白枕山雀
+Machlolophus spilonotus_黄颊山雀
+Machlolophus xanthogenys_眼纹黄山雀
+Mackenziaena leachii_大尾蚁鵙
+Mackenziaena severa_须蚁鵙
+Macroagelaius imthurni_金簇山拟鹩哥
+Macroagelaius subalaris_山拟鹩哥
+Macronus ptilosus_绒背纹胸鹛
+Macronus striaticeps_褐纹胸鹛
+Macronyx capensis_橙喉长爪鹡鸰
+Macronyx croceus_黄喉长爪鹡鸰
+Macronyx fuelleborni_福氏长爪鹡鸰
+Macropygia amboinensis_红胸鹃鸠
+Macropygia doreya_苏坦氏鹃鸠
+Macropygia mackinlayi_棕鹃鸠
+Macropygia phasianella_褐鹃鸠
+Macropygia ruficeps_小鹃鸠
+Macropygia tenuirostris_菲律宾鹃鸠
+Macropygia unchall_斑尾鹃鸠
+Macrosphenus concolor_灰长嘴莺
+Macrosphenus flavicans_黄长嘴莺
+Macrosphenus kempi_肯氏长嘴莺
+Magumma parva_小绿雀
+Malacocincla abbotti_阿氏雅鹛
+Malacocincla sepiaria_霍氏雅鹛
+Malaconotus blanchoti_灰头丛鵙
+Malacopteron affine_纯色树鹛
+Malacopteron cinereum_小红头树鹛
+Malacopteron magnirostre_须树鹛
+Malacopteron magnum_大红头树鹛
+Malacoptila fulvogularis_黑纹蓬头䴕
+Malacoptila fusca_白胸蓬头䴕
+Malacoptila mystacalis_须蓬头䴕
+Malacoptila panamensis_白须蓬头䴕
+Malacoptila rufa_棕颈蓬头䴕
+Malacoptila semicincta_半领蓬头䴕
+Malacoptila striata_月胸蓬头䴕
+Malacorhynchus membranaceus_红耳鸭
+Malcorus pectoralis_棕耳鹪莺
+Malia grata_苏拉威西鹛莺
+Malimbus nitens_蓝嘴精织雀
+Malindangia mcgregori_尖尾鹃鵙
+Malurus alboscapulatus_白肩细尾鹩莺
+Malurus amabilis_娇美细尾鹩莺
+Malurus assimilis_紫背细尾鹩莺
+Malurus cyaneus_华丽细尾鹩莺
+Malurus cyanocephalus_蓝细尾鹩莺
+Malurus elegans_红翅细尾鹩莺
+Malurus lamberti_杂色细尾鹩莺
+Malurus leucopterus_蓝白细尾鹩莺
+Malurus melanocephalus_红背细尾鹩莺
+Malurus splendens_辉蓝细尾鹩莺
+Manacus aurantiacus_橙领娇鹟
+Manacus candei_白头娇鹟
+Manacus manacus_白须娇鹟
+Manacus vitellinus_金领娇鹟
+Manorina flavigula_黄喉矿吸蜜鸟
+Manorina melanocephala_黑额矿吸蜜鸟
+Manorina melanophrys_矿吸蜜鸟
+Mareca americana_绿眉鸭
+Mareca falcata_罗纹鸭
+Mareca penelope_赤颈鸭
+Mareca sibilatrix_黑白斑胸鸭
+Mareca strepera_赤膀鸭
+Margarops fuscatus_珠眼嘲鸫
+Margarornis rubiginosus_棕爬树雀
+Margarornis squamiger_鳞斑爬树雀
+Masius chrysopterus_金翅娇鹟
+Mazaria propinqua_白腹针尾雀
+Mecocerculus hellmayri_黄斑姬霸鹟
+Mecocerculus leucophrys_白喉姬霸鹟
+Mecocerculus minor_黄腹姬霸鹟
+Mecocerculus poecilocercus_白尾姬霸鹟
+Mecocerculus stictopterus_白斑姬霸鹟
+Megaceryle alcyon_白腹鱼狗
+Megaceryle lugubris_冠鱼狗
+Megaceryle maxima_大鱼狗
+Megaceryle torquata_棕腹鱼狗
+Megalurus palustris_沼泽大尾莺
+Megapodius cumingii_菲律宾塚雉
+Megapodius eremita_红斑塚雉
+Megapodius freycinet_暗色塚雉
+Megapodius reinwardt_橙脚塚雉
+Megarynchus pitangua_船嘴霸鹟
+Megascops albogularis_白喉角鸮
+Megascops asio_东美角鸮
+Megascops atricapilla_黑顶角鸮
+Megascops centralis_乔科角鸮
+Megascops choliba_热带角鸮
+Megascops clarkii_裸胫角鸮
+Megascops cooperi_太平洋角鸮
+Megascops gilesi_圣玛尔塔角鸮
+Megascops guatemalae_中美角鸮
+Megascops hoyi_霍氏角鸮
+Megascops ingens_萨氏角鸮
+Megascops kennicottii_西美角鸮
+Megascops koepckeae_马氏角鸮
+Megascops petersoni_桂红角鸮
+Megascops roboratus_秘鲁角鸮
+Megascops roraimae_委内瑞拉角鸮
+Megascops sanctaecatarinae_长簇角鸮
+Megascops seductus_巴尔萨斯角鸮
+Megascops trichopsis_长耳须角鸮
+Megascops watsonii_茶腹角鸮
+Megastictus margaritatus_珠翅蚁鵙
+Megaxenops parnaguae_大翘嘴雀
+Meiglyptes tristis_黄腰斑啄木鸟
+Meiglyptes tukki_黄颈斑啄木鸟
+Melaenornis edolioides_黑鹟
+Melaenornis fischeri_白眼黑鹟
+Melaenornis pammelaina_南非黑鹟
+Melaenornis silens_白翅斑黑鹟
+Melampitta lugubris_小黑脚风鸟
+Melanerpes aurifrons_金额啄木鸟
+Melanerpes cactorum_白额啄木鸟
+Melanerpes candidus_白啄木鸟
+Melanerpes carolinus_红腹啄木鸟
+Melanerpes chrysauchen_金枕啄木鸟
+Melanerpes chrysogenys_金颊啄木鸟
+Melanerpes cruentatus_黄须啄木鸟
+Melanerpes erythrocephalus_红头啄木鸟
+Melanerpes flavifrons_黄额啄木鸟
+Melanerpes formicivorus_橡树啄木鸟
+Melanerpes hoffmannii_霍氏啄木鸟
+Melanerpes hypopolius_灰胸啄木鸟
+Melanerpes lewis_刘氏啄木鸟
+Melanerpes portoricensis_波多黎各啄木鸟
+Melanerpes pucherani_黑颊啄木鸟
+Melanerpes pygmaeus_尤卡坦啄木鸟
+Melanerpes radiolatus_牙买加啄木鸟
+Melanerpes rubricapillus_红冠啄木鸟
+Melanerpes striatus_拉美啄木鸟
+Melanerpes superciliaris_大红腹啄木鸟
+Melanerpes uropygialis_吉拉啄木鸟
+Melaniparus afer_灰山雀
+Melaniparus albiventris_白胸山雀
+Melaniparus cinerascens_阿卡山雀
+Melaniparus funereus_暗色山雀
+Melaniparus leucomelas_白翅黑山雀
+Melaniparus niger_南黑山雀
+Melaniparus rufiventris_棕胸山雀
+Melaniparus thruppi_索马里山雀
+Melanitta americana_黑海番鸭
+Melanitta fusca_丝绒海番鸭
+Melanitta nigra_普通海番鸭
+Melanitta perspicillata_斑头海番鸭
+Melanochlora sultanea_冕雀
+Melanocorypha calandra_草原百灵
+Melanocorypha maxima_长嘴百灵
+Melanodera melanodera_黑喉雀鹀
+Melanodera xanthogramma_黄纹雀鹀
+Melanodryas cucullata_冠鸲鹟
+Melanodryas vittata_暗色鸲鹟
+Melanopareia elegans_丽月胸窜鸟
+Melanopareia maranonica_秘鲁月胸窜鸟
+Melanopareia maximiliani_绿冠月胸窜鸟
+Melanopareia torquata_领月胸窜鸟
+Melanoptila glabrirostris_黑嘲鸫
+Melanorectes nigrescens_黑林鵙鹟
+Melanospiza bicolor_黑脸草雀
+Melanotis caerulescens_蓝嘲鸫
+Melanotis hypoleucus_蓝白嘲鸫
+Meleagris gallopavo_火鸡
+Meleagris ocellata_眼斑火鸡
+Meliarchus sclateri_圣克里吸蜜鸟
+Melidectes belfordi_博氏寻蜜鸟
+Melidectes rufocrissalis_黄眉寻蜜鸟
+Melidora macrorrhina_钩嘴翠鸟
+Meliphaga lewinii_利氏吸蜜鸟
+Meliphaga notata_黄斑吸蜜鸟
+Melithreptus affinis_黑头抚蜜鸟
+Melithreptus albogularis_白喉抚蜜鸟
+Melithreptus brevirostris_褐头抚蜜鸟
+Melithreptus chloropsis_西白颈抚蜜鸟
+Melithreptus gularis_黑颏抚蜜鸟
+Melithreptus lunatus_白颈抚蜜鸟
+Melithreptus validirostris_坚嘴抚蜜鸟
+Mellisuga helenae_吸蜜蜂鸟
+Mellisuga minima_小吸蜜蜂鸟
+Melocichla mentalis_须薮莺
+Melopsittacus undulatus_虎皮鹦鹉
+Melopyrrha portoricensis_波多黎各牛雀
+Melopyrrha violacea_大安德牛雀
+Melospiza georgiana_沼泽带鹀
+Melospiza lincolnii_林氏带鹀
+Melospiza melodia_歌带鹀
+Melozone aberti_红腹唧鹀
+Melozone albicollis_白喉唧鹀
+Melozone biarcuata_普氏地雀
+Melozone cabanisi_哥斯达黎加地雀
+Melozone crissalis_加州唧鹀
+Melozone fusca_棕喉唧鹀
+Melozone kieneri_锈顶地雀
+Melozone leucotis_白耳地雀
+Menura alberti_艾氏琴鸟
+Menura novaehollandiae_华丽琴鸟
+Mergellus albellus_斑头秋沙鸭
+Mergus merganser_普通秋沙鸭
+Mergus serrator_红胸秋沙鸭
+Merops albicollis_白喉蜂虎
+Merops apiaster_黄喉蜂虎
+Merops bullockoides_白额蜂虎
+Merops bulocki_赤喉蜂虎
+Merops hirundineus_燕尾蜂虎
+Merops leschenaulti_栗头蜂虎
+Merops oreobates_红胸蜂虎
+Merops orientalis_绿喉蜂虎
 Merops ornatus_彩虹蜂虎
-Merops persicus_藍頰蜂虎
+Merops persicus_蓝颊蜂虎
 Merops philippinus_栗喉蜂虎
-Merops pusillus_Little Bee-eater
-Merops superciliosus_Madagascar Bee-eater
-Merops variegatus_Blue-breasted Bee-eater
-Merops viridis_藍喉蜂虎
-Merulaxis ater_Slaty Bristlefront
-Mesembrinibis cayennensis_Green Ibis
-Mesitornis unicolor_Brown Mesite
-Mesitornis variegatus_White-breasted Mesite
-Metallura tyrianthina_Tyrian Metaltail
-Metallura williami_Viridian Metaltail
-Metopidius indicus_Bronze-winged Jacana
-Metopothrix aurantiaca_Orange-fronted Plushcrown
-Metriopelia melanoptera_Black-winged Ground Dove
-Micrastur buckleyi_Buckley's Forest-Falcon
-Micrastur gilvicollis_Lined Forest-Falcon
-Micrastur mintoni_Cryptic Forest-Falcon
-Micrastur mirandollei_Slaty-backed Forest-Falcon
-Micrastur ruficollis_Barred Forest-Falcon
-Micrastur semitorquatus_Collared Forest-Falcon
-Micrathene whitneyi_Elf Owl
-Microbates cinereiventris_Tawny-faced Gnatwren
-Microbates collaris_Collared Gnatwren
-Microcarbo niger_Little Cormorant
+Merops pusillus_小蜂虎
+Merops superciliosus_马岛蜂虎
+Merops variegatus_蓝胸蜂虎
+Merops viridis_蓝喉蜂虎
+Merulaxis ater_须额窜鸟
+Mesembrinibis cayennensis_绿鹮
+Mesitornis unicolor_褐拟鹑
+Mesitornis variegatus_白胸拟鹑
+Metallura tyrianthina_紫辉尾蜂鸟
+Metallura williami_翠绿辉尾蜂鸟
+Metopidius indicus_铜翅水雉
+Metopothrix aurantiaca_橙额绒顶雀
+Metriopelia melanoptera_黑翅地鸠
+Micrastur buckleyi_巴氏林隼
+Micrastur gilvicollis_细纹林隼
+Micrastur mintoni_隐林隼
+Micrastur mirandollei_灰背林隼
+Micrastur ruficollis_斑林隼
+Micrastur semitorquatus_领林隼
+Micrathene whitneyi_娇鸺鹠
+Microbates cinereiventris_半领蚋莺
+Microbates collaris_领蚋莺
+Microcarbo niger_黑颈鸬鹚
 Microcentrum rhombifolium_Greater Angle-wing
-Microcerculus bambla_Wing-banded Wren
-Microcerculus marginatus_Scaly-breasted Wren
-Microcerculus philomela_Nightingale Wren
-Microcerculus ustulatus_Flutist Wren
-Microeca fascinans_Jacky-winter
-Microeca flavigaster_Lemon-bellied Flycatcher
-Microhierax fringillarius_Black-thighed Falconet
-Micromonacha lanceolata_Lanceolated Monklet
-Micronisus gabar_Gabar Goshawk
-Micropsitta finschii_Finsch's Pygmy-Parrot
-Micropternus brachyurus_Rufous Woodpecker
-Micropygia schomburgkii_Ocellated Crake
-Microrhopias quixensis_Dot-winged Antwren
-Microspingus cabanisi_Gray-throated Warbling Finch
-Microspingus erythrophrys_Rusty-browed Warbling Finch
-Microspingus lateralis_Buff-throated Warbling Finch
-Microspingus melanoleucus_Black-capped Warbling Finch
-Microspingus torquatus_Ringed Warbling Finch
-Microxenops milleri_Rufous-tailed Xenops
-Milvago chimachima_Yellow-headed Caracara
-Milvago chimango_Chimango Caracara
-Milvus migrans_黑鳶
-Milvus milvus_Red Kite
-Mimus dorsalis_Brown-backed Mockingbird
-Mimus gilvus_Tropical Mockingbird
-Mimus gundlachii_Bahama Mockingbird
-Mimus longicaudatus_Long-tailed Mockingbird
-Mimus patagonicus_Patagonian Mockingbird
-Mimus polyglottos_Northern Mockingbird
-Mimus saturninus_Chalk-browed Mockingbird
-Mimus thenca_Chilean Mockingbird
-Mimus triurus_White-banded Mockingbird
-Minla ignotincta_Red-tailed Minla
-Mino dumontii_Yellow-faced Myna
-Mino kreffti_Long-tailed Myna
+Microcerculus bambla_斑翅鹪鹩
+Microcerculus marginatus_鳞胸鹪鹩
+Microcerculus philomela_夜莺鹪鹩
+Microcerculus ustulatus_笛声鹪鹩
+Microeca fascinans_褐背小鹟
+Microeca flavigaster_黄胸小鹟
+Microhierax fringillarius_黑腿小隼 
+Micromonacha lanceolata_矛蓬头䴕
+Micronisus gabar_小歌鹰
+Micropsitta finschii_芬氏侏鹦鹉
+Micropternus brachyurus_栗啄木鸟
+Micropygia schomburgkii_眼斑田鸡
+Microrhopias quixensis_斑翅蚁鹩
+Microspingus cabanisi_灰喉歌鹀
+Microspingus erythrophrys_锈眉歌鹀
+Microspingus lateralis_红腰歌鹀
+Microspingus melanoleucus_黑顶歌鹀
+Microspingus torquatus_黑领歌鹀
+Microxenops milleri_棕尾翘嘴雀
+Milvago chimachima_黄头叫隼
+Milvago chimango_叫隼
+Milvus migrans_黑鸢
+Milvus milvus_赤鸢
+Mimus dorsalis_棕背小嘲鸫
+Mimus gilvus_热带小嘲鸫
+Mimus gundlachii_巴哈马小嘲鸫
+Mimus longicaudatus_长尾小嘲鸫
+Mimus patagonicus_南美小嘲鸫
+Mimus polyglottos_小嘲鸫
+Mimus saturninus_淡褐小嘲鸫
+Mimus thenca_智利小嘲鸫
+Mimus triurus_白斑小嘲鸫
+Minla ignotincta_火尾希鹛
+Mino dumontii_黄脸树八哥
+Mino kreffti_长尾树八哥
 Miogryllus saussurei_Miogryllus saussurei
-Mionectes macconnelli_McConnell's Flycatcher
-Mionectes oleagineus_Ochre-bellied Flycatcher
-Mionectes olivaceus_Olive-striped Flycatcher (Olive-streaked)
-Mionectes rufiventris_Gray-hooded Flycatcher
-Mionectes striaticollis_Streak-necked Flycatcher
+Mionectes macconnelli_麦氏霸鹟
+Mionectes oleagineus_赭腹霸鹟
+Mionectes olivaceus_灰橄榄绿纹霸鹟
+Mionectes rufiventris_灰冠霸鹟
+Mionectes striaticollis_纹颈霸鹟
 Mirafra affinis_Jerdon's Bushlark
-Mirafra africana_Rufous-naped Lark
-Mirafra apiata_Cape Clapper Lark
+Mirafra africana_棕颈歌百灵
+Mirafra apiata_振翅歌百灵
 Mirafra assamica_Bengal Bushlark
 Mirafra cantillans_Singing Bushlark
-Mirafra cheniana_Latakoo Lark
+Mirafra cheniana_南非歌百灵
 Mirafra erythrocephala_Indochinese Bushlark
 Mirafra erythroptera_Indian Bushlark
-Mirafra fasciolata_Eastern Clapper Lark
-Mirafra javanica_Singing Bushlark
-Mirafra passerina_Monotonous Lark
-Mirafra rufocinnamomea_Flappet Lark
-Mitrephanes phaeocercus_Tufted Flycatcher
-Mitrospingus cassinii_Dusky-faced Tanager
-Mitrospingus oleagineus_Olive-backed Tanager
-Mitu salvini_Salvin's Curassow
-Mitu tomentosum_Crestless Curassow
-Mitu tuberosum_Razor-billed Curassow
-Mixornis bornensis_Bold-striped Tit-Babbler
-Mixornis flavicollis_Gray-cheeked Tit-Babbler
-Mixornis gularis_Pin-striped Tit-Babbler
-Mixornis kelleyi_Gray-faced Tit-Babbler
-Mniotilta varia_Black-and-white Warbler
-Modulatrix stictigula_Spot-throat
-Mohoua albicilla_Whitehead
-Mohoua novaeseelandiae_Pipipi
-Mohoua ochrocephala_Yellowhead
-Molothrus aeneus_Bronzed Cowbird
-Molothrus ater_Brown-headed Cowbird
-Molothrus bonariensis_Shiny Cowbird
-Molothrus oryzivorus_Giant Cowbird
-Molothrus rufoaxillaris_Screaming Cowbird
-Momotus aequatorialis_Andean Motmot
-Momotus coeruliceps_Blue-capped Motmot
-Momotus lessonii_Lesson's Motmot
-Momotus mexicanus_Russet-crowned Motmot
-Momotus momota_Amazonian Motmot
-Momotus subrufescens_Whooping Motmot
-Monarcha castaneiventris_Chestnut-bellied Monarch
-Monarcha frater_Black-winged Monarch
-Monarcha melanopsis_Black-faced Monarch
-Monarcha richardsii_White-capped Monarch
-Monasa atra_Black Nunbird
-Monasa flavirostris_Yellow-billed Nunbird
-Monasa morphoeus_White-fronted Nunbird
-Monasa nigrifrons_Black-fronted Nunbird
-Montecincla fairbanki_Palani Laughingthrush
-Monticola cinclorhyncha_Blue-capped Rock-Thrush
-Monticola gularis_白喉磯鶇
-Monticola rufiventris_Chestnut-bellied Rock-Thrush
-Monticola rupestris_Cape Rock-Thrush
-Monticola saxatilis_Rufous-tailed Rock-Thrush
-Monticola sharpei_Forest Rock-Thrush
-Monticola solitarius_藍磯鶇
-Montifringilla blanfordi_Blanford's Snowfinch
-Montifringilla nivalis_White-winged Snowfinch
-Montifringilla taczanowskii_White-rumped Snowfinch
-Morococcyx erythropygus_Lesser Ground-Cuckoo
-Morphnarchus princeps_Barred Hawk
-Morphnus guianensis_Crested Eagle
-Morus bassanus_Northern Gannet
-Motacilla aguimp_African Pied Wagtail
-Motacilla alba_白鶺鴒
-Motacilla capensis_Cape Wagtail
-Motacilla cinerea_灰鶺鴒
-Motacilla citreola_黃頭鶺鴒
-Motacilla clara_Mountain Wagtail
-Motacilla flava_西方黃鶺鴒
-Motacilla flaviventris_Madagascar Wagtail
-Motacilla grandis_日本鶺鴒
-Motacilla maderaspatensis_White-browed Wagtail
-Motacilla tschutschensis_東方黃鶺鴒
-Mulleripicus fulvus_Ashy Woodpecker
-Mulleripicus pulverulentus_Great Slaty Woodpecker
-Muscicapa adusta_African Dusky Flycatcher
-Muscicapa aquatica_Swamp Flycatcher
-Muscicapa dauurica_寬嘴鶲
-Muscicapa ferruginea_紅尾鶲
-Muscicapa griseisticta_灰斑鶲
-Muscicapa muttui_褐胸鶲
-Muscicapa sibirica_烏鶲
-Muscicapa striata_斑鶲
-Muscicapa williamsoni_Brown-streaked Flycatcher
-Muscigralla brevicauda_Short-tailed Field Tyrant
-Muscipipra vetula_Shear-tailed Gray Tyrant
-Muscisaxicola albilora_White-browed Ground-Tyrant
-Muscisaxicola maculirostris_Spot-billed Ground-Tyrant
-Musophaga rossae_Ross's Turaco
-Mustelirallus albicollis_Ash-throated Crake
-Mustelirallus erythrops_Paint-billed Crake
-Myadestes coloratus_Varied Solitaire
-Myadestes elisabeth_Cuban Solitaire
-Myadestes genibarbis_Rufous-throated Solitaire
-Myadestes melanops_Black-faced Solitaire
-Myadestes obscurus_Omao
-Myadestes occidentalis_Brown-backed Solitaire
-Myadestes palmeri_Puaiohi
-Myadestes ralloides_Andean Solitaire
-Myadestes townsendi_Townsend's Solitaire
-Myadestes unicolor_Slate-colored Solitaire
-Mycerobas affinis_Collared Grosbeak
-Mycerobas carnipes_White-winged Grosbeak
-Mycerobas icterioides_Black-and-yellow Grosbeak
-Mycteria americana_Wood Stork
-Mycteria leucocephala_Painted Stork
-Myiagra alecto_Shining Flycatcher
-Myiagra caledonica_Melanesian Flycatcher
-Myiagra cyanoleuca_Satin Flycatcher
-Myiagra ferrocyanea_Steel-blue Flycatcher
-Myiagra galeata_Moluccan Flycatcher
-Myiagra inquieta_Restless Flycatcher
-Myiagra nana_Paperbark Flycatcher
-Myiagra rubecula_Leaden Flycatcher
-Myiagra ruficollis_Broad-billed Flycatcher
-Myiagra vanikorensis_Vanikoro Flycatcher
-Myiarchus antillarum_Puerto Rican Flycatcher
-Myiarchus apicalis_Apical Flycatcher
-Myiarchus barbirostris_Sad Flycatcher
-Myiarchus cephalotes_Pale-edged Flycatcher
-Myiarchus cinerascens_Ash-throated Flycatcher
-Myiarchus crinitus_Great Crested Flycatcher
-Myiarchus ferox_Short-crested Flycatcher
-Myiarchus nuttingi_Nutting's Flycatcher
-Myiarchus panamensis_Panama Flycatcher
-Myiarchus phaeocephalus_Sooty-crowned Flycatcher
-Myiarchus sagrae_La Sagra's Flycatcher
-Myiarchus stolidus_Stolid Flycatcher
-Myiarchus swainsoni_Swainson's Flycatcher
-Myiarchus tuberculifer_Dusky-capped Flycatcher
-Myiarchus tyrannulus_Brown-crested Flycatcher
-Myiarchus venezuelensis_Venezuelan Flycatcher
-Myiarchus yucatanensis_Yucatan Flycatcher
-Myiobius atricaudus_Black-tailed Flycatcher
-Myiobius barbatus_Whiskered Flycatcher
-Myiobius sulphureipygius_Sulphur-rumped Flycatcher
-Myioborus albifrons_White-fronted Redstart
-Myioborus brunniceps_Brown-capped Redstart
-Myioborus castaneocapilla_Tepui Redstart
-Myioborus flavivertex_Yellow-crowned Redstart
-Myioborus melanocephalus_Spectacled Redstart
-Myioborus miniatus_Slate-throated Redstart
-Myioborus ornatus_Golden-fronted Redstart
-Myioborus pictus_Painted Redstart
-Myioborus torquatus_Collared Redstart
-Myiodynastes bairdii_Baird's Flycatcher
-Myiodynastes chrysocephalus_Golden-crowned Flycatcher
-Myiodynastes hemichrysus_Golden-bellied Flycatcher
-Myiodynastes luteiventris_Sulphur-bellied Flycatcher
-Myiodynastes maculatus_Streaked Flycatcher
-Myiomela leucura_白尾鴝
-Myiopagis caniceps_Gray Elaenia (Gray-headed)
-Myiopagis flavivertex_Yellow-crowned Elaenia
-Myiopagis gaimardii_Forest Elaenia
-Myiopagis olallai_Foothill Elaenia
-Myiopagis subplacens_Pacific Elaenia
-Myiopagis viridicata_Greenish Elaenia
-Myiophobus cryptoxanthus_Olive-chested Flycatcher
-Myiophobus fasciatus_Bran-colored Flycatcher
-Myiophobus flavicans_Flavescent Flycatcher
-Myiophobus phoenicomitra_Orange-crested Flycatcher
-Myiopsitta monachus_和尚鸚鵡
-Myiornis albiventris_White-bellied Pygmy-Tyrant
-Myiornis atricapillus_Black-capped Pygmy-Tyrant
-Myiornis auricularis_Eared Pygmy-Tyrant
-Myiornis ecaudatus_Short-tailed Pygmy-Tyrant
-Myiotheretes fumigatus_Smoky Bush-Tyrant
-Myiotheretes fuscorufus_Rufous-bellied Bush-Tyrant
-Myiotheretes pernix_Santa Marta Bush-Tyrant
-Myiotheretes striaticollis_Streak-throated Bush-Tyrant
-Myiothlypis basilica_Santa Marta Warbler
-Myiothlypis bivittata_Two-banded Warbler
-Myiothlypis chrysogaster_Golden-bellied Warbler (Golden-bellied)
-Myiothlypis cinereicollis_Gray-throated Warbler
-Myiothlypis conspicillata_White-lored Warbler
-Myiothlypis coronata_Russet-crowned Warbler
-Myiothlypis flaveola_Flavescent Warbler
-Myiothlypis fraseri_Gray-and-gold Warbler
-Myiothlypis fulvicauda_Buff-rumped Warbler
-Myiothlypis leucoblephara_White-browed Warbler
-Myiothlypis leucophrys_White-striped Warbler
-Myiothlypis luteoviridis_Citrine Warbler
-Myiothlypis nigrocristata_Black-crested Warbler
-Myiothlypis rivularis_Riverbank Warbler
-Myiothlypis signata_Pale-legged Warbler
-Myiotriccus ornatus_Ornate Flycatcher
-Myiozetetes cayanensis_Rusty-margined Flycatcher
-Myiozetetes granadensis_Gray-capped Flycatcher
-Myiozetetes luteiventris_Dusky-chested Flycatcher
-Myiozetetes similis_Social Flycatcher
-Myophonus caeruleus_白斑紫嘯鶇
-Myophonus horsfieldii_Malabar Whistling-Thrush
-Myophonus insularis_台灣紫嘯鶇
-Myophonus melanurus_Shiny Whistling-Thrush
-Myornis senilis_Ash-colored Tapaculo
-Myrmeciza longipes_White-bellied Antbird
-Myrmecocichla aethiops_Northern Anteater-Chat
-Myrmecocichla arnotti_Arnot's Chat
-Myrmecocichla formicivora_Southern Anteater-Chat
-Myrmecocichla monticola_Mountain Wheatear
-Myrmecocichla nigra_Sooty Chat
-Myrmelastes humaythae_Humaita Antbird
-Myrmelastes hyperythrus_Plumbeous Antbird
-Myrmelastes leucostigma_Spot-winged Antbird
-Myrmelastes rufifacies_Rufous-faced Antbird
-Myrmelastes schistaceus_Slate-colored Antbird
-Myrmoborus leucophrys_White-browed Antbird
-Myrmoborus lophotes_White-lined Antbird
-Myrmoborus lugubris_Ash-breasted Antbird
-Myrmoborus melanurus_Black-tailed Antbird
-Myrmoborus myotherinus_Black-faced Antbird
-Myrmochanes hemileucus_Black-and-white Antbird
-Myrmoderus ferrugineus_Ferruginous-backed Antbird
-Myrmoderus loricatus_White-bibbed Antbird
-Myrmoderus ruficauda_Scalloped Antbird
-Myrmoderus squamosus_Squamate Antbird
-Myrmophylax atrothorax_Black-throated Antbird
-Myrmorchilus strigilatus_Stripe-backed Antbird
-Myrmornis torquata_Wing-banded Antbird
-Myrmothera berlepschi_Amazonian Antpitta
-Myrmothera campanisona_Thrush-like Antpitta
-Myrmothera dives_Thicket Antpitta
-Myrmothera fulviventris_White-lored Antpitta
-Myrmothera simplex_Tepui Antpitta
-Myrmothera subcanescens_Tapajos Antpitta
-Myrmotherula ambigua_Yellow-throated Antwren
-Myrmotherula assimilis_Leaden Antwren
-Myrmotherula axillaris_White-flanked Antwren
-Myrmotherula brachyura_Pygmy Antwren
-Myrmotherula cherriei_Cherrie's Antwren
-Myrmotherula ignota_Moustached Antwren
-Myrmotherula iheringi_Ihering's Antwren
-Myrmotherula klagesi_Klages's Antwren
-Myrmotherula longicauda_Stripe-chested Antwren
-Myrmotherula longipennis_Long-winged Antwren
-Myrmotherula menetriesii_Gray Antwren
-Myrmotherula minor_Salvadori's Antwren
-Myrmotherula multostriata_Amazonian Streaked-Antwren
-Myrmotherula pacifica_Pacific Antwren
-Myrmotherula schisticolor_Slaty Antwren
-Myrmotherula sclateri_Sclater's Antwren
-Myrmotherula surinamensis_Guianan Streaked-Antwren
-Myrmotherula unicolor_Unicolored Antwren
-Myrmotherula urosticta_Band-tailed Antwren
-Myrtis fanny_Purple-collared Woodstar
-Mystacornis crossleyi_Crossley's Vanga
-Myza sarasinorum_White-eared Myza
-Myzomela cardinalis_Cardinal Myzomela
-Myzomela erythrocephala_Red-headed Myzomela
-Myzomela obscura_Dusky Myzomela
-Myzomela rosenbergii_Red-collared Myzomela
-Myzomela rubratra_Micronesian Myzomela
-Myzomela sanguinolenta_Scarlet Myzomela
-Nannopsittaca panychlora_Tepui Parrotlet
-Nannopterum auritum_Double-crested Cormorant
-Nannopterum brasilianum_Neotropic Cormorant
-Napothera danjoui_Short-tailed Scimitar-Babbler
-Napothera epilepidota_Eyebrowed Wren-Babbler
-Napothera malacoptila_Long-billed Wren-Babbler
-Nasica longirostris_Long-billed Woodcreeper
-Nectarinia famosa_Malachite Sunbird
-Nectarinia kilimensis_Bronze Sunbird
-Nemosia pileata_Hooded Tanager
-Nengetus cinereus_Gray Monjita
-Neochmia phaeton_Crimson Finch
-Neochmia temporalis_Red-browed Firetail
+Mirafra fasciolata_东振翅歌百灵
+Mirafra javanica_歌百灵
+Mirafra passerina_雀歌百灵
+Mirafra rufocinnamomea_垂耳歌百灵
+Mitrephanes phaeocercus_领霸鹟
+Mitrospingus cassinii_乌脸唐纳雀
+Mitrospingus oleagineus_绿背唐纳雀
+Mitu salvini_白腹盔嘴雉
+Mitu tomentosum_无冠盔嘴雉
+Mitu tuberosum_巨嘴盔嘴雉
+Mixornis bornensis_宽纹胸鹛
+Mixornis flavicollis_黄领纹胸鹛
+Mixornis gularis_纹胸鹛
+Mixornis kelleyi_灰脸纹胸鹛
+Mniotilta varia_黑白森莺
+Modulatrix stictigula_斑喉䳭
+Mohoua albicilla_白头刺莺
+Mohoua novaeseelandiae_新西兰刺莺
+Mohoua ochrocephala_黄头刺莺
+Molothrus aeneus_铜色牛鹂
+Molothrus ater_褐头牛鹂
+Molothrus bonariensis_紫辉牛鹂
+Molothrus oryzivorus_巨牛鹂
+Molothrus rufoaxillaris_啸声牛鹂
+Momotus aequatorialis_高原翠鴗
+Momotus coeruliceps_蓝顶翠鴗
+Momotus lessonii_雷氏翠鴗
+Momotus mexicanus_锈顶翠鴗
+Momotus momota_亚马逊翠鴗
+Momotus subrufescens_叫翠鴗
+Monarcha castaneiventris_栗腹王鹟
+Monarcha frater_黑翅王鹟
+Monarcha melanopsis_黑脸王鹟
+Monarcha richardsii_里氏王鹟
+Monasa atra_黑䴕
+Monasa flavirostris_黄嘴黑䴕
+Monasa morphoeus_白额黑䴕
+Monasa nigrifrons_黑额黑䴕
+Montecincla fairbanki_暗灰胸噪鹛
+Monticola cinclorhyncha_蓝头矶鸫
+Monticola gularis_白喉矶鸫
+Monticola rufiventris_栗腹矶鸫
+Monticola rupestris_南非矶鸫
+Monticola saxatilis_白背矶鸫
+Monticola sharpei_岩鸲鸫
+Monticola solitarius_蓝矶鸫
+Montifringilla blanfordi_棕背雪雀
+Montifringilla nivalis_白斑翅雪雀
+Montifringilla taczanowskii_白腰雪雀
+Morococcyx erythropygus_小地鹃
+Morphnarchus princeps_横斑南美鵟
+Morphnus guianensis_冠雕
+Morus bassanus_北鲣鸟
+Motacilla aguimp_非洲斑鹡鸰
+Motacilla alba_白鹡鸰
+Motacilla capensis_海角鹡鸰
+Motacilla cinerea_灰鹡鸰
+Motacilla citreola_黄头鹡鸰
+Motacilla clara_非洲山鹡鸰
+Motacilla flava_西黄鹡鸰
+Motacilla flaviventris_马岛鹡鸰
+Motacilla grandis_日本鹡鸰
+Motacilla maderaspatensis_大斑鹡鸰
+Motacilla tschutschensis_黄鹡鸰
+Mulleripicus fulvus_暗黄啄木鸟
+Mulleripicus pulverulentus_大灰啄木鸟
+Muscicapa adusta_暗鹟
+Muscicapa aquatica_泽鹟
+Muscicapa dauurica_北灰鹟
+Muscicapa ferruginea_棕尾褐鹟
+Muscicapa griseisticta_灰纹鹟
+Muscicapa muttui_褐胸鹟
+Muscicapa sibirica_乌鹟
+Muscicapa striata_斑鹟
+Muscicapa williamsoni_褐纹鹟
+Muscigralla brevicauda_短尾田霸鹟
+Muscipipra vetula_剪尾灰霸鹟
+Muscisaxicola albilora_白眉地霸鹟
+Muscisaxicola maculirostris_斑嘴地霸鹟
+Musophaga rossae_短冠紫蕉鹃
+Mustelirallus albicollis_灰喉田鸡
+Mustelirallus erythrops_彩喙秧鸡
+Myadestes coloratus_多色孤鸫
+Myadestes elisabeth_古巴孤鸫
+Myadestes genibarbis_棕喉孤鸫
+Myadestes melanops_黑脸孤鸫
+Myadestes obscurus_夏威夷鸫
+Myadestes occidentalis_褐背孤鸫
+Myadestes palmeri_小考岛鸫
+Myadestes ralloides_安第斯孤鸫
+Myadestes townsendi_坦氏孤鸫
+Myadestes unicolor_灰孤鸫
+Mycerobas affinis_黄颈拟蜡嘴雀
+Mycerobas carnipes_白斑翅拟蜡嘴雀
+Mycerobas icterioides_黄腹拟蜡嘴雀
+Mycteria americana_黑头鹮鹳
+Mycteria leucocephala_彩鹳
+Myiagra alecto_辉阔嘴鹟
+Myiagra caledonica_美岛阔嘴鹟
+Myiagra cyanoleuca_缎辉阔嘴鹟
+Myiagra ferrocyanea_所罗门阔嘴鹟
+Myiagra galeata_盔阔嘴鹟
+Myiagra inquieta_大阔嘴鹟
+Myiagra nana_小阔嘴鹟
+Myiagra rubecula_铅灰阔嘴鹟
+Myiagra ruficollis_棕颈阔嘴鹟
+Myiagra vanikorensis_瓦岛阔嘴鹟
+Myiarchus antillarum_波多黎各蝇霸鹟
+Myiarchus apicalis_尖顶蝇霸鹟
+Myiarchus barbirostris_牙买加蝇霸鹟
+Myiarchus cephalotes_淡边蝇霸鹟
+Myiarchus cinerascens_灰喉蝇霸鹟
+Myiarchus crinitus_大冠蝇霸鹟
+Myiarchus ferox_短冠蝇霸鹟
+Myiarchus nuttingi_淡喉蝇霸鹟
+Myiarchus panamensis_巴拿马蝇霸鹟
+Myiarchus phaeocephalus_乌冠蝇霸鹟
+Myiarchus sagrae_拉氏蝇霸鹟
+Myiarchus stolidus_憨蝇霸鹟
+Myiarchus swainsoni_斯氏蝇霸鹟
+Myiarchus tuberculifer_暗顶蝇霸鹟
+Myiarchus tyrannulus_褐冠蝇霸鹟
+Myiarchus venezuelensis_委内瑞拉蝇霸鹟
+Myiarchus yucatanensis_尤卡坦蝇霸鹟
+Myiobius atricaudus_黑尾黄腰霸鹟
+Myiobius barbatus_须黄腰霸鹟
+Myiobius sulphureipygius_硫磺腰霸鹟
+Myioborus albifrons_白额鸲莺
+Myioborus brunniceps_褐顶鸲莺
+Myioborus castaneocapilla_泰普鸲莺
+Myioborus flavivertex_黄顶鸲莺
+Myioborus melanocephalus_黑头鸲莺
+Myioborus miniatus_暗喉鸲莺
+Myioborus ornatus_金额鸲莺
+Myioborus pictus_彩鸲莺
+Myioborus torquatus_黑领鸲莺
+Myiodynastes bairdii_比氏大嘴霸鹟
+Myiodynastes chrysocephalus_金顶大嘴霸鹟
+Myiodynastes hemichrysus_金腹大嘴霸鹟
+Myiodynastes luteiventris_黄腹大嘴霸鹟
+Myiodynastes maculatus_纹大嘴霸鹟
+Myiomela leucura_白尾蓝地鸲
+Myiopagis caniceps_灰色伊拉鹟
+Myiopagis flavivertex_黄顶伊拉鹟
+Myiopagis gaimardii_林伊拉鹟
+Myiopagis olallai_山地伊拉鹟
+Myiopagis subplacens_太平洋伊拉鹟
+Myiopagis viridicata_绿伊拉鹟
+Myiophobus cryptoxanthus_绿胸斑翅霸鹟
+Myiophobus fasciatus_浅褐斑翅霸鹟
+Myiophobus flavicans_黄斑翅霸鹟
+Myiophobus phoenicomitra_橙冠斑翅霸鹟
+Myiopsitta monachus_灰胸鹦哥
+Myiornis albiventris_白胸侏霸鹟
+Myiornis atricapillus_黑顶侏霸鹟
+Myiornis auricularis_角侏霸鹟
+Myiornis ecaudatus_短尾侏霸鹟
+Myiotheretes fumigatus_烟色丛霸鹟
+Myiotheretes fuscorufus_棕腹丛霸鹟
+Myiotheretes pernix_哥伦比亚丛霸鹟
+Myiotheretes striaticollis_纹喉丛霸鹟
+Myiothlypis basilica_黑头王森莺
+Myiothlypis bivittata_双斑王森莺
+Myiothlypis chrysogaster_金腹王森莺
+Myiothlypis cinereicollis_灰喉王森莺
+Myiothlypis conspicillata_白眼先王森莺
+Myiothlypis coronata_褐冠王森莺
+Myiothlypis flaveola_黄王森莺
+Myiothlypis fraseri_灰黄王森莺
+Myiothlypis fulvicauda_黄腰王森莺
+Myiothlypis leucoblephara_白眉王森莺
+Myiothlypis leucophrys_白纹王森莺
+Myiothlypis luteoviridis_柠黄王森莺
+Myiothlypis nigrocristata_黑冠王森莺
+Myiothlypis rivularis_河岸王森莺
+Myiothlypis signata_淡脚王森莺
+Myiotriccus ornatus_华丽霸鹟
+Myiozetetes cayanensis_锈边短嘴霸鹟
+Myiozetetes granadensis_灰顶短嘴霸鹟
+Myiozetetes luteiventris_暗胸短嘴霸鹟
+Myiozetetes similis_群栖短嘴霸鹟
+Myophonus caeruleus_紫啸鸫
+Myophonus horsfieldii_印度啸鸫
+Myophonus insularis_台湾紫啸鸫
+Myophonus melanurus_辉亮啸鸫
+Myornis senilis_灰窜鸟
+Myrmeciza longipes_白腹蚁鸟
+Myrmecocichla aethiops_蚁䳭
+Myrmecocichla arnotti_阿氏蚁䳭
+Myrmecocichla formicivora_南方蚁䳭
+Myrmecocichla monticola_山䳭
+Myrmecocichla nigra_暗色蚁䳭
+Myrmelastes humaythae_乌迈塔蚁鸟
+Myrmelastes hyperythrus_铅色蚁鸟
+Myrmelastes leucostigma_点翅蚁鸟
+Myrmelastes rufifacies_棕脸蚁鸟
+Myrmelastes schistaceus_蓝灰蚁鸟
+Myrmoborus leucophrys_白眉蚁鸟
+Myrmoborus lophotes_棕冠蚁鸟
+Myrmoborus lugubris_灰胸蚁鸟
+Myrmoborus melanurus_黑尾蚁鸟
+Myrmoborus myotherinus_黑脸蚁鸟
+Myrmochanes hemileucus_黑白蚁鸟
+Myrmoderus ferrugineus_棕背蚁鸟
+Myrmoderus loricatus_白枕蚁鸟
+Myrmoderus ruficauda_扇尾蚁鸟
+Myrmoderus squamosus_鳞纹蚁鸟
+Myrmophylax atrothorax_黑喉蚁鸟
+Myrmorchilus strigilatus_纹背蚁鹩
+Myrmornis torquata_斑翅蚁鸟
+Myrmothera berlepschi_亚马孙蚁鸫
+Myrmothera campanisona_拟鸫蚁鸫
+Myrmothera dives_黄腹蚁鸫
+Myrmothera fulviventris_白眼先蚁鸫
+Myrmothera simplex_褐胸蚁鸫
+Myrmothera subcanescens_塔河蚁鸫
+Myrmotherula ambigua_黄喉蚁鹩
+Myrmotherula assimilis_铅色蚁鹩
+Myrmotherula axillaris_白胁蚁鹩
+Myrmotherula brachyura_姬蚁鹩
+Myrmotherula cherriei_红蚁鹩
+Myrmotherula ignota_须蚁鹩
+Myrmotherula iheringi_亚马孙蚁鹩
+Myrmotherula klagesi_凯氏蚁鹩
+Myrmotherula longicauda_纹胸蚁鹩
+Myrmotherula longipennis_长翅蚁鹩
+Myrmotherula menetriesii_灰蚁鹩
+Myrmotherula minor_小蚁鹩
+Myrmotherula multostriata_亚马孙纵纹蚁鹩
+Myrmotherula pacifica_太平洋纵纹蚁鹩
+Myrmotherula schisticolor_蓝灰蚁鹩
+Myrmotherula sclateri_巴西蚁鹩
+Myrmotherula surinamensis_纵纹蚁鹩
+Myrmotherula unicolor_纯色蚁鹩
+Myrmotherula urosticta_斑尾蚁鹩
+Myrtis fanny_紫领蜂鸟
+Mystacornis crossleyi_克氏须鹛
+Myza sarasinorum_白耳汲蜜鸟
+Myzomela cardinalis_深红摄蜜鸟
+Myzomela erythrocephala_红头摄蜜鸟
+Myzomela obscura_暗摄蜜鸟
+Myzomela rosenbergii_红领摄蜜鸟
+Myzomela rubratra_密岛摄蜜鸟
+Myzomela sanguinolenta_绯红摄蜜鸟
+Nannopsittaca panychlora_特布伊鹦哥
+Nannopterum auritum_角鸬鹚
+Nannopterum brasilianum_美洲鸬鹚
+Napothera danjoui_短尾钩嘴鹛
+Napothera epilepidota_纹胸鹪鹛
+Napothera malacoptila_长嘴鹩鹛
+Nasica longirostris_长嘴䴕雀
+Nectarinia famosa_辉绿花蜜鸟
+Nectarinia kilimensis_长尾铜花蜜鸟
+Nemosia pileata_黑顶唐纳雀
+Nengetus cinereus_灰蒙霸鹟
+Neochmia phaeton_赤胸星雀
+Neochmia temporalis_红眉火尾雀
 Neoconocephalus bivocatus_False Robust Conehead
 Neoconocephalus ensiger_Sword-bearing Conehead
 Neoconocephalus retusus_Round-tipped Conehead
 Neoconocephalus robustus_Robust Conehead
 Neocossyphus finschi_Finsch's Flycatcher-Thrush
 Neocossyphus fraseri_Rufous Flycatcher-Thrush
-Neocossyphus poensis_White-tailed Ant-Thrush
-Neocossyphus rufus_Red-tailed Ant-Thrush
-Neoctantes niger_Black Bushbird
-Neomixis striatigula_Stripe-throated Jery
-Neomixis tenella_Common Jery
-Neomorphus geoffroyi_Rufous-vented Ground-Cuckoo
-Neomorphus rufipennis_Rufous-winged Ground-Cuckoo
+Neocossyphus poensis_白尾蚁鸫
+Neocossyphus rufus_红尾蚁鸫
+Neoctantes niger_黑丛蚁鵙
+Neomixis striatigula_纹喉杂鹛
+Neomixis tenella_北杂鹛
+Neomorphus geoffroyi_棕腹鸡鹃
+Neomorphus rufipennis_棕翅鸡鹃
 Neonemobius cubensis_Cuban Ground Cricket
-Neopelma aurifrons_Wied's Tyrant-Manakin
-Neopelma chrysocephalum_Saffron-crested Tyrant-Manakin
-Neopelma chrysolophum_Serra do Mar Tyrant-Manakin
-Neopelma pallescens_Pale-bellied Tyrant-Manakin
-Neopelma sulphureiventer_Sulphur-bellied Tyrant-Manakin
-Neophema pulchella_Turquoise Parrot
-Neopipo cinnamomea_Cinnamon Manakin-Tyrant
-Neothraupis fasciata_White-banded Tanager
-Nephelomyias lintoni_Orange-banded Flycatcher
-Nephelomyias pulcher_Handsome Flycatcher
-Nesillas lantzii_Subdesert Brush-Warbler
-Nesillas typica_Malagasy Brush-Warbler
-Nesoenas mayeri_Pink Pigeon
-Nesoptilotis flavicollis_Yellow-throated Honeyeater
-Nesoptilotis leucotis_White-eared Honeyeater
-Nesospingus speculiferus_Puerto Rican Tanager
-Nestor meridionalis_New Zealand Kaka
-Netta rufina_赤嘴潛鴨
-Nettapus coromandelianus_棉鴨
-Newtonia amphichroa_Dark Newtonia
-Newtonia archboldi_Archbold's Newtonia
-Newtonia brunneicauda_Common Newtonia
-Nicator chloris_Western Nicator
-Nicator gularis_Eastern Nicator
-Nicator vireo_Yellow-throated Nicator
-Nigrita canicapillus_Gray-headed Nigrita
-Nilaus afer_Brubru
-Niltava grandis_Large Niltava
-Niltava macgrigoriae_Small Niltava
-Niltava sundara_棕腹仙鶲
-Niltava vivida_黃腹琉璃
-Ninox boobook_Southern Boobook
-Ninox connivens_Barking Owl
-Ninox ios_Cinnabar Boobook
-Ninox japonica_褐鷹鴞
-Ninox novaeseelandiae_Morepork
-Ninox obscura_Hume's Boobook
-Ninox philippensis_Luzon Boobook
-Ninox scutulata_Brown Boobook
-Ninox strenua_Powerful Owl
-Ninox theomacha_Papuan Boobook
-Nisaetus cirrhatus_Changeable Hawk-Eagle
-Nisaetus nanus_Wallace's Hawk-Eagle
-Nisaetus nipalensis_熊鷹
+Neopelma aurifrons_巴西霸娇鹟
+Neopelma chrysocephalum_黄冠霸娇鹟
+Neopelma chrysolophum_巴西黄冠霸娇鹟
+Neopelma pallescens_淡腹霸娇鹟
+Neopelma sulphureiventer_黄腹霸娇鹟
+Neophema pulchella_绿宝石鹦鹉
+Neopipo cinnamomea_栗红霸鹟
+Neothraupis fasciata_白斑唐纳雀
+Nephelomyias lintoni_橙斑翅霸鹟
+Nephelomyias pulcher_华丽斑翅霸鹟
+Nesillas lantzii_荒漠薮莺
+Nesillas typica_马岛薮莺
+Nesoenas mayeri_粉红鸽
+Nesoptilotis flavicollis_黄喉吸蜜鸟
+Nesoptilotis leucotis_白耳吸蜜鸟
+Nesospingus speculiferus_暗唐纳雀
+Nestor meridionalis_白顶啄羊鹦鹉
+Netta rufina_赤嘴潜鸭
+Nettapus coromandelianus_棉凫
+Newtonia amphichroa_暗牛顿莺
+Newtonia archboldi_阿氏牛顿莺
+Newtonia brunneicauda_棕尾牛顿莺
+Nicator chloris_黄翼斑斗鹎
+Nicator gularis_东非斗鹎
+Nicator vireo_黄喉斗鹎
+Nigrita canicapillus_灰冠黑雀
+Nilaus afer_非洲鵙
+Niltava grandis_大仙鹟
+Niltava macgrigoriae_小仙鹟
+Niltava sundara_棕腹仙鹟
+Niltava vivida_台湾蓝仙鹟
+Ninox boobook_南鹰鸮
+Ninox connivens_吠鹰鸮
+Ninox ios_棕红鹰鸮
+Ninox japonica_北鹰鸮
+Ninox novaeseelandiae_新西兰鹰鸮
+Ninox obscura_休氏鹰鸮
+Ninox philippensis_菲律宾鹰鸮
+Ninox scutulata_鹰鸮
+Ninox strenua_猛鹰鸮
+Ninox theomacha_褐鹰鸮
+Nisaetus cirrhatus_凤头鹰雕
+Nisaetus nanus_华氏鹰雕
+Nisaetus nipalensis_鹰雕
 Noise_Noise
-Nonnula brunnea_Brown Nunlet
-Nonnula frontalis_Gray-cheeked Nunlet
-Nonnula rubecula_Rusty-breasted Nunlet
-Nonnula ruficapilla_Rufous-capped Nunlet
-Northiella haematogaster_Greater Bluebonnet
-Notharchus hyperrhynchus_White-necked Puffbird
-Notharchus macrorhynchos_Guianan Puffbird
-Notharchus ordii_Brown-banded Puffbird
-Notharchus pectoralis_Black-breasted Puffbird
-Notharchus swainsoni_Buff-bellied Puffbird
-Notharchus tectus_Pied Puffbird
-Nothocercus bonapartei_Highland Tinamou
-Nothocercus julius_Tawny-breasted Tinamou
-Nothocercus nigrocapillus_Hooded Tinamou
-Nothocrax urumutum_Nocturnal Curassow
-Nothoprocta cinerascens_Brushland Tinamou
-Nothoprocta ornata_Ornate Tinamou
-Nothoprocta pentlandii_Andean Tinamou
-Nothoprocta perdicaria_Chilean Tinamou
-Nothura boraquira_White-bellied Nothura
-Nothura darwinii_Darwin's Nothura
-Nothura maculosa_Spotted Nothura
-Notiomystis cincta_Stitchbird
-Notopholia corusca_Black-bellied Starling
-Nucifraga caryocatactes_星鴉
-Nucifraga columbiana_Clark's Nutcracker
-Numenius americanus_Long-billed Curlew
-Numenius arquata_大杓鷸
-Numenius madagascariensis_黦鷸
-Numenius minutus_小杓鷸
-Numenius phaeopus_中杓鷸
-Numenius tahitiensis_Bristle-thighed Curlew
-Numida meleagris_Helmeted Guineafowl
-Nyctanassa violacea_Yellow-crowned Night-Heron
-Nyctibius aethereus_Long-tailed Potoo
-Nyctibius bracteatus_Rufous Potoo
-Nyctibius grandis_Great Potoo
-Nyctibius griseus_Common Potoo
-Nyctibius jamaicensis_Northern Potoo
-Nyctibius leucopterus_White-winged Potoo
-Nycticorax nycticorax_夜鷺
-Nyctidromus albicollis_Common Pauraque
-Nyctidromus anthonyi_Scrub Nightjar
-Nyctiphrynus mcleodii_Eared Poorwill
-Nyctiphrynus ocellatus_Ocellated Poorwill
-Nyctiphrynus rosenbergi_Choco Poorwill
-Nyctiphrynus yucatanicus_Yucatan Poorwill
-Nyctipolus nigrescens_Blackish Nightjar
-Nyctiprogne leucopyga_Band-tailed Nighthawk
-Nyctyornis amictus_Red-bearded Bee-eater
-Nyctyornis athertoni_Blue-bearded Bee-eater
-Nymphicus hollandicus_雞尾鸚鵡
-Nystalus chacuru_White-eared Puffbird
-Nystalus maculatus_Spot-backed Puffbird
-Nystalus obamai_Western Striolated-Puffbird
-Nystalus radiatus_Barred Puffbird
-Nystalus striolatus_Eastern Striolated-Puffbird
-Ochetorhynchus andaecola_Rock Earthcreeper
-Ochetorhynchus melanurus_Crag Chilia
-Ochetorhynchus phoenicurus_Band-tailed Earthcreeper
-Ochetorhynchus ruficaudus_Straight-billed Earthcreeper
-Ochthoeca cinnamomeiventris_Slaty-backed Chat-Tyrant (Slaty-backed)
-Ochthoeca diadema_Yellow-bellied Chat-Tyrant
-Ochthoeca frontalis_Crowned Chat-Tyrant
-Ochthoeca fumicolor_Brown-backed Chat-Tyrant
-Ochthoeca jelskii_Jelski's Chat-Tyrant
-Ochthoeca leucophrys_White-browed Chat-Tyrant
-Ochthoeca oenanthoides_d'Orbigny's Chat-Tyrant
-Ochthoeca pulchella_Golden-browed Chat-Tyrant
-Ochthoeca rufipectoralis_Rufous-breasted Chat-Tyrant
-Ochthornis littoralis_Drab Water Tyrant
-Ocreatus underwoodii_Booted Racket-tail (White-booted)
-Ocyceros birostris_Indian Gray Hornbill
-Ocyceros gingalensis_Sri Lanka Gray Hornbill
-Ocyceros griseus_Malabar Gray Hornbill
-Ocyphaps lophotes_Crested Pigeon
+Nonnula brunnea_褐小蓬头䴕
+Nonnula frontalis_灰颊小蓬头䴕
+Nonnula rubecula_锈胸小蓬头䴕
+Nonnula ruficapilla_棕顶小蓬头䴕
+Northiella haematogaster_红腹蓝额鹦鹉
+Notharchus hyperrhynchus_白颈蓬头䴕
+Notharchus macrorhynchos_圭亚那蓬头䴕
+Notharchus ordii_褐斑蓬头䴕
+Notharchus pectoralis_黑胸蓬头䴕
+Notharchus swainsoni_黄腹蓬头䴕
+Notharchus tectus_丽色蓬头䴕
+Nothocercus bonapartei_黑头林䳍
+Nothocercus julius_红头林䳍
+Nothocercus nigrocapillus_灰头白喉林䳍
+Nothocrax urumutum_夜冠雉
+Nothoprocta cinerascens_灰斑䳍
+Nothoprocta ornata_丽色斑䳍
+Nothoprocta pentlandii_安第斯斑䳍
+Nothoprocta perdicaria_智利斑䳍
+Nothura boraquira_白腹拟䳍
+Nothura darwinii_达尔文拟䳍
+Nothura maculosa_斑拟䳍
+Notiomystis cincta_须吸蜜鸟
+Notopholia corusca_黑腹辉椋鸟
+Nucifraga caryocatactes_星鸦
+Nucifraga columbiana_北美星鸦
+Numenius americanus_长嘴杓鹬
+Numenius arquata_白腰杓鹬
+Numenius madagascariensis_大杓鹬
+Numenius minutus_小杓鹬
+Numenius phaeopus_中杓鹬
+Numenius tahitiensis_太平洋杓鹬
+Numida meleagris_珠鸡
+Nyctanassa violacea_黄冠夜鹭
+Nyctibius aethereus_长尾钩嘴夜鹰
+Nyctibius bracteatus_棕钩嘴夜鹰
+Nyctibius grandis_大钩嘴夜鹰
+Nyctibius griseus_钩嘴夜鹰
+Nyctibius jamaicensis_北钩嘴夜鹰
+Nyctibius leucopterus_白翅钩嘴夜鹰
+Nycticorax nycticorax_夜鹭
+Nyctidromus albicollis_帕拉夜鹰
+Nyctidromus anthonyi_灌丛夜鹰
+Nyctiphrynus mcleodii_耳夜鹰
+Nyctiphrynus ocellatus_黑夜鹰
+Nyctiphrynus rosenbergi_查岛夜鹰
+Nyctiphrynus yucatanicus_尤卡坦夜鹰
+Nyctipolus nigrescens_暗色夜鹰
+Nyctiprogne leucopyga_斑尾夜鹰
+Nyctyornis amictus_赤须夜蜂虎
+Nyctyornis athertoni_蓝须夜蜂虎
+Nymphicus hollandicus_鸡尾鹦鹉
+Nystalus chacuru_白耳蓬头䴕
+Nystalus maculatus_斑背蓬头䴕
+Nystalus obamai_西条纹蓬头䴕
+Nystalus radiatus_横斑蓬头䴕
+Nystalus striolatus_条纹蓬头䴕
+Ochetorhynchus andaecola_岩爬地雀
+Ochetorhynchus melanurus_崖爬地雀
+Ochetorhynchus phoenicurus_斑尾爬地雀
+Ochetorhynchus ruficaudus_直嘴爬地雀
+Ochthoeca cinnamomeiventris_灰背唧霸鹟
+Ochthoeca diadema_黄腹唧霸鹟
+Ochthoeca frontalis_冠唧霸鹟
+Ochthoeca fumicolor_褐背唧霸鹟
+Ochthoeca jelskii_杰氏唧霸鹟
+Ochthoeca leucophrys_白眉唧霸鹟
+Ochthoeca oenanthoides_南美唧霸鹟
+Ochthoeca pulchella_金眉唧霸鹟
+Ochthoeca rufipectoralis_棕胸唧霸鹟
+Ochthornis littoralis_淡褐唧霸鹟
+Ocreatus underwoodii_盘尾蜂鸟
+Ocyceros birostris_灰犀鸟
+Ocyceros gingalensis_斯里兰卡灰犀鸟
+Ocyceros griseus_印度灰犀鸟
+Ocyphaps lophotes_冠鸠
 Odocoileus virginianus_White-tailed Deer
-Odontophorus atrifrons_Black-fronted Wood-Quail
-Odontophorus balliviani_Stripe-faced Wood-Quail
-Odontophorus capueira_Spot-winged Wood-Quail
-Odontophorus columbianus_Venezuelan Wood-Quail
-Odontophorus erythrops_Rufous-fronted Wood-Quail
-Odontophorus gujanensis_Marbled Wood-Quail
-Odontophorus guttatus_Spotted Wood-Quail
-Odontophorus hyperythrus_Chestnut Wood-Quail
-Odontophorus leucolaemus_Black-breasted Wood-Quail
-Odontophorus melanonotus_Dark-backed Wood-Quail
-Odontophorus melanotis_Black-eared Wood-Quail
-Odontophorus speciosus_Rufous-breasted Wood-Quail
-Odontophorus stellatus_Starred Wood-Quail
-Odontophorus strophium_Gorgeted Wood-Quail
-Odontorchilus branickii_Gray-mantled Wren
-Odontorchilus cinereus_Tooth-billed Wren
+Odontophorus atrifrons_黑额林鹑
+Odontophorus balliviani_纹颊林鹑
+Odontophorus capueira_斑翅林鹑
+Odontophorus columbianus_委内瑞拉林鹑
+Odontophorus erythrops_棕额林鹑
+Odontophorus gujanensis_云斑林鹑
+Odontophorus guttatus_点斑林鹑
+Odontophorus hyperythrus_栗林鹑
+Odontophorus leucolaemus_白喉林鹑
+Odontophorus melanonotus_暗背林鹑
+Odontophorus melanotis_黑耳林鹑
+Odontophorus speciosus_棕胸林鹑
+Odontophorus stellatus_黄眼斑林鹑
+Odontophorus strophium_领林鹑
+Odontorchilus branickii_灰背锯嘴鹪鹩
+Odontorchilus cinereus_锯嘴鹪鹩
 Oecanthus celerinictus_Fast-calling Tree Cricket
 Oecanthus exclamationis_Davis's Tree Cricket
 Oecanthus fultoni_Snowy Tree Cricket
@@ -4026,909 +4026,909 @@ Oecanthus nigricornis_Blackhorned Tree Cricket
 Oecanthus niveus_Narrow-winged Tree Cricket
 Oecanthus pini_Pine Tree Cricket
 Oecanthus quadripunctatus_Four-spotted Tree Cricket
-Oena capensis_Namaqua Dove
+Oena capensis_小长尾鸠
 Oenanthe deserti_漠䳭
-Oenanthe familiaris_Familiar Chat
-Oenanthe fusca_Brown Rock Chat
-Oenanthe hispanica_Western Black-eared Wheatear
+Oenanthe familiaris_红尾岩䳭
+Oenanthe fusca_褐岩䳭
+Oenanthe hispanica_黑耳䳭
 Oenanthe isabellina_沙䳭
-Oenanthe leucopyga_White-crowned Wheatear
-Oenanthe leucura_Black Wheatear
-Oenanthe melanoleuca_Eastern Black-eared Wheatear
-Oenanthe melanura_Blackstart
+Oenanthe leucopyga_白冠黑䳭
+Oenanthe leucura_白尾黑䳭
+Oenanthe melanoleuca_东黑耳䳭
+Oenanthe melanura_黑尾岩䳭
 Oenanthe oenanthe_穗䳭
-Oenanthe pileata_Capped Wheatear
-Oenanthe pleschanka_白頂䳭
-Oenanthe scotocerca_Brown-tailed Chat
-Ognorhynchus icterotis_Yellow-eared Parrot
-Oncostoma cinereigulare_Northern Bentbill
-Oncostoma olivaceum_Southern Bentbill
-Oneillornis lunulatus_Lunulated Antbird
-Oneillornis salvini_White-throated Antbird
-Onychognathus morio_Red-winged Starling
-Onychognathus nabouroup_Pale-winged Starling
-Onychognathus tenuirostris_Slender-billed Starling
-Onychognathus tristramii_Tristram's Starling
-Onychognathus walleri_Waller's Starling
-Onychoprion aleuticus_白腰燕鷗
-Onychoprion anaethetus_白眉燕鷗
-Onychoprion fuscatus_烏領燕鷗
-Onychoprion lunatus_Gray-backed Tern
-Onychorhynchus coronatus_Royal Flycatcher
-Opisthocomus hoazin_Hoatzin
-Oporornis agilis_Connecticut Warbler
+Oenanthe pileata_冕䳭
+Oenanthe pleschanka_白顶䳭
+Oenanthe scotocerca_褐尾岩䳭
+Ognorhynchus icterotis_黄耳鹦哥
+Oncostoma cinereigulare_北弯嘴霸鹟
+Oncostoma olivaceum_南弯嘴霸鹟
+Oneillornis lunulatus_月斑蚁鸟
+Oneillornis salvini_白喉蚁鸟
+Onychognathus morio_红翅椋鸟
+Onychognathus nabouroup_淡栗翅椋鸟
+Onychognathus tenuirostris_细嘴栗翅椋鸟
+Onychognathus tristramii_红海栗翅椋鸟
+Onychognathus walleri_高山栗翅椋鸟
+Onychoprion aleuticus_白腰燕鸥
+Onychoprion anaethetus_褐翅燕鸥
+Onychoprion fuscatus_乌燕鸥
+Onychoprion lunatus_灰背燕鸥
+Onychorhynchus coronatus_皇霸鹟
+Opisthocomus hoazin_麝雉
+Oporornis agilis_灰喉地莺
 Orchelimum agile_Agile Meadow Katydid
 Orchelimum concinnum_Stripe-faced Meadow Katydid
 Orchelimum pulchellum_Handsome Meadow Katydid
-Orchesticus abeillei_Brown Tanager
-Oreocharis arfaki_Tit Berrypecker
-Oreoica gutturalis_Crested Bellbird
-Oreolais pulcher_Black-collared Apalis
-Oreolais ruwenzorii_Rwenzori Apalis
-Oreomystis bairdi_Akikiki
-Oreophasis derbianus_Horned Guan
-Oreopholus ruficollis_Tawny-throated Dotterel
-Oreopsar bolivianus_Bolivian Blackbird
-Oreortyx pictus_Mountain Quail
-Oreoscoptes montanus_Sage Thrasher
-Oreoscopus gutturalis_Fernwren
-Oreothlypis gutturalis_Flame-throated Warbler
-Oreothlypis superciliosa_Crescent-chested Warbler
-Oreothraupis arremonops_Tanager Finch
-Oreotrochilus estella_Andean Hillstar
-Oressochen jubatus_Orinoco Goose
-Oressochen melanopterus_Andean Goose
-Oriolus auratus_African Golden Oriole
-Oriolus brachyrynchus_Western Black-headed Oriole
-Oriolus chinensis_黃鸝
-Oriolus chlorocephalus_Green-headed Oriole
-Oriolus cruentus_Black-and-crimson Oriole
-Oriolus flavocinctus_Green Oriole
-Oriolus kundoo_Indian Golden Oriole
-Oriolus larvatus_African Black-headed Oriole
-Oriolus monacha_Ethiopian Black-headed Oriole
-Oriolus nigripennis_Black-winged Oriole
-Oriolus oriolus_Eurasian Golden Oriole
-Oriolus percivali_Black-tailed Oriole
-Oriolus phaeochromus_Halmahera Oriole
-Oriolus sagittatus_Olive-backed Oriole
-Oriolus steerii_Philippine Oriole
-Oriolus szalayi_Brown Oriole
-Oriolus tenuirostris_Slender-billed Oriole
-Oriolus traillii_朱鸝
-Oriolus xanthonotus_Dark-throated Oriole
-Oriolus xanthornus_Black-hooded Oriole
-Oriturus superciliosus_Striped Sparrow
-Ornithion brunneicapillus_Brown-capped Tyrannulet
-Ornithion inerme_White-lored Tyrannulet
-Ornithion semiflavum_Yellow-bellied Tyrannulet
+Orchesticus abeillei_褐唐纳雀
+Oreocharis arfaki_拟雀啄果鸟
+Oreoica gutturalis_冠钟鹟
+Oreolais pulcher_黑领娇莺
+Oreolais ruwenzorii_领娇莺
+Oreomystis bairdi_考岛悬木雀
+Oreophasis derbianus_角冠雉
+Oreopholus ruficollis_橙喉鸻
+Oreopsar bolivianus_玻利维亚拟鹂
+Oreortyx pictus_山翎鹑
+Oreoscoptes montanus_高山弯嘴嘲鸫
+Oreoscopus gutturalis_蕨鹩刺莺
+Oreothlypis gutturalis_火喉森莺
+Oreothlypis superciliosa_月胸森莺
+Oreothraupis arremonops_拟唐纳雀
+Oreotrochilus estella_安第斯山蜂鸟
+Oressochen jubatus_绿翅雁
+Oressochen melanopterus_黑翅草雁
+Oriolus auratus_非洲黄鹂
+Oriolus brachyrynchus_西非黑头黄鹂
+Oriolus chinensis_黑枕黄鹂
+Oriolus chlorocephalus_绿头黄鹂
+Oriolus cruentus_爪哇黄鹂
+Oriolus flavocinctus_绿鹂
+Oriolus kundoo_印度金黄鹂
+Oriolus larvatus_东非黑头黄鹂
+Oriolus monacha_黑头林黄鹂
+Oriolus nigripennis_黑翅黄鹂
+Oriolus oriolus_金黄鹂
+Oriolus percivali_山鹂
+Oriolus phaeochromus_暗褐鹂
+Oriolus sagittatus_绿背黄鹂
+Oriolus steerii_菲律宾黄鹂
+Oriolus szalayi_褐鹂
+Oriolus tenuirostris_细嘴黄鹂
+Oriolus traillii_朱鹂
+Oriolus xanthonotus_黑喉黄鹂
+Oriolus xanthornus_黑头黄鹂
+Oriturus superciliosus_纹雀鹀
+Ornithion brunneicapillus_褐顶小霸鹟
+Ornithion inerme_白眼先小霸鹟
+Ornithion semiflavum_黄腹小霸鹟
 Orocharis saltator_Jumping Bush Cricket
-Orochelidon flavipes_Pale-footed Swallow
-Orochelidon murina_Brown-bellied Swallow
-Ortalis araucuan_East Brazilian Chachalaca
-Ortalis canicollis_Chaco Chachalaca
-Ortalis cinereiceps_Gray-headed Chachalaca
-Ortalis columbiana_Colombian Chachalaca
-Ortalis erythroptera_Rufous-headed Chachalaca
-Ortalis garrula_Chestnut-winged Chachalaca
-Ortalis guttata_Speckled Chachalaca
-Ortalis leucogastra_White-bellied Chachalaca
-Ortalis motmot_Variable Chachalaca
-Ortalis poliocephala_West Mexican Chachalaca
-Ortalis ruficauda_Rufous-vented Chachalaca
-Ortalis squamata_Scaled Chachalaca
-Ortalis vetula_Plain Chachalaca
-Ortalis wagleri_Rufous-bellied Chachalaca
-Orthogonys chloricterus_Olive-green Tanager
-Orthonyx novaeguineae_Papuan Logrunner
-Orthonyx spaldingii_Chowchilla
-Orthonyx temminckii_Australian Logrunner
-Orthopsittaca manilatus_Red-bellied Macaw
-Orthotomus atrogularis_Dark-necked Tailorbird
-Orthotomus chaktomuk_Cambodian Tailorbird
-Orthotomus chloronotus_Green-backed Tailorbird
-Orthotomus derbianus_Gray-backed Tailorbird
-Orthotomus frontalis_Rufous-fronted Tailorbird
-Orthotomus nigriceps_White-browed Tailorbird
-Orthotomus ruficeps_Ashy Tailorbird
-Orthotomus sepium_Olive-backed Tailorbird
-Orthotomus sericeus_Rufous-tailed Tailorbird
-Orthotomus sutorius_Common Tailorbird
-Ortygornis pondicerianus_Gray Francolin
-Ortygornis sephaena_Crested Francolin
-Ortygospiza atricollis_Quailfinch
-Otidiphaps nobilis_Pheasant Pigeon
-Otocichla mupinensis_Chinese Thrush
-Otus bakkamoena_Indian Scops-Owl
-Otus cyprius_Cyprus Scops-Owl
-Otus elegans_蘭嶼角鴞
-Otus lempiji_Sunda Scops-Owl
-Otus lettia_領角鴞
-Otus madagascariensis_Torotoroka Scops-Owl
-Otus magicus_Moluccan Scops-Owl
-Otus manadensis_Sulawesi Scops-Owl
-Otus mantananensis_Mantanani Scops-Owl
-Otus pamelae_Arabian Scops-Owl
-Otus rufescens_Reddish Scops-Owl
-Otus rutilus_Madagascar Scops-Owl
-Otus sagittatus_White-fronted Scops-Owl
-Otus scops_Eurasian Scops-Owl
-Otus semitorques_Japanese Scops-Owl
-Otus senegalensis_African Scops-Owl
-Otus spilocephalus_黃嘴角鴞
-Otus sunia_東方角鴞
-Oxylabes madagascariensis_White-throated Oxylabes
-Oxyruncus cristatus_Sharpbill
-Oxyura ferruginea_Andean Duck
-Oxyura jamaicensis_Ruddy Duck
-Pachycare flavogriseum_Goldenface
-Pachycephala chlorura_Vanuatu Whistler
-Pachycephala cinerea_Mangrove Whistler
-Pachycephala flavifrons_Samoan Whistler
-Pachycephala fuliginosa_Western Whistler
-Pachycephala fulvotincta_Rusty-breasted Whistler
-Pachycephala griseonota_Drab Whistler
-Pachycephala homeyeri_White-vented Whistler
-Pachycephala hypoxantha_Bornean Whistler
-Pachycephala inornata_Gilbert's Whistler
-Pachycephala lanioides_White-breasted Whistler
-Pachycephala macrorhyncha_Yellow-throated Whistler
-Pachycephala mentalis_Black-chinned Whistler
-Pachycephala nudigula_Bare-throated Whistler
-Pachycephala olivacea_Olive Whistler
-Pachycephala orioloides_Oriole Whistler
-Pachycephala pectoralis_Golden Whistler
-Pachycephala philippinensis_Yellow-bellied Whistler
-Pachycephala rufiventris_Rufous Whistler
-Pachycephala schlegelii_Regent Whistler
-Pachycephala simplex_Gray Whistler
-Pachycephala soror_Sclater's Whistler
-Pachycephala sulfuriventer_Sulphur-bellied Whistler
-Pachycephala vitiensis_Fiji Whistler
-Pachyphantes superciliosus_Compact Weaver
-Pachyramphus aglaiae_Rose-throated Becard
-Pachyramphus albogriseus_Black-and-white Becard
-Pachyramphus castaneus_Chestnut-crowned Becard
-Pachyramphus cinnamomeus_Cinnamon Becard
-Pachyramphus homochrous_One-colored Becard
-Pachyramphus major_Gray-collared Becard
-Pachyramphus marginatus_Black-capped Becard
-Pachyramphus minor_Pink-throated Becard
-Pachyramphus niger_Jamaican Becard
-Pachyramphus polychopterus_White-winged Becard
-Pachyramphus rufus_Cinereous Becard
-Pachyramphus surinamus_Glossy-backed Becard
-Pachyramphus validus_Crested Becard
-Pachyramphus versicolor_Barred Becard
-Pachyramphus viridis_Green-backed Becard
-Pachysylvia aurantiifrons_Golden-fronted Greenlet
-Pachysylvia decurtata_Lesser Greenlet
-Pachysylvia hypoxantha_Dusky-capped Greenlet
-Pachysylvia muscicapina_Buff-cheeked Greenlet
-Pachysylvia semibrunnea_Rufous-naped Greenlet
-Padda oryzivora_爪哇雀
-Palmeria dolei_Akohekohe
-Pampa curvipennis_Wedge-tailed Sabrewing
-Pandion haliaetus_魚鷹
-Panterpe insignis_Fiery-throated Hummingbird
-Panurus biarmicus_Bearded Reedling
-Panyptila sanctihieronymi_Great Swallow-tailed Swift
-Parabuteo leucorrhous_White-rumped Hawk
-Parabuteo unicinctus_栗翅鷹
-Paraclaravis mondetoura_Maroon-chested Ground Dove
-Paradisaea minor_Lesser Bird-of-Paradise
-Paradisaea rubra_Red Bird-of-Paradise
-Paradoxornis flavirostris_Black-breasted Parrotbill
-Paradoxornis guttaticollis_Spot-breasted Parrotbill
-Pardalotus punctatus_Spotted Pardalote
-Pardalotus rubricatus_Red-browed Pardalote
-Pardalotus striatus_Striated Pardalote
-Pardirallus maculatus_Spotted Rail
-Pardirallus nigricans_Blackish Rail
-Pardirallus sanguinolentus_Plumbeous Rail
-Parkerthraustes humeralis_Yellow-shouldered Grosbeak
-Parkesia motacilla_Louisiana Waterthrush
-Parkesia noveboracensis_Northern Waterthrush
-Paroaria capitata_Yellow-billed Cardinal
-Paroaria coronata_紅冠唐納雀
-Paroaria dominicana_Red-cowled Cardinal
-Paroaria gularis_紅頂唐納雀
-Paroreomyza montana_Maui Alauahio
-Parus cinereus_Cinereous Tit
-Parus major_Great Tit
-Parus minor_白頰山雀
-Parus monticolus_青背山雀
-Parvipsitta porphyrocephala_Purple-crowned Lorikeet
-Parvipsitta pusilla_Little Lorikeet
-Passer ammodendri_Saxaul Sparrow
+Orochelidon flavipes_淡脚南美燕
+Orochelidon murina_褐腹南美燕
+Ortalis araucuan_巴西小冠雉
+Ortalis canicollis_查科小冠雉
+Ortalis cinereiceps_灰头小冠雉
+Ortalis columbiana_哥伦比亚小冠雉
+Ortalis erythroptera_棕头小冠雉
+Ortalis garrula_栗翅小冠雉
+Ortalis guttata_鳞斑小冠雉
+Ortalis leucogastra_白腹小冠雉
+Ortalis motmot_小冠雉
+Ortalis poliocephala_墨西哥小冠雉
+Ortalis ruficauda_棕臀小冠雉
+Ortalis squamata_点斑小冠雉
+Ortalis vetula_纯色小冠雉
+Ortalis wagleri_棕腹小冠雉
+Orthogonys chloricterus_巴西绿唐纳雀
+Orthonyx novaeguineae_新几内亚刺尾鸫
+Orthonyx spaldingii_黑头刺尾鸫
+Orthonyx temminckii_刺尾鸫
+Orthopsittaca manilatus_红腹金刚鹦鹉
+Orthotomus atrogularis_黑喉缝叶莺
+Orthotomus chaktomuk_柬埔寨缝叶莺
+Orthotomus chloronotus_绿背缝叶莺
+Orthotomus derbianus_灰背缝叶莺
+Orthotomus frontalis_吕宋缝叶莺
+Orthotomus nigriceps_黑头缝叶莺
+Orthotomus ruficeps_灰缝叶莺
+Orthotomus sepium_爪哇缝叶莺
+Orthotomus sericeus_红头缝叶莺
+Orthotomus sutorius_长尾缝叶莺
+Ortygornis pondicerianus_灰鹧鸪
+Ortygornis sephaena_凤头鹧鸪
+Ortygospiza atricollis_黑喉鹑雀
+Otidiphaps nobilis_雉鸠
+Otocichla mupinensis_宝兴歌鸫
+Otus bakkamoena_印度领角鸮
+Otus cyprius_塞浦路斯角鸮
+Otus elegans_琉球角鸮
+Otus lempiji_巽他领角鸮
+Otus lettia_领角鸮
+Otus madagascariensis_托罗卡角鸮
+Otus magicus_摩鹿加角鸮
+Otus manadensis_苏拉威西角鸮
+Otus mantananensis_南菲律宾角鸮
+Otus pamelae_阿拉伯角鸮
+Otus rufescens_棕角鸮
+Otus rutilus_马岛角鸮
+Otus sagittatus_白额角鸮
+Otus scops_西红角鸮
+Otus semitorques_北领角鸮
+Otus senegalensis_非洲角鸮
+Otus spilocephalus_黄嘴角鸮
+Otus sunia_红角鸮
+Oxylabes madagascariensis_白喉马岛莺
+Oxyruncus cristatus_尖喙霸鹟
+Oxyura ferruginea_安第斯硬尾鸭
+Oxyura jamaicensis_棕硬尾鸭
+Pachycare flavogriseum_金脸啸鹟
+Pachycephala chlorura_美岛啸鹟
+Pachycephala cinerea_红树啸鹟
+Pachycephala flavifrons_黄额啸鹟
+Pachycephala fuliginosa_西方啸鹟
+Pachycephala fulvotincta_帝汶啸鹟
+Pachycephala griseonota_褐啸鹟
+Pachycephala homeyeri_白臀啸鹟
+Pachycephala hypoxantha_加里啸鹟
+Pachycephala inornata_吉氏啸鹟
+Pachycephala lanioides_白胸啸鹟
+Pachycephala macrorhyncha_黄喉啸鹟
+Pachycephala mentalis_黑颏啸鹟
+Pachycephala nudigula_裸喉啸鹟
+Pachycephala olivacea_绿啸鹟
+Pachycephala orioloides_鹂啸鹟
+Pachycephala pectoralis_金啸鹟
+Pachycephala philippinensis_黄腹啸鹟
+Pachycephala rufiventris_棕啸鹟
+Pachycephala schlegelii_斯氏啸鹟
+Pachycephala simplex_灰啸鹟
+Pachycephala soror_黑领啸鹟
+Pachycephala sulfuriventer_硫黄腹啸鹟
+Pachycephala vitiensis_白喉斐济啸鹟
+Pachyphantes superciliosus_褐翅织雀
+Pachyramphus aglaiae_红喉厚嘴霸鹟
+Pachyramphus albogriseus_黑白厚嘴霸鹟
+Pachyramphus castaneus_栗顶厚嘴霸鹟
+Pachyramphus cinnamomeus_桂红厚嘴霸鹟
+Pachyramphus homochrous_单色厚嘴霸鹟
+Pachyramphus major_灰领厚嘴霸鹟
+Pachyramphus marginatus_黑顶厚嘴霸鹟
+Pachyramphus minor_粉喉厚嘴霸鹟
+Pachyramphus niger_牙买加厚嘴霸鹟
+Pachyramphus polychopterus_白翅厚嘴霸鹟
+Pachyramphus rufus_灰厚嘴霸鹟
+Pachyramphus surinamus_亮背厚嘴霸鹟
+Pachyramphus validus_淡色厚嘴霸鹟
+Pachyramphus versicolor_斑纹厚嘴霸鹟
+Pachyramphus viridis_绿背厚嘴霸鹟
+Pachysylvia aurantiifrons_金额绿莺雀
+Pachysylvia decurtata_灰头绿莺雀
+Pachysylvia hypoxantha_乌顶绿莺雀
+Pachysylvia muscicapina_黄颊绿莺雀
+Pachysylvia semibrunnea_棕颈绿莺雀
+Padda oryzivora_禾雀
+Palmeria dolei_冠旋蜜雀
+Pampa curvipennis_弯翅刀翅蜂鸟
+Pandion haliaetus_鹗
+Panterpe insignis_火喉蜂鸟
+Panurus biarmicus_文须雀
+Panyptila sanctihieronymi_大燕尾雨燕
+Parabuteo leucorrhous_白腰鵟
+Parabuteo unicinctus_栗翅鹰
+Paraclaravis mondetoura_紫胸地鸠
+Paradisaea minor_小极乐鸟
+Paradisaea rubra_红极乐鸟
+Paradoxornis flavirostris_斑胸鸦雀
+Paradoxornis guttaticollis_点胸鸦雀
+Pardalotus punctatus_斑翅食蜜鸟
+Pardalotus rubricatus_红眉食蜜鸟
+Pardalotus striatus_纹翅食蜜鸟
+Pardirallus maculatus_美洲斑秧鸡
+Pardirallus nigricans_暗色秧鸡
+Pardirallus sanguinolentus_铅色秧鸡
+Parkerthraustes humeralis_黄肩厚嘴雀
+Parkesia motacilla_白眉灶莺
+Parkesia noveboracensis_黄眉灶莺
+Paroaria capitata_黄嘴蜡嘴鹀
+Paroaria coronata_冠蜡嘴鹀
+Paroaria dominicana_冕蜡嘴鹀
+Paroaria gularis_红顶蜡嘴鹀
+Paroreomyza montana_毛岛管舌雀
+Parus cinereus_苍背山雀
+Parus major_欧亚大山雀
+Parus minor_Japanese Tit
+Parus monticolus_绿背山雀
+Parvipsitta porphyrocephala_紫顶鹦鹉
+Parvipsitta pusilla_姬鹦鹉
+Passer ammodendri_黑顶麻雀
 Passer cinnamomeus_山麻雀
-Passer diffusus_Southern Gray-headed Sparrow
+Passer diffusus_南非灰头麻雀
 Passer domesticus_家麻雀
-Passer flaveolus_Plain-backed Sparrow
-Passer griseus_Northern Gray-headed Sparrow
-Passer hispaniolensis_Spanish Sparrow
-Passer italiae_Italian Sparrow
-Passer melanurus_Cape Sparrow
-Passer moabiticus_Dead Sea Sparrow
+Passer flaveolus_黄腹麻雀
+Passer griseus_灰头麻雀
+Passer hispaniolensis_黑胸麻雀
+Passer italiae_意大利麻雀
+Passer melanurus_南非麻雀
+Passer moabiticus_死海麻雀
 Passer montanus_麻雀
-Passer pyrrhonotus_Sind Sparrow
-Passer rufocinctus_Kenya Rufous Sparrow
-Passer simplex_Desert Sparrow
-Passer swainsonii_Swainson's Sparrow
-Passerculus sandwichensis_稀樹草鵐
-Passerella iliaca_Fox Sparrow
-Passerina amoena_Lazuli Bunting
-Passerina caerulea_Blue Grosbeak
-Passerina ciris_Painted Bunting
-Passerina cyanea_Indigo Bunting
-Passerina leclancherii_Orange-breasted Bunting
-Passerina rositae_Rose-bellied Bunting
-Passerina versicolor_Varied Bunting
-Pastor roseus_粉紅椋鳥
-Patagioenas araucana_Chilean Pigeon
-Patagioenas cayennensis_Pale-vented Pigeon
-Patagioenas corensis_Bare-eyed Pigeon
-Patagioenas fasciata_Band-tailed Pigeon
-Patagioenas flavirostris_Red-billed Pigeon
-Patagioenas goodsoni_Dusky Pigeon
-Patagioenas leucocephala_White-crowned Pigeon
-Patagioenas maculosa_Spot-winged Pigeon
-Patagioenas nigrirostris_Short-billed Pigeon
-Patagioenas picazuro_Picazuro Pigeon
-Patagioenas plumbea_Plumbeous Pigeon
-Patagioenas speciosa_Scaled Pigeon
-Patagioenas squamosa_Scaly-naped Pigeon
-Patagioenas subvinacea_Ruddy Pigeon
-Patagona gigas_Giant Hummingbird
-Pauxi pauxi_Helmeted Curassow
-Pavo cristatus_藍孔雀
-Pelargopsis amauroptera_Brown-winged Kingfisher
-Pelargopsis capensis_Stork-billed Kingfisher
-Pelecanus conspicillatus_Australian Pelican
-Pelecanus erythrorhynchos_American White Pelican
-Pelecanus occidentalis_Brown Pelican
-Pellorneum albiventre_Spot-throated Babbler
-Pellorneum bicolor_Ferruginous Babbler
-Pellorneum capistratum_Black-capped Babbler
-Pellorneum celebense_Sulawesi Babbler
-Pellorneum fuscocapillus_Brown-capped Babbler
-Pellorneum malaccense_Short-tailed Babbler
-Pellorneum palustre_Marsh Babbler
-Pellorneum pyrrogenys_Temminck's Babbler
-Pellorneum rostratum_White-chested Babbler
-Pellorneum ruficeps_Puff-throated Babbler
-Pellorneum tickelli_Buff-breasted Babbler
-Peltops montanus_Mountain Peltops
-Penelope albipennis_White-winged Guan
-Penelope argyrotis_Band-tailed Guan
-Penelope barbata_Bearded Guan
-Penelope dabbenei_Red-faced Guan
-Penelope jacquacu_Spix's Guan
-Penelope marail_Marail Guan
-Penelope montagnii_Andean Guan
-Penelope obscura_Dusky-legged Guan
-Penelope perspicax_Cauca Guan
-Penelope purpurascens_Crested Guan
-Penelope superciliaris_Rusty-margined Guan
-Penelopides affinis_Mindanao Hornbill
-Penelopina nigra_Highland Guan
-Peneothello cyanus_Blue-gray Robin
-Peneothello sigillata_White-winged Robin
-Percnostola arenarum_Allpahuayo Antbird
-Percnostola rufifrons_Black-headed Antbird
-Perdicula argoondah_Rock Bush-Quail
-Perdicula asiatica_Jungle Bush-Quail
-Perdicula erythrorhyncha_Painted Bush-Quail
-Perdix perdix_Gray Partridge
-Pericrocotus cantonensis_小灰山椒鳥
-Pericrocotus cinnamomeus_Small Minivet
-Pericrocotus divaricatus_灰山椒鳥
-Pericrocotus erythropygius_White-bellied Minivet
-Pericrocotus ethologus_長尾山椒鳥
-Pericrocotus flammeus_Orange Minivet
-Pericrocotus solaris_灰喉山椒鳥
-Pericrocotus speciosus_赤紅山椒鳥
-Pericrocotus tegimae_琉球山椒鳥
+Passer pyrrhonotus_丛林麻雀
+Passer rufocinctus_肯尼亚麻雀
+Passer simplex_荒漠麻雀
+Passer swainsonii_斯氏麻雀
+Passerculus sandwichensis_稀树草鹀
+Passerella iliaca_狐色雀鹀
+Passerina amoena_白腹蓝彩鹀
+Passerina caerulea_斑翅蓝彩鹀
+Passerina ciris_丽彩鹀
+Passerina cyanea_靛蓝彩鹀
+Passerina leclancherii_橙胸彩鹀
+Passerina rositae_粉腹彩鹀
+Passerina versicolor_杂色彩鹀
+Pastor roseus_粉红椋鸟
+Patagioenas araucana_智利鸽
+Patagioenas cayennensis_淡腹鸽
+Patagioenas corensis_裸眶鸽
+Patagioenas fasciata_北斑尾鸽
+Patagioenas flavirostris_红嘴鸽
+Patagioenas goodsoni_乌鸽
+Patagioenas leucocephala_白顶鸽
+Patagioenas maculosa_斑翅鸽
+Patagioenas nigrirostris_短嘴鸽
+Patagioenas picazuro_红头鸽
+Patagioenas plumbea_铅灰鸽
+Patagioenas speciosa_鳞斑鸽
+Patagioenas squamosa_鳞枕鸽
+Patagioenas subvinacea_赤鸽
+Patagona gigas_巨蜂鸟
+Pauxi pauxi_盔凤冠雉
+Pavo cristatus_蓝孔雀
+Pelargopsis amauroptera_褐翅翡翠
+Pelargopsis capensis_鹳嘴翡翠
+Pelecanus conspicillatus_澳洲鹈鹕
+Pelecanus erythrorhynchos_美洲鹈鹕
+Pelecanus occidentalis_褐鹈鹕
+Pellorneum albiventre_白腹幽鹛
+Pellorneum bicolor_锈色雅鹛
+Pellorneum capistratum_黑冠幽鹛
+Pellorneum celebense_苏拉威西雅鹛
+Pellorneum fuscocapillus_褐冠幽鹛
+Pellorneum malaccense_短尾雅鹛
+Pellorneum palustre_沼泽幽鹛
+Pellorneum pyrrogenys_泰氏幽鹛
+Pellorneum rostratum_白胸雅鹛
+Pellorneum ruficeps_棕头幽鹛
+Pellorneum tickelli_棕胸雅鹛
+Peltops montanus_山盾钟鹊
+Penelope albipennis_白翅冠雉
+Penelope argyrotis_斑尾冠雉
+Penelope barbata_须冠雉
+Penelope dabbenei_红脸冠雉
+Penelope jacquacu_棕胸冠雉
+Penelope marail_绿背冠雉
+Penelope montagnii_安第斯冠雉
+Penelope obscura_乌腿冠雉
+Penelope perspicax_考卡冠雉
+Penelope purpurascens_紫冠雉
+Penelope superciliaris_眉纹冠雉
+Penelopides affinis_棉岛犀鸟
+Penelopina nigra_山冠雉
+Peneothello cyanus_蓝灰薮鹟
+Peneothello sigillata_白翅薮鹟
+Percnostola arenarum_栗腹蚁鸟
+Percnostola rufifrons_黑头蚁鸟
+Perdicula argoondah_岩林鹑
+Perdicula asiatica_丛林鹑
+Perdicula erythrorhyncha_红嘴林鹑
+Perdix perdix_灰山鹑
+Pericrocotus cantonensis_小灰山椒鸟
+Pericrocotus cinnamomeus_小山椒鸟
+Pericrocotus divaricatus_灰山椒鸟
+Pericrocotus erythropygius_白腹山椒鸟
+Pericrocotus ethologus_长尾山椒鸟
+Pericrocotus flammeus_赤黄山椒鸟
+Pericrocotus solaris_灰喉山椒鸟
+Pericrocotus speciosus_赤红山椒鸟
+Pericrocotus tegimae_琉球山椒鸟
 Periparus ater_煤山雀
-Periparus elegans_Elegant Tit
-Periparus rubidiventris_Rufous-vented Tit
-Periparus rufonuchalis_Rufous-naped Tit
-Periparus venustulus_黃腹山雀
-Periporphyrus erythromelas_Red-and-black Grosbeak
-Perisoreus canadensis_Canada Jay
-Perisoreus infaustus_Siberian Jay
-Perissocephalus tricolor_Capuchinbird
-Pernis apivorus_European Honey-buzzard
-Pernis ptilorhynchus_東方蜂鷹
-Petrochelidon ariel_Fairy Martin
-Petrochelidon fluvicola_Streak-throated Swallow
-Petrochelidon fulva_Cave Swallow
-Petrochelidon nigricans_Tree Martin
-Petrochelidon pyrrhonota_Cliff Swallow
-Petrochelidon spilodera_South African Swallow
-Petroica australis_South Island Robin
-Petroica boodang_Scarlet Robin
-Petroica goodenovii_Red-capped Robin
-Petroica longipes_North Island Robin
-Petroica macrocephala_Tomtit
-Petroica phoenicea_Flame Robin
-Petroica pusilla_Pacific Robin
-Petroica rodinogaster_Pink Robin
-Petroica rosea_Rose Robin
-Petronia petronia_Rock Sparrow
-Peucaea aestivalis_Bachman's Sparrow
-Peucaea botterii_Botteri's Sparrow
-Peucaea carpalis_Rufous-winged Sparrow
-Peucaea cassinii_Cassin's Sparrow
-Peucaea humeralis_Black-chested Sparrow
-Peucaea mystacalis_Bridled Sparrow
-Peucaea ruficauda_Stripe-headed Sparrow
-Peucaea sumichrasti_Cinnamon-tailed Sparrow
-Peucedramus taeniatus_Olive Warbler
-Pezopetes capitalis_Large-footed Finch
-Pezoporus wallicus_Ground Parrot
-Phacellodomus dorsalis_Chestnut-backed Thornbird
-Phacellodomus erythrophthalmus_Orange-eyed Thornbird
-Phacellodomus ferrugineigula_Orange-breasted Thornbird
-Phacellodomus maculipectus_Spot-breasted Thornbird
-Phacellodomus ruber_Greater Thornbird
-Phacellodomus rufifrons_Rufous-fronted Thornbird
-Phacellodomus sibilatrix_Little Thornbird
-Phacellodomus striaticeps_Streak-fronted Thornbird
-Phacellodomus striaticollis_Freckle-breasted Thornbird
-Phaenicophaeus sumatranus_Chestnut-bellied Malkoha
-Phaenicophaeus tristis_Green-billed Malkoha
-Phaenicophaeus viridirostris_Blue-faced Malkoha
-Phaenicophilus palmarum_Black-crowned Palm-Tanager
-Phaenostictus mcleannani_Ocellated Antbird
-Phaeochroa cuvierii_Scaly-breasted Hummingbird
+Periparus elegans_丽色山雀
+Periparus rubidiventris_黑冠山雀
+Periparus rufonuchalis_棕枕山雀
+Periparus venustulus_黄腹山雀
+Periporphyrus erythromelas_黑头红锡嘴雀
+Perisoreus canadensis_灰噪鸦
+Perisoreus infaustus_北噪鸦
+Perissocephalus tricolor_三色伞鸟
+Pernis apivorus_鹃头蜂鹰
+Pernis ptilorhynchus_凤头蜂鹰
+Petrochelidon ariel_彩石燕
+Petrochelidon fluvicola_黄额燕
+Petrochelidon fulva_穴崖燕
+Petrochelidon nigricans_树燕
+Petrochelidon pyrrhonota_美洲燕
+Petrochelidon spilodera_非洲斑燕
+Petroica australis_新西兰鸲鹟
+Petroica boodang_绯红鸲鹟
+Petroica goodenovii_红头鸲鹟
+Petroica longipes_北岛鸲鹟
+Petroica macrocephala_雀鸲鹟
+Petroica phoenicea_火红鸲鹟
+Petroica pusilla_太平洋鸲鹟
+Petroica rodinogaster_粉红鸲鹟
+Petroica rosea_瑰色鸲鹟
+Petronia petronia_石雀
+Peucaea aestivalis_巴氏猛雀鹀
+Peucaea botterii_伯氏猛雀鹀
+Peucaea carpalis_棕翅猛雀鹀
+Peucaea cassinii_卡氏猛雀鹀
+Peucaea humeralis_黑胸猛雀鹀
+Peucaea mystacalis_白须猛雀鹀
+Peucaea ruficauda_纹头猛雀鹀
+Peucaea sumichrasti_红尾猛雀鹀
+Peucedramus taeniatus_橄榄绿森莺
+Pezopetes capitalis_大脚薮雀
+Pezoporus wallicus_地鹦鹉
+Phacellodomus dorsalis_栗背棘雀
+Phacellodomus erythrophthalmus_红眼棘雀
+Phacellodomus ferrugineigula_橙胸棘雀
+Phacellodomus maculipectus_点斑胸棘雀
+Phacellodomus ruber_大棘雀
+Phacellodomus rufifrons_棕额棘雀
+Phacellodomus sibilatrix_小棘雀
+Phacellodomus striaticeps_纹额棘雀
+Phacellodomus striaticollis_斑胸棘雀
+Phaenicophaeus sumatranus_棕腹地鹃
+Phaenicophaeus tristis_绿嘴地鹃
+Phaenicophaeus viridirostris_小绿嘴地鹃
+Phaenicophilus palmarum_黑顶长尾唐纳雀
+Phaenostictus mcleannani_眼斑蚁鸟
+Phaeochroa cuvierii_鳞胸刀翅蜂鸟
 Phaeomyias murina_Mouse-colored Tyrannulet
-Phaethon aethereus_紅嘴熱帶鳥
-Phaethon lepturus_白尾熱帶鳥
-Phaethon rubricauda_紅尾熱帶鳥
-Phaethornis atrimentalis_Black-throated Hermit
-Phaethornis bourcieri_Straight-billed Hermit
-Phaethornis eurynome_Scale-throated Hermit
-Phaethornis griseogularis_Gray-chinned Hermit
-Phaethornis guy_Green Hermit
-Phaethornis hispidus_White-bearded Hermit
-Phaethornis longirostris_Long-billed Hermit
-Phaethornis longuemareus_Little Hermit
-Phaethornis malaris_Great-billed Hermit
-Phaethornis nattereri_Cinnamon-throated Hermit
-Phaethornis pretrei_Planalto Hermit
-Phaethornis ruber_Reddish Hermit
-Phaethornis rupurumii_Streak-throated Hermit
-Phaethornis squalidus_Dusky-throated Hermit
-Phaethornis striigularis_Stripe-throated Hermit
-Phaethornis superciliosus_Long-tailed Hermit
-Phaethornis syrmatophorus_Tawny-bellied Hermit
-Phaethornis yaruqui_White-whiskered Hermit
-Phaetusa simplex_Large-billed Tern
-Phainopepla nitens_Phainopepla
-Phalacrocorax carbo_鸕鷀
-Phalaenoptilus nuttallii_Common Poorwill
-Phalaropus fulicarius_灰瓣足鷸
-Phalaropus lobatus_紅領瓣足鷸
-Phalaropus tricolor_Wilson's Phalarope
-Phapitreron amethystinus_Amethyst Brown-Dove
-Phapitreron leucotis_White-eared Brown-Dove
-Phaps chalcoptera_Common Bronzewing
-Phaps elegans_Brush Bronzewing
-Pharomachrus antisianus_Crested Quetzal
-Pharomachrus auriceps_Golden-headed Quetzal
-Pharomachrus fulgidus_White-tipped Quetzal
-Pharomachrus mocinno_Resplendent Quetzal
-Pharomachrus pavoninus_Pavonine Quetzal
-Phasianus colchicus_環頸雉
-Phedina borbonica_Mascarene Martin
-Phegornis mitchellii_Diademed Sandpiper-Plover
-Phelpsia inornata_White-bearded Flycatcher
-Pheucticus aureoventris_Black-backed Grosbeak
-Pheucticus chrysogaster_Golden Grosbeak
-Pheucticus chrysopeplus_Yellow Grosbeak
-Pheucticus ludovicianus_Rose-breasted Grosbeak
-Pheucticus melanocephalus_Black-headed Grosbeak
-Pheucticus tibialis_Black-thighed Grosbeak
-Pheugopedius atrogularis_Black-throated Wren
-Pheugopedius coraya_Coraya Wren
-Pheugopedius eisenmanni_Inca Wren
-Pheugopedius euophrys_Plain-tailed Wren
-Pheugopedius fasciatoventris_Black-bellied Wren
-Pheugopedius felix_Happy Wren
-Pheugopedius genibarbis_Moustached Wren
-Pheugopedius maculipectus_Spot-breasted Wren
-Pheugopedius mystacalis_Whiskered Wren
-Pheugopedius rutilus_Rufous-breasted Wren
-Pheugopedius sclateri_Speckle-breasted Wren
-Pheugopedius spadix_Sooty-headed Wren
-Philemon buceroides_Helmeted Friarbird
-Philemon citreogularis_Little Friarbird
-Philemon corniculatus_Noisy Friarbird
-Philentoma pyrhoptera_Rufous-winged Philentoma
-Philentoma velata_Maroon-breasted Philentoma
-Philepitta schlegeli_Schlegel's Asity
-Philesturnus rufusater_North Island Saddleback
-Philetairus socius_Sociable Weaver
-Philortyx fasciatus_Banded Quail
-Philydor atricapillus_Black-capped Foliage-gleaner
-Philydor erythrocercum_Rufous-rumped Foliage-gleaner
-Philydor fuscipenne_Slaty-winged Foliage-gleaner
-Philydor pyrrhodes_Cinnamon-rumped Foliage-gleaner
-Phimosus infuscatus_Bare-faced Ibis
-Phlegopsis erythroptera_Reddish-winged Bare-eye
-Phlegopsis nigromaculata_Black-spotted Bare-eye
-Phleocryptes melanops_Wren-like Rushbird
-Phlogophilus hemileucurus_Ecuadorian Piedtail
-Phodilus assimilis_Sri Lanka Bay-Owl
-Phodilus badius_Oriental Bay-Owl
+Phaethon aethereus_红嘴鹲
+Phaethon lepturus_白尾鹲
+Phaethon rubricauda_红尾鹲
+Phaethornis atrimentalis_黑喉隐蜂鸟
+Phaethornis bourcieri_直嘴隐蜂鸟
+Phaethornis eurynome_鳞喉隐蜂鸟
+Phaethornis griseogularis_灰颏隐蜂鸟
+Phaethornis guy_绿隐蜂鸟
+Phaethornis hispidus_白髯隐蜂鸟
+Phaethornis longirostris_西长尾隐蜂鸟
+Phaethornis longuemareus_小隐蜂鸟
+Phaethornis malaris_大嘴隐蜂鸟
+Phaethornis nattereri_红喉隐蜂鸟
+Phaethornis pretrei_普拉隐蜂鸟
+Phaethornis ruber_红隐蜂鸟
+Phaethornis rupurumii_斑喉隐蜂鸟
+Phaethornis squalidus_暗喉隐蜂鸟
+Phaethornis striigularis_纹喉隐蜂鸟
+Phaethornis superciliosus_长尾隐蜂鸟
+Phaethornis syrmatophorus_茶腹隐蜂鸟
+Phaethornis yaruqui_白须隐蜂鸟
+Phaetusa simplex_巨嘴燕鸥
+Phainopepla nitens_黑丝鹟
+Phalacrocorax carbo_普通鸬鹚
+Phalaenoptilus nuttallii_北美小夜鹰
+Phalaropus fulicarius_灰瓣蹼鹬
+Phalaropus lobatus_红颈瓣蹼鹬
+Phalaropus tricolor_细嘴瓣蹼鹬
+Phapitreron amethystinus_大褐果鸠
+Phapitreron leucotis_小褐果鸠
+Phaps chalcoptera_铜翅鸠
+Phaps elegans_灌丛铜翅鸠
+Pharomachrus antisianus_凤头绿咬鹃
+Pharomachrus auriceps_金头绿咬鹃
+Pharomachrus fulgidus_白尾梢绿咬鹃
+Pharomachrus mocinno_凤尾绿咬鹃
+Pharomachrus pavoninus_彩绿咬鹃
+Phasianus colchicus_雉鸡
+Phedina borbonica_马岛原燕
+Phegornis mitchellii_黑顶鸻
+Phelpsia inornata_白须短嘴霸鹟
+Pheucticus aureoventris_黑背斑翅雀
+Pheucticus chrysogaster_黄腹斑翅雀
+Pheucticus chrysopeplus_黄色斑翅雀
+Pheucticus ludovicianus_玫胸斑翅雀
+Pheucticus melanocephalus_黑头斑翅雀
+Pheucticus tibialis_黑腿斑翅雀
+Pheugopedius atrogularis_黑喉苇鹪鹩
+Pheugopedius coraya_科拉苇鹪鹩
+Pheugopedius eisenmanni_印加苇鹪鹩
+Pheugopedius euophrys_淡尾苇鹪鹩
+Pheugopedius fasciatoventris_黑腹苇鹪鹩
+Pheugopedius felix_快乐苇鹪鹩
+Pheugopedius genibarbis_须苇鹪鹩
+Pheugopedius maculipectus_斑胸苇鹪鹩
+Pheugopedius mystacalis_髯苇鹪鹩
+Pheugopedius rutilus_棕胸苇鹪鹩
+Pheugopedius sclateri_鳞胸苇鹪鹩
+Pheugopedius spadix_黑头苇鹪鹩
+Philemon buceroides_盔吮蜜鸟
+Philemon citreogularis_小吮蜜鸟
+Philemon corniculatus_噪吮蜜鸟
+Philentoma pyrhoptera_棕翅王鵙
+Philentoma velata_栗胸王鵙
+Philepitta schlegeli_施氏裸眉鸫
+Philesturnus rufusater_北岛鞍背鸦
+Philetairus socius_群织雀
+Philortyx fasciatus_斑鹑
+Philydor atricapillus_黑顶拾叶雀
+Philydor erythrocercum_棕腰拾叶雀
+Philydor fuscipenne_蓝灰拾叶雀
+Philydor pyrrhodes_红腰拾叶雀
+Phimosus infuscatus_裸脸鹮
+Phlegopsis erythroptera_红翅裸眼蚁鸟
+Phlegopsis nigromaculata_黑斑裸眼蚁鸟
+Phleocryptes melanops_拟鹩针尾雀
+Phlogophilus hemileucurus_厄瓜多尔斑尾蜂鸟
+Phodilus assimilis_斯里兰卡栗鸮
+Phodilus badius_栗鸮
 Phoebastria immutabilis_黑背信天翁
-Phoebastria nigripes_黑腳信天翁
-Phoenicircus carnifex_Guianan Red-Cotinga
-Phoenicircus nigricollis_Black-necked Red-Cotinga
-Phoeniconaias minor_Lesser Flamingo
-Phoenicoparrus andinus_Andean Flamingo
-Phoenicoparrus jamesi_James's Flamingo
-Phoenicopterus chilensis_Chilean Flamingo
-Phoenicopterus roseus_大紅鸛
-Phoenicopterus ruber_美洲红鸛
-Phoeniculus bollei_White-headed Woodhoopoe
-Phoeniculus purpureus_Green Woodhoopoe
-Phoenicurus auroreus_黃尾鴝
-Phoenicurus frontalis_藍額紅尾鴝
-Phoenicurus fuliginosus_鉛色水鶇
-Phoenicurus hodgsoni_Hodgson's Redstart
-Phoenicurus leucocephalus_白頂溪鴝
-Phoenicurus moussieri_Moussier's Redstart
-Phoenicurus ochruros_赭紅尾鴝
-Phoenicurus phoenicurus_Common Redstart
-Pholia sharpii_Sharpe's Starling
-Phonygammus keraudrenii_Trumpet Manucode
-Phragmacia substriata_Namaqua Warbler
-Phrygilus atriceps_Black-hooded Sierra Finch
-Phrygilus gayi_Gray-hooded Sierra Finch
-Phrygilus patagonicus_Patagonian Sierra Finch
-Phylidonyris niger_White-cheeked Honeyeater
-Phylidonyris novaehollandiae_New Holland Honeyeater
-Phylidonyris pyrrhopterus_Crescent Honeyeater
-Phyllastrephus cabanisi_Cabanis's Greenbul
-Phyllastrephus cerviniventris_Gray-olive Greenbul
-Phyllastrephus fischeri_Fischer's Greenbul
-Phyllastrephus flavostriatus_Yellow-streaked Greenbul
-Phyllastrephus strepitans_Northern Brownbul
-Phyllastrephus terrestris_Terrestrial Brownbul
-Phyllergates cucullatus_Mountain Tailorbird
-Phyllergates heterolaemus_Rufous-headed Tailorbird
-Phyllolais pulchella_Buff-bellied Warbler
-Phyllomyias burmeisteri_Rough-legged Tyrannulet (Burmeister's)
-Phyllomyias cinereiceps_Ashy-headed Tyrannulet
-Phyllomyias fasciatus_Planalto Tyrannulet
-Phyllomyias griseiceps_Sooty-headed Tyrannulet
-Phyllomyias griseocapilla_Gray-capped Tyrannulet
-Phyllomyias nigrocapillus_Black-capped Tyrannulet
-Phyllomyias plumbeiceps_Plumbeous-crowned Tyrannulet
-Phyllomyias sclateri_Sclater's Tyrannulet
-Phyllomyias uropygialis_Tawny-rumped Tyrannulet
-Phyllomyias virescens_Greenish Tyrannulet
+Phoebastria nigripes_黑脚信天翁
+Phoenicircus carnifex_圭亚那红伞鸟
+Phoenicircus nigricollis_黑颈红伞鸟
+Phoeniconaias minor_小红鹳 
+Phoenicoparrus andinus_安第斯红鹳
+Phoenicoparrus jamesi_秘鲁红鹳
+Phoenicopterus chilensis_智利红鹳
+Phoenicopterus roseus_大红鹳
+Phoenicopterus ruber_美洲红鹳
+Phoeniculus bollei_白头林戴胜
+Phoeniculus purpureus_绿林戴胜
+Phoenicurus auroreus_北红尾鸲
+Phoenicurus frontalis_蓝额红尾鸲
+Phoenicurus fuliginosus_红尾水鸲
+Phoenicurus hodgsoni_黑喉红尾鸲
+Phoenicurus leucocephalus_白顶溪鸲
+Phoenicurus moussieri_北非红尾鸲
+Phoenicurus ochruros_赭红尾鸲
+Phoenicurus phoenicurus_欧亚红尾鸲
+Pholia sharpii_黄腹紫椋鸟
+Phonygammus keraudrenii_号声极乐鸟
+Phragmacia substriata_亚纹山鹪莺
+Phrygilus atriceps_黑头岭雀鹀
+Phrygilus gayi_灰头岭雀鹀
+Phrygilus patagonicus_南美岭雀鹀
+Phylidonyris niger_白颊澳蜜鸟
+Phylidonyris novaehollandiae_黄翅澳蜜鸟
+Phylidonyris pyrrhopterus_月斑澳蜜鸟
+Phyllastrephus cabanisi_卡氏旋木鹎
+Phyllastrephus cerviniventris_灰绿旋木鹎
+Phyllastrephus fischeri_费氏旋木鹎
+Phyllastrephus flavostriatus_黄纹旋木鹎
+Phyllastrephus strepitans_锯齿旋木鹎
+Phyllastrephus terrestris_褐旋木鹎
+Phyllergates cucullatus_金头拟缝叶莺
+Phyllergates heterolaemus_褐头缝叶莺
+Phyllolais pulchella_黄腹莺
+Phyllomyias burmeisteri_毛腿小霸鹟
+Phyllomyias cinereiceps_灰头小霸鹟
+Phyllomyias fasciatus_带斑小霸鹟
+Phyllomyias griseiceps_乌头小霸鹟
+Phyllomyias griseocapilla_灰顶小霸鹟
+Phyllomyias nigrocapillus_黑顶小霸鹟
+Phyllomyias plumbeiceps_铅色顶小霸鹟
+Phyllomyias sclateri_阿根廷小霸鹟
+Phyllomyias uropygialis_褐腰小霸鹟
+Phyllomyias virescens_绿色小霸鹟
 Phyllopalpus pulchellus_Handsome Trig
-Phylloscartes ceciliae_Alagoas Tyrannulet
+Phylloscartes ceciliae_长尾姬霸鹟
 Phylloscartes difficilis_Serra do Mar Tyrannulet
 Phylloscartes eximius_Southern Bristle-Tyrant
-Phylloscartes gualaquizae_Ecuadorian Tyrannulet
-Phylloscartes kronei_Restinga Tyrannulet
+Phylloscartes gualaquizae_厄瓜多尔姬霸鹟
+Phylloscartes kronei_雷斯姬霸鹟
 Phylloscartes lanyoni_Antioquia Bristle-Tyrant
 Phylloscartes ophthalmicus_Marble-faced Bristle-Tyrant
-Phylloscartes oustaleti_Oustalet's Tyrannulet
-Phylloscartes parkeri_Cinnamon-faced Tyrannulet
+Phylloscartes oustaleti_欧氏姬霸鹟
+Phylloscartes parkeri_棕脸姬霸鹟
 Phylloscartes paulista_Sao Paulo Tyrannulet
 Phylloscartes poecilotis_Variegated Bristle-Tyrant
-Phylloscartes roquettei_Minas Gerais Tyrannulet
-Phylloscartes superciliaris_Rufous-browed Tyrannulet
-Phylloscartes sylviolus_Bay-ringed Tyrannulet
-Phylloscartes ventralis_Mottle-cheeked Tyrannulet
-Phylloscartes virescens_Olive-green Tyrannulet
-Phylloscopus affinis_黃腹柳鶯
-Phylloscopus armandii_棕眉柳鶯
-Phylloscopus bonelli_Western Bonelli's Warbler
-Phylloscopus borealis_極北柳鶯
-Phylloscopus borealoides_庫頁島柳鶯
-Phylloscopus budongoensis_Uganda Woodland-Warbler
-Phylloscopus burkii_Green-crowned Warbler
-Phylloscopus calciatilis_Limestone Leaf Warbler
-Phylloscopus cantator_Yellow-vented Warbler
-Phylloscopus castaniceps_栗頭鶲鶯
-Phylloscopus chloronotus_Lemon-rumped Warbler
-Phylloscopus claudiae_克氏冠紋柳鶯
-Phylloscopus collybita_嘰喳柳鶯
-Phylloscopus coronatus_冠羽柳鶯
-Phylloscopus emeiensis_Emei Leaf Warbler
-Phylloscopus examinandus_勘察加柳鶯
-Phylloscopus forresti_Sichuan Leaf Warbler
-Phylloscopus fuligiventer_Smoky Warbler
-Phylloscopus fuscatus_褐色柳鶯
-Phylloscopus goodsoni_哈氏冠紋柳鶯
-Phylloscopus grammiceps_Sunda Warbler
-Phylloscopus griseolus_Sulphur-bellied Warbler
-Phylloscopus humei_淡眉柳鶯
-Phylloscopus ibericus_Iberian Chiffchaff
-Phylloscopus ijimae_飯島柳鶯
-Phylloscopus inornatus_黃眉柳鶯
-Phylloscopus intensior_Davison's Leaf Warbler
-Phylloscopus intermedius_白眶鶲鶯
-Phylloscopus kansuensis_Gansu Leaf Warbler
-Phylloscopus maculipennis_Ashy-throated Warbler
-Phylloscopus magnirostris_Large-billed Leaf Warbler
-Phylloscopus montis_Yellow-breasted Warbler
-Phylloscopus neglectus_Plain Leaf Warbler
-Phylloscopus nitidus_Green Warbler
-Phylloscopus occipitalis_Western Crowned Warbler
+Phylloscartes roquettei_米州姬霸鹟
+Phylloscartes superciliaris_棕额姬霸鹟
+Phylloscartes sylviolus_栗环姬霸鹟
+Phylloscartes ventralis_点颊姬霸鹟
+Phylloscartes virescens_橄榄绿姬霸鹟
+Phylloscopus affinis_黄腹柳莺
+Phylloscopus armandii_棕眉柳莺
+Phylloscopus bonelli_博氏柳莺
+Phylloscopus borealis_极北柳莺
+Phylloscopus borealoides_库页岛柳莺
+Phylloscopus budongoensis_乌干达柳莺
+Phylloscopus burkii_金眶鹟莺
+Phylloscopus calciatilis_灰岩柳莺
+Phylloscopus cantator_黄胸柳莺
+Phylloscopus castaniceps_栗头鹟莺
+Phylloscopus chloronotus_淡黄腰柳莺
+Phylloscopus claudiae_冠纹柳莺
+Phylloscopus collybita_叽喳柳莺
+Phylloscopus coronatus_冕柳莺
+Phylloscopus emeiensis_峨眉柳莺
+Phylloscopus examinandus_堪察加柳莺
+Phylloscopus forresti_四川柳莺
+Phylloscopus fuligiventer_烟柳莺
+Phylloscopus fuscatus_褐柳莺
+Phylloscopus goodsoni_华南冠纹柳莺
+Phylloscopus grammiceps_纹顶鹟莺
+Phylloscopus griseolus_灰柳莺
+Phylloscopus humei_淡眉柳莺
+Phylloscopus ibericus_伊比利亚柳莺
+Phylloscopus ijimae_饭岛柳莺
+Phylloscopus inornatus_黄眉柳莺
+Phylloscopus intensior_云南白斑尾柳莺
+Phylloscopus intermedius_白眶鹟莺
+Phylloscopus kansuensis_甘肃柳莺
+Phylloscopus maculipennis_灰喉柳莺
+Phylloscopus magnirostris_乌嘴柳莺
+Phylloscopus montis_黄胸鹟莺
+Phylloscopus neglectus_纯色柳莺
+Phylloscopus nitidus_绿柳莺
+Phylloscopus occipitalis_大冕柳莺
 Phylloscopus occisinensis_Alpine Leaf Warbler
-Phylloscopus ogilviegranti_Kloss's Leaf Warbler
-Phylloscopus olivaceus_Philippine Leaf Warbler
-Phylloscopus omeiensis_Martens's Warbler
-Phylloscopus orientalis_Eastern Bonelli's Warbler
-Phylloscopus plumbeitarsus_雙斑綠柳鶯
-Phylloscopus poliocephalus_Island Leaf Warbler
-Phylloscopus poliogenys_Gray-cheeked Warbler
-Phylloscopus proregulus_黃腰柳鶯
-Phylloscopus pulcher_Buff-barred Warbler
-Phylloscopus reguloides_Blyth's Leaf Warbler
-Phylloscopus ruficapilla_Yellow-throated Woodland-Warbler
-Phylloscopus sarasinorum_Sulawesi Leaf Warbler (Lompobattang)
-Phylloscopus schwarzi_巨嘴柳鶯
-Phylloscopus sibilatrix_林柳鶯
-Phylloscopus sindianus_東方嘰咋柳鶯
-Phylloscopus soror_淡尾鶲鶯
-Phylloscopus subaffinis_棕腹柳鶯
-Phylloscopus subviridis_Brooks's Leaf Warbler
-Phylloscopus tenellipes_淡腳柳鶯
-Phylloscopus tephrocephalus_Gray-crowned Warbler
-Phylloscopus trivirgatus_Mountain Leaf Warbler
-Phylloscopus trochiloides_暗綠柳鶯
-Phylloscopus trochilus_歐亞柳鶯
-Phylloscopus tytleri_Tytler's Leaf Warbler
-Phylloscopus umbrovirens_Brown Woodland-Warbler
-Phylloscopus valentini_比氏鶲鶯
-Phylloscopus whistleri_Whistler's Warbler
-Phylloscopus xanthodryas_日本柳鶯
-Phylloscopus xanthoschistos_Gray-hooded Warbler
-Phylloscopus yunnanensis_雲南柳鶯
-Phytotoma raimondii_Peruvian Plantcutter
-Phytotoma rara_Rufous-tailed Plantcutter
-Phytotoma rutila_White-tipped Plantcutter
-Piaya cayana_Squirrel Cuckoo
-Piaya melanogaster_Black-bellied Cuckoo
-Pica bottanensis_Black-rumped Magpie
-Pica hudsonia_Black-billed Magpie
-Pica nuttalli_Yellow-billed Magpie
-Pica pica_西方喜鵲
-Pica serica_喜鵲
-Picoides arcticus_Black-backed Woodpecker
-Picoides dorsalis_American Three-toed Woodpecker
-Picoides tridactylus_Eurasian Three-toed Woodpecker
-Piculus aurulentus_White-browed Woodpecker
-Piculus callopterus_Stripe-cheeked Woodpecker
-Piculus chrysochloros_Golden-green Woodpecker
-Piculus flavigula_Yellow-throated Woodpecker
-Piculus leucolaemus_White-throated Woodpecker
-Picumnus albosquamatus_White-wedged Piculet
-Picumnus aurifrons_Bar-breasted Piculet
-Picumnus cinnamomeus_Chestnut Piculet
-Picumnus cirratus_White-barred Piculet
-Picumnus dorbignyanus_Ocellated Piculet
-Picumnus exilis_Golden-spangled Piculet
-Picumnus granadensis_Grayish Piculet
-Picumnus innominatus_Speckled Piculet
-Picumnus lafresnayi_Lafresnaye's Piculet
-Picumnus limae_Ochraceous Piculet
-Picumnus nebulosus_Mottled Piculet
-Picumnus olivaceus_Olivaceous Piculet
-Picumnus pygmaeus_Spotted Piculet
-Picumnus rufiventris_Rufous-breasted Piculet
-Picumnus sclateri_Ecuadorian Piculet
-Picumnus spilogaster_White-bellied Piculet
-Picumnus squamulatus_Scaled Piculet
-Picumnus temminckii_Ochre-collared Piculet
-Picus awokera_Japanese Woodpecker
-Picus canus_綠啄木
-Picus chlorolophus_Lesser Yellownape
-Picus erythropygius_Black-headed Woodpecker
-Picus puniceus_Crimson-winged Woodpecker
-Picus sharpei_Iberian Green Woodpecker
-Picus squamatus_Scaly-bellied Woodpecker
-Picus vaillantii_Levaillant's Woodpecker
-Picus viridis_Eurasian Green Woodpecker
-Picus vittatus_Laced Woodpecker
-Picus xanthopygaeus_Streak-throated Woodpecker
-Pinicola enucleator_Pine Grosbeak
-Pionites leucogaster_White-bellied Parrot
-Pionites melanocephalus_Black-headed Parrot
-Pionopsitta pileata_Pileated Parrot
-Pionus chalcopterus_Bronze-winged Parrot
-Pionus fuscus_Dusky Parrot
-Pionus maximiliani_Scaly-headed Parrot
-Pionus menstruus_Blue-headed Parrot
-Pionus senilis_White-crowned Parrot
-Pionus sordidus_Red-billed Parrot
-Pionus tumultuosus_Speckle-faced Parrot
-Pipile cujubi_Red-throated Piping-Guan
-Pipile cumanensis_Blue-throated Piping-Guan (Blue-throated)
-Pipilo chlorurus_Green-tailed Towhee
-Pipilo erythrophthalmus_Eastern Towhee
-Pipilo maculatus_Spotted Towhee
-Pipilo ocai_Collared Towhee
-Pipra aureola_Crimson-hooded Manakin
-Pipra fasciicauda_Band-tailed Manakin
-Pipra filicauda_Wire-tailed Manakin
-Pipraeidea melanonota_Fawn-breasted Tanager
-Pipreola arcuata_Barred Fruiteater
-Pipreola aureopectus_Golden-breasted Fruiteater
-Pipreola formosa_Handsome Fruiteater
-Pipreola frontalis_Scarlet-breasted Fruiteater
-Pipreola intermedia_Band-tailed Fruiteater
-Pipreola jucunda_Orange-breasted Fruiteater
-Pipreola lubomirskii_Black-chested Fruiteater
-Pipreola riefferii_Green-and-black Fruiteater
-Pipreola whitelyi_Red-banded Fruiteater
-Piprites chloris_Wing-barred Piprites
-Piprites griseiceps_Gray-headed Piprites
-Piprites pileata_Black-capped Piprites
-Piranga bidentata_Flame-colored Tanager
-Piranga erythrocephala_Red-headed Tanager
-Piranga flava_Hepatic Tanager
-Piranga leucoptera_White-winged Tanager
-Piranga ludoviciana_Western Tanager
-Piranga olivacea_Scarlet Tanager
-Piranga roseogularis_Rose-throated Tanager
-Piranga rubra_Summer Tanager
-Piranga rubriceps_Red-hooded Tanager
-Pitangus lictor_Lesser Kiskadee
-Pitangus sulphuratus_Great Kiskadee
-Pithecophaga jefferyi_Philippine Eagle
-Pithys albifrons_White-plumed Antbird
-Pitohui kirhocephalus_Northern Variable Pitohui
-Pitta brachyura_Indian Pitta
-Pitta elegans_Elegant Pitta
-Pitta maxima_Ivory-breasted Pitta
-Pitta megarhyncha_Mangrove Pitta
-Pitta moluccensis_藍翅八色鳥
-Pitta nympha_八色鳥
-Pitta sordida_綠胸八色鳥
-Pitta steerii_Azure-breasted Pitta
-Pitta versicolor_Noisy Pitta
-Pittasoma michleri_Black-crowned Antpitta
-Pittasoma rufopileatum_Rufous-crowned Antpitta
-Pityriasis gymnocephala_Bornean Bristlehead
-Platalea ajaja_Roseate Spoonbill
-Platalea leucorodia_白琵鷺
-Platycercus adscitus_Pale-headed Rosella
-Platycercus caledonicus_Green Rosella
-Platycercus elegans_Crimson Rosella
-Platycercus eximius_Eastern Rosella
-Platylophus galericulatus_Crested Shrikejay
-Platyrinchus cancrominus_Stub-tailed Spadebill
-Platyrinchus coronatus_Golden-crowned Spadebill
-Platyrinchus flavigularis_Yellow-throated Spadebill
-Platyrinchus leucoryphus_Russet-winged Spadebill
-Platyrinchus mystaceus_White-throated Spadebill
-Platyrinchus platyrhynchos_White-crested Spadebill
-Platyrinchus saturatus_Cinnamon-crested Spadebill
-Platysmurus leucopterus_Black Magpie
-Platysteira blissetti_Red-cheeked Wattle-eye
-Platysteira castanea_Chestnut Wattle-eye
-Platysteira concreta_Yellow-bellied Wattle-eye
-Platysteira cyanea_Brown-throated Wattle-eye
-Platysteira peltata_Black-throated Wattle-eye
-Plectorhyncha lanceolata_Striped Honeyeater
-Plectrophenax hyperboreus_McKay's Bunting
-Plectrophenax nivalis_雪鵐
-Plegadis chihi_White-faced Ibis
-Plegadis falcinellus_彩䴉
-Plegadis ridgwayi_Puna Ibis
-Plocepasser mahali_White-browed Sparrow-Weaver
-Plocepasser superciliosus_Chestnut-crowned Sparrow-Weaver
-Ploceus baglafecht_Baglafecht Weaver
-Ploceus bicolor_Forest Weaver
-Ploceus capensis_Cape Weaver
-Ploceus cucullatus_黑頭織雀
-Ploceus galbula_Rüppell's Weaver
-Ploceus hypoxanthus_Asian Golden Weaver
-Ploceus intermedius_Lesser Masked-Weaver
-Ploceus jacksoni_金背織雀
-Ploceus luteolus_Little Weaver
-Ploceus manyar_Streaked Weaver
-Ploceus melanocephalus_Black-headed Weaver
-Ploceus nelicourvi_Nelicourvi Weaver
-Ploceus nigerrimus_Vieillot's Weaver (Black)
-Ploceus nigricollis_Black-necked Weaver (Black-backed)
-Ploceus ocularis_Spectacled Weaver
-Ploceus philippinus_Baya Weaver
-Ploceus sakalava_Sakalava Weaver
-Ploceus spekei_Speke's Weaver
-Ploceus subaureus_非洲金織雀
-Ploceus velatus_Southern Masked-Weaver
-Ploceus vitellinus_Vitelline Masked-Weaver
-Ploceus xanthops_Holub's Golden-Weaver
-Ploceus xanthopterus_Southern Brown-throated Weaver
-Pluvialis apricaria_European Golden-Plover
-Pluvialis dominica_美洲金斑鴴
-Pluvialis fulva_太平洋金斑鴴
-Pluvialis squatarola_灰斑鴴
-Pnoepyga albiventer_Scaly-breasted Cupwing
-Pnoepyga formosana_台灣鷦眉
-Pnoepyga immaculata_Immaculate Cupwing
-Pnoepyga pusilla_Pygmy Cupwing
-Podargus ocellatus_Marbled Frogmouth
-Podargus strigoides_Tawny Frogmouth
-Podiceps auritus_角鸊鷉
-Podiceps cristatus_冠鸊鷉
-Podiceps gallardoi_Hooded Grebe
-Podiceps grisegena_赤頸鸊鷉
-Podiceps major_Great Grebe
-Podiceps nigricollis_黑頸鸊鷉
-Podiceps occipitalis_Silvery Grebe
-Podilymbus podiceps_Pied-billed Grebe
-Podoces hendersoni_Mongolian Ground-Jay
-Poecile atricapillus_Black-capped Chickadee
-Poecile carolinensis_Carolina Chickadee
-Poecile cinctus_Gray-headed Chickadee
-Poecile gambeli_Mountain Chickadee
-Poecile hudsonicus_Boreal Chickadee
-Poecile lugubris_Sombre Tit
-Poecile montanus_Willow Tit
-Poecile palustris_Marsh Tit
-Poecile rufescens_Chestnut-backed Chickadee
-Poecile sclateri_Mexican Chickadee
-Poecile weigoldicus_Sichuan Tit
-Poecilodryas hypoleuca_Black-sided Robin
-Poecilostreptus cabanisi_Azure-rumped Tanager
-Poecilostreptus palmeri_Gray-and-gold Tanager
-Poecilotriccus albifacies_White-cheeked Tody-Flycatcher
-Poecilotriccus calopterus_Golden-winged Tody-Flycatcher
-Poecilotriccus capitalis_Black-and-white Tody-Flycatcher
-Poecilotriccus fumifrons_Smoky-fronted Tody-Flycatcher
-Poecilotriccus latirostris_Rusty-fronted Tody-Flycatcher
-Poecilotriccus luluae_Johnson's Tody-Flycatcher
-Poecilotriccus plumbeiceps_Ochre-faced Tody-Flycatcher
-Poecilotriccus ruficeps_Rufous-crowned Tody-Flycatcher
-Poecilotriccus russatus_Ruddy Tody-Flycatcher
-Poecilotriccus sylvia_Slate-headed Tody-Flycatcher
-Pogoniulus atroflavus_Red-rumped Tinkerbird
-Pogoniulus bilineatus_Yellow-rumped Tinkerbird
-Pogoniulus chrysoconus_Yellow-fronted Tinkerbird
-Pogoniulus leucomystax_Moustached Tinkerbird
-Pogoniulus pusillus_Red-fronted Tinkerbird
-Pogoniulus scolopaceus_Speckled Tinkerbird
-Pogoniulus simplex_Green Tinkerbird
-Pogoniulus subsulphureus_Yellow-throated Tinkerbird
-Pogonocichla stellata_White-starred Robin
-Poicephalus cryptoxanthus_Brown-headed Parrot
-Poicephalus fuscicollis_Brown-necked Parrot
-Poicephalus meyeri_Meyer's Parrot
-Poicephalus robustus_Cape Parrot
-Poicephalus rufiventris_Red-bellied Parrot
-Poicephalus senegalus_塞內加爾鸚鵡
-Poliocrania exsul_Chestnut-backed Antbird
-Poliolimnas cinereus_白眉秧雞
-Polioptila albiloris_White-lored Gnatcatcher
-Polioptila bilineata_White-browed Gnatcatcher
-Polioptila caerulea_Blue-gray Gnatcatcher
-Polioptila californica_California Gnatcatcher
-Polioptila dumicola_Masked Gnatcatcher
-Polioptila lactea_Creamy-bellied Gnatcatcher
-Polioptila lembeyei_Cuban Gnatcatcher
-Polioptila melanura_Black-tailed Gnatcatcher
-Polioptila nigriceps_Black-capped Gnatcatcher
-Polioptila plumbea_Tropical Gnatcatcher
-Polioptila schistaceigula_Slate-throated Gnatcatcher
-Polyboroides typus_African Harrier-Hawk
-Polyerata amabilis_Blue-chested Hummingbird
-Polyerata decora_Charming Hummingbird
-Polyplectron bicalcaratum_Gray Peacock-Pheasant
-Polyplectron chalcurum_Bronze-tailed Peacock-Pheasant
-Polyplectron germaini_Germain's Peacock-Pheasant
-Polyplectron malacense_Malayan Peacock-Pheasant
-Polystictus pectoralis_Bearded Tachuri
-Polystictus superciliaris_Gray-backed Tachuri
-Polytelis anthopeplus_Regent Parrot
-Polytelis swainsonii_Superb Parrot
-Polytmus guainumbi_White-tailed Goldenthroat
-Polytmus theresiae_Green-tailed Goldenthroat
-Pomatorhinus ferruginosus_Coral-billed Scimitar-Babbler (Black-crowned)
-Pomatorhinus horsfieldii_Indian Scimitar-Babbler
-Pomatorhinus melanurus_Sri Lanka Scimitar-Babbler
-Pomatorhinus montanus_Chestnut-backed Scimitar-Babbler (Javan)
-Pomatorhinus musicus_小彎嘴
-Pomatorhinus ochraceiceps_Red-billed Scimitar-Babbler
-Pomatorhinus ruficollis_Streak-breasted Scimitar-Babbler
-Pomatorhinus schisticeps_White-browed Scimitar-Babbler
-Pomatorhinus superciliaris_Slender-billed Scimitar-Babbler
-Pomatostomus ruficeps_Chestnut-crowned Babbler
-Pomatostomus superciliosus_White-browed Babbler
-Pomatostomus temporalis_Gray-crowned Babbler
-Poodytes gramineus_Little Grassbird
-Poodytes punctatus_New Zealand Fernbird
-Pooecetes gramineus_Vesper Sparrow
-Poospiza nigrorufa_Black-and-rufous Warbling Finch
-Porphyrio flavirostris_Azure Gallinule
-Porphyrio madagascariensis_African Swamphen
-Porphyrio martinica_Purple Gallinule
-Porphyrio melanotus_紐澳紫水雞
-Porphyrio poliocephalus_灰頭紫水雞
-Porphyrio porphyrio_Western Swamphen
-Porphyriops melanops_Spot-flanked Gallinule
-Porzana carolina_Sora
-Porzana porzana_斑胸秧雞
-Porzana spiloptera_Dot-winged Crake
+Phylloscopus ogilviegranti_白斑尾柳莺
+Phylloscopus olivaceus_菲律宾柳莺
+Phylloscopus omeiensis_峨眉鹟莺
+Phylloscopus orientalis_东博氏柳莺
+Phylloscopus plumbeitarsus_双斑绿柳莺
+Phylloscopus poliocephalus_海岛柳莺
+Phylloscopus poliogenys_灰脸鹟莺
+Phylloscopus proregulus_黄腰柳莺
+Phylloscopus pulcher_橙斑翅柳莺
+Phylloscopus reguloides_西南冠纹柳莺
+Phylloscopus ruficapilla_黄喉柳莺
+Phylloscopus sarasinorum_隆山柳莺
+Phylloscopus schwarzi_巨嘴柳莺
+Phylloscopus sibilatrix_林柳莺
+Phylloscopus sindianus_东方叽喳柳莺
+Phylloscopus soror_淡尾鹟莺
+Phylloscopus subaffinis_棕腹柳莺
+Phylloscopus subviridis_布氏柳莺
+Phylloscopus tenellipes_淡脚柳莺
+Phylloscopus tephrocephalus_灰冠鹟莺
+Phylloscopus trivirgatus_山柳莺
+Phylloscopus trochiloides_暗绿柳莺
+Phylloscopus trochilus_欧柳莺
+Phylloscopus tytleri_泰氏柳莺
+Phylloscopus umbrovirens_褐林柳莺
+Phylloscopus valentini_比氏鹟莺
+Phylloscopus whistleri_韦氏鹟莺
+Phylloscopus xanthodryas_日本柳莺
+Phylloscopus xanthoschistos_灰头柳莺
+Phylloscopus yunnanensis_云南柳莺
+Phytotoma raimondii_秘鲁割草鸟
+Phytotoma rara_棕尾割草鸟
+Phytotoma rutila_红胸割草鸟
+Piaya cayana_灰腹棕鹃
+Piaya melanogaster_黑腹棕鹃
+Pica bottanensis_青藏喜鹊
+Pica hudsonia_北美喜鹊
+Pica nuttalli_黄嘴喜鹊
+Pica pica_欧亚喜鹊
+Pica serica_喜鹊
+Picoides arcticus_黑背三趾啄木鸟
+Picoides dorsalis_美洲三趾啄木鸟
+Picoides tridactylus_三趾啄木鸟
+Piculus aurulentus_白眉啄木鸟
+Piculus callopterus_纹颊啄木鸟
+Piculus chrysochloros_黄绿啄木鸟
+Piculus flavigula_黄喉啄木鸟
+Piculus leucolaemus_白喉啄木鸟
+Picumnus albosquamatus_白尾姬啄木鸟
+Picumnus aurifrons_金额姬啄木鸟
+Picumnus cinnamomeus_栗姬啄木鸟
+Picumnus cirratus_白斑姬啄木鸟
+Picumnus dorbignyanus_眼斑姬啄木鸟
+Picumnus exilis_亮丽姬啄木鸟
+Picumnus granadensis_灰姬啄木鸟
+Picumnus innominatus_斑姬啄木鸟
+Picumnus lafresnayi_拉氏姬啄木鸟
+Picumnus limae_赭色姬啄木鸟
+Picumnus nebulosus_丽色姬啄木鸟
+Picumnus olivaceus_暗绿姬啄木鸟
+Picumnus pygmaeus_姬啄木鸟
+Picumnus rufiventris_棕胸姬啄木鸟
+Picumnus sclateri_厄瓜多尔姬啄木鸟
+Picumnus spilogaster_白腹姬啄木鸟
+Picumnus squamulatus_鳞斑姬啄木鸟
+Picumnus temminckii_赭领姬啄木鸟
+Picus awokera_日本绿啄木鸟
+Picus canus_灰头绿啄木鸟
+Picus chlorolophus_黄冠啄木鸟
+Picus erythropygius_黑头绿啄木鸟
+Picus puniceus_红翅绿啄木鸟
+Picus sharpei_伊比利亚绿啄木鸟
+Picus squamatus_鳞腹绿啄木鸟
+Picus vaillantii_利氏绿啄木鸟
+Picus viridis_绿啄木鸟
+Picus vittatus_花腹绿啄木鸟
+Picus xanthopygaeus_鳞喉绿啄木鸟
+Pinicola enucleator_松雀
+Pionites leucogaster_白腹凯克鹦哥
+Pionites melanocephalus_黑头凯克鹦哥
+Pionopsitta pileata_红顶鹦哥
+Pionus chalcopterus_青铜翅鹦哥
+Pionus fuscus_暗色鹦哥
+Pionus maximiliani_鳞头鹦哥
+Pionus menstruus_蓝头鹦哥
+Pionus senilis_白冠鹦哥
+Pionus sordidus_红嘴鹦哥
+Pionus tumultuosus_紫冠鹦哥
+Pipile cujubi_红喉鸣冠雉
+Pipile cumanensis_蓝喉鸣冠雉
+Pipilo chlorurus_绿尾唧鹀
+Pipilo erythrophthalmus_棕胁唧鹀
+Pipilo maculatus_斑唧鹀
+Pipilo ocai_领唧鹀
+Pipra aureola_绯红冠娇鹟
+Pipra fasciicauda_斑尾娇鹟
+Pipra filicauda_线尾娇鹟
+Pipraeidea melanonota_黄胸裸鼻雀
+Pipreola arcuata_横斑食果伞鸟
+Pipreola aureopectus_金胸食果伞鸟
+Pipreola formosa_丽色食果伞鸟
+Pipreola frontalis_红胸食果伞鸟
+Pipreola intermedia_斑尾食果伞鸟
+Pipreola jucunda_橙胸食果伞鸟
+Pipreola lubomirskii_黑胸食果伞鸟
+Pipreola riefferii_绿黑食果伞鸟
+Pipreola whitelyi_红斑食果伞鸟
+Piprites chloris_斑翅娇鹟
+Piprites griseiceps_灰头娇鹟
+Piprites pileata_黑顶娇鹟
+Piranga bidentata_火领丽唐纳雀
+Piranga erythrocephala_红头丽唐纳雀
+Piranga flava_南暗红丽唐纳雀
+Piranga leucoptera_白翅丽唐纳雀
+Piranga ludoviciana_黄腹丽唐纳雀
+Piranga olivacea_猩红丽唐纳雀
+Piranga roseogularis_玫喉丽唐纳雀
+Piranga rubra_玫红丽唐纳雀
+Piranga rubriceps_红冠丽唐纳雀
+Pitangus lictor_小食蝇霸鹟
+Pitangus sulphuratus_大食蝇霸鹟
+Pithecophaga jefferyi_菲律宾雕
+Pithys albifrons_白羽蚁鸟
+Pitohui kirhocephalus_杂色林鵙鹟
+Pitta brachyura_印度八色鸫
+Pitta elegans_华丽八色鸫
+Pitta maxima_白胸八色鸫
+Pitta megarhyncha_红树八色鸫
+Pitta moluccensis_蓝翅八色鸫
+Pitta nympha_仙八色鸫
+Pitta sordida_绿胸八色鸫
+Pitta steerii_蓝胸八色鸫
+Pitta versicolor_噪八色鸫
+Pittasoma michleri_黑顶蚁鸫
+Pittasoma rufopileatum_棕冠蚁鸫
+Pityriasis gymnocephala_棘头鵙
+Platalea ajaja_粉红琵鹭
+Platalea leucorodia_白琵鹭
+Platycercus adscitus_淡头玫瑰鹦鹉
+Platycercus caledonicus_绿背玫瑰鹦鹉
+Platycercus elegans_红玫瑰鹦鹉
+Platycercus eximius_东澳玫瑰鹦鹉
+Platylophus galericulatus_冠鸦
+Platyrinchus cancrominus_短尾铲嘴雀
+Platyrinchus coronatus_金冠铲嘴雀
+Platyrinchus flavigularis_黄喉铲嘴雀
+Platyrinchus leucoryphus_黄褐翅铲嘴雀
+Platyrinchus mystaceus_白喉铲嘴雀
+Platyrinchus platyrhynchos_白冠铲嘴雀
+Platyrinchus saturatus_桂红冠铲嘴雀
+Platysmurus leucopterus_白翅鹊
+Platysteira blissetti_红颊疣眼鹟
+Platysteira castanea_栗色疣眼鹟
+Platysteira concreta_栗腹疣眼鹟
+Platysteira cyanea_褐喉疣眼鹟
+Platysteira peltata_黑喉疣眼鹟
+Plectorhyncha lanceolata_纵纹吸蜜鸟
+Plectrophenax hyperboreus_麦氏鹀
+Plectrophenax nivalis_雪鹀
+Plegadis chihi_白脸彩鹮
+Plegadis falcinellus_彩鹮
+Plegadis ridgwayi_秘鲁彩鹮
+Plocepasser mahali_白眉织雀
+Plocepasser superciliosus_栗顶织雀
+Ploceus baglafecht_黄腹织雀
+Ploceus bicolor_灰背织雀
+Ploceus capensis_南非织雀
+Ploceus cucullatus_黑头织雀
+Ploceus galbula_栗脸织雀
+Ploceus hypoxanthus_亚洲金织雀
+Ploceus intermedius_黑脸织雀
+Ploceus jacksoni_苏丹金背织雀
+Ploceus luteolus_小织雀
+Ploceus manyar_纹胸织雀
+Ploceus melanocephalus_黑头黄背织雀
+Ploceus nelicourvi_纳利织雀
+Ploceus nigerrimus_大黑织雀
+Ploceus nigricollis_黑颈织雀
+Ploceus ocularis_眼斑织雀
+Ploceus philippinus_黄胸织雀
+Ploceus sakalava_萨卡织雀
+Ploceus spekei_斯氏织雀
+Ploceus subaureus_东非织巢鸟
+Ploceus velatus_黑额织雀
+Ploceus vitellinus_赤道黑额织雀
+Ploceus xanthops_大金织雀
+Ploceus xanthopterus_褐喉金织雀
+Pluvialis apricaria_欧金鸻
+Pluvialis dominica_美洲金鸻
+Pluvialis fulva_金斑鸻
+Pluvialis squatarola_灰斑鸻
+Pnoepyga albiventer_鳞胸鹪鹛
+Pnoepyga formosana_台湾鹪鹛
+Pnoepyga immaculata_尼泊尔鹪鹛
+Pnoepyga pusilla_小鳞胸鹪鹛
+Podargus ocellatus_云斑蛙口夜鹰
+Podargus strigoides_茶色蛙口夜鹰
+Podiceps auritus_角䴙䴘
+Podiceps cristatus_凤头䴙䴘
+Podiceps gallardoi_阿根廷䴙䴘
+Podiceps grisegena_赤颈䴙䴘
+Podiceps major_大䴙䴘
+Podiceps nigricollis_黑颈䴙䴘
+Podiceps occipitalis_银䴙䴘
+Podilymbus podiceps_斑嘴巨䴙䴘
+Podoces hendersoni_黑尾地鸦
+Poecile atricapillus_黑顶山雀
+Poecile carolinensis_卡罗山雀
+Poecile cinctus_西伯利亚山雀
+Poecile gambeli_北美白眉山雀
+Poecile hudsonicus_北山雀
+Poecile lugubris_暗山雀
+Poecile montanus_褐头山雀
+Poecile palustris_沼泽山雀
+Poecile rufescens_栗背山雀
+Poecile sclateri_墨西哥山雀
+Poecile weigoldicus_川褐头山雀
+Poecilodryas hypoleuca_黑白杂色鹟
+Poecilostreptus cabanisi_蓝腰靓唐纳雀
+Poecilostreptus palmeri_灰黄靓唐纳雀
+Poecilotriccus albifacies_白颊哑霸鹟
+Poecilotriccus calopterus_金翅哑霸鹟
+Poecilotriccus capitalis_黑白哑霸鹟
+Poecilotriccus fumifrons_灰额哑霸鹟
+Poecilotriccus latirostris_锈额哑霸鹟
+Poecilotriccus luluae_红头哑霸鹟
+Poecilotriccus plumbeiceps_赭脸哑霸鹟
+Poecilotriccus ruficeps_棕顶哑霸鹟
+Poecilotriccus russatus_赤黄哑霸鹟
+Poecilotriccus sylvia_蓝灰头哑霸鹟
+Pogoniulus atroflavus_红腰小拟啄木鸟
+Pogoniulus bilineatus_金腰小拟啄木鸟
+Pogoniulus chrysoconus_黄额小拟啄木鸟
+Pogoniulus leucomystax_须绿小拟啄木鸟
+Pogoniulus pusillus_红额小拟啄木鸟
+Pogoniulus scolopaceus_点斑小拟啄木鸟
+Pogoniulus simplex_绿小拟啄木鸟
+Pogoniulus subsulphureus_黄喉小拟啄木鸟
+Pogonocichla stellata_白点鸲
+Poicephalus cryptoxanthus_褐头鹦鹉
+Poicephalus fuscicollis_褐颈鹦鹉
+Poicephalus meyeri_褐鹦鹉
+Poicephalus robustus_好望角鹦鹉
+Poicephalus rufiventris_红腹鹦鹉
+Poicephalus senegalus_塞内加尔鹦鹉
+Poliocrania exsul_栗背蚁鸟
+Poliolimnas cinereus_白眉田鸡
+Polioptila albiloris_白眼先蚋莺
+Polioptila bilineata_白眉蚋莺
+Polioptila caerulea_灰蓝蚋莺
+Polioptila californica_加州蚋莺
+Polioptila dumicola_花脸蚋莺
+Polioptila lactea_白腹蚋莺
+Polioptila lembeyei_古巴蚋莺
+Polioptila melanura_黑尾蚋莺
+Polioptila nigriceps_黑顶蚋莺
+Polioptila plumbea_热带蚋莺
+Polioptila schistaceigula_灰喉蚋莺
+Polyboroides typus_非洲鬣鹰
+Polyerata amabilis_蓝胸蜂鸟
+Polyerata decora_娇蜂鸟
+Polyplectron bicalcaratum_灰孔雀雉
+Polyplectron chalcurum_铜尾孔雀雉
+Polyplectron germaini_眼斑孔雀雉
+Polyplectron malacense_凤冠孔雀雉
+Polystictus pectoralis_须多斑霸鹟
+Polystictus superciliaris_灰背多斑霸鹟
+Polytelis anthopeplus_黄鹦鹉
+Polytelis swainsonii_靓鹦鹉
+Polytmus guainumbi_白尾金喉蜂鸟
+Polytmus theresiae_绿尾金喉蜂鸟
+Pomatorhinus ferruginosus_黑冠钩嘴鹛
+Pomatorhinus horsfieldii_霍氏钩嘴鹛
+Pomatorhinus melanurus_斯里兰卡钩嘴鹛
+Pomatorhinus montanus_栗背钩嘴鹛
+Pomatorhinus musicus_台湾棕颈钩嘴鹛
+Pomatorhinus ochraceiceps_棕头钩嘴鹛
+Pomatorhinus ruficollis_棕颈钩嘴鹛
+Pomatorhinus schisticeps_灰头钩嘴鹛
+Pomatorhinus superciliaris_剑嘴鹛
+Pomatostomus ruficeps_栗冠弯嘴鹛
+Pomatostomus superciliosus_白眉弯嘴鹛
+Pomatostomus temporalis_灰冠弯嘴鹛
+Poodytes gramineus_姬蝗莺
+Poodytes punctatus_新西兰蝗莺
+Pooecetes gramineus_栗肩雀鹀
+Poospiza nigrorufa_棕黑歌鹀
+Porphyrio flavirostris_淡青水鸡
+Porphyrio madagascariensis_非洲紫水鸡
+Porphyrio martinica_紫青水鸡
+Porphyrio melanotus_澳洲紫水鸡
+Porphyrio poliocephalus_紫水鸡
+Porphyrio porphyrio_西紫水鸡
+Porphyriops melanops_斑胁水鸡
+Porzana carolina_黑脸田鸡
+Porzana porzana_斑胸田鸡
+Porzana spiloptera_点翅田鸡
 Power tools_Power tools
-Premnoplex brunnescens_Spotted Barbtail
-Premnornis guttuliger_Rusty-winged Barbtail
-Primolius auricollis_黃領金剛鸚鵡
-Primolius couloni_Blue-headed Macaw
-Primolius maracana_Blue-winged Macaw
-Prinia atrogularis_Black-throated Prinia
-Prinia bairdii_Banded Prinia
-Prinia buchanani_Rufous-fronted Prinia
-Prinia crinigera_Himalayan Prinia
-Prinia erythroptera_Red-winged Prinia
-Prinia familiaris_Bar-winged Prinia
-Prinia flavicans_Black-chested Prinia
-Prinia flaviventris_灰頭鷦鶯
-Prinia gracilis_Graceful Prinia
-Prinia hodgsonii_Gray-breasted Prinia
-Prinia hypoxantha_Drakensberg Prinia
-Prinia inornata_褐頭鷦鶯
-Prinia lepida_Delicate Prinia
-Prinia maculosa_Karoo Prinia
-Prinia polychroa_Brown Prinia
-Prinia rufescens_Rufescent Prinia
-Prinia rufifrons_Red-fronted Prinia
-Prinia socialis_Ashy Prinia
-Prinia striata_斑紋鷦鶯
-Prinia subflava_Tawny-flanked Prinia
-Prinia superciliaris_Hill Prinia
-Prinia sylvatica_Jungle Prinia
-Prionochilus maculatus_Yellow-breasted Flowerpecker
-Prionochilus thoracicus_Scarlet-breasted Flowerpecker
-Prionochilus xanthopygius_Yellow-rumped Flowerpecker
-Prionops plumatus_White Helmetshrike
-Prionops retzii_Retz's Helmetshrike
-Priotelus roseigaster_Hispaniolan Trogon
-Priotelus temnurus_Cuban Trogon
-Probosciger aterrimus_Palm Cockatoo
-Procarduelis nipalensis_Dark-breasted Rosefinch
-Procnias albus_White Bellbird
-Procnias averano_Bearded Bellbird
-Procnias nudicollis_Bare-throated Bellbird
-Procnias tricarunculatus_Three-wattled Bellbird
-Progne chalybea_Gray-breasted Martin
-Progne elegans_Southern Martin
-Progne subis_Purple Martin
-Progne tapera_Brown-chested Martin
-Promerops cafer_Cape Sugarbird
-Prosopeia personata_Masked Shining-Parrot
-Prosopeia tabuensis_Red Shining-Parrot
-Prosthemadera novaeseelandiae_Tui
-Protonotaria citrea_Prothonotary Warbler
-Prunella collaris_岩鷚
-Prunella fulvescens_Brown Accentor
-Prunella modularis_Dunnock
-Prunella montanella_棕眉山岩鷚
-Prunella ocularis_Radde's Accentor
-Prunella rubeculoides_Robin Accentor
-Prunella strophiata_Rufous-breasted Accentor
-Psalidoprocne pristoptera_Black Sawwing
-Psaltriparus minimus_Bushtit
-Psarisomus dalhousiae_Long-tailed Broadbill
-Psarocolius angustifrons_Russet-backed Oropendola
-Psarocolius atrovirens_Dusky-green Oropendola
-Psarocolius bifasciatus_Olive Oropendola
-Psarocolius decumanus_Crested Oropendola
-Psarocolius montezuma_Montezuma Oropendola
-Psarocolius viridis_Green Oropendola
-Psarocolius wagleri_Chestnut-headed Oropendola
-Psephotus haematonotus_Red-rumped Parrot
-Psephotus varius_Mulga Parrot
+Premnoplex brunnescens_点斑尾雀
+Premnornis guttuliger_锈翅斑尾雀
+Primolius auricollis_金领金刚鹦鹉
+Primolius couloni_蓝头金刚鹦鹉
+Primolius maracana_蓝翅金刚鹦鹉
+Prinia atrogularis_黑胸山鹪莺
+Prinia bairdii_横斑山鹪莺
+Prinia buchanani_棕额山鹪莺
+Prinia crinigera_喜山山鹪莺
+Prinia erythroptera_红翅山鹪莺
+Prinia familiaris_斑翅山鹪莺
+Prinia flavicans_黑胸鹪莺
+Prinia flaviventris_黄腹山鹪莺
+Prinia gracilis_优雅山鹪莺
+Prinia hodgsonii_灰胸山鹪莺
+Prinia hypoxantha_德拉山鹪莺
+Prinia inornata_纯色山鹪莺
+Prinia lepida_娇美山鹪莺
+Prinia maculosa_斑山鹪莺
+Prinia polychroa_褐山鹪莺
+Prinia rufescens_暗冕山鹪莺
+Prinia rufifrons_红脸娇莺
+Prinia socialis_灰山鹪莺
+Prinia striata_山鹪莺
+Prinia subflava_褐胁鹪莺
+Prinia superciliaris_黑喉山鹪莺
+Prinia sylvatica_丛林山鹪莺
+Prionochilus maculatus_黄喉锯齿啄花鸟
+Prionochilus thoracicus_赤胸锯齿啄花鸟
+Prionochilus xanthopygius_婆罗洲啄花鸟
+Prionops plumatus_长冠盔鵙
+Prionops retzii_雷氏盔鵙
+Priotelus roseigaster_伊岛咬鹃
+Priotelus temnurus_古巴咬鹃
+Probosciger aterrimus_棕树凤头鹦鹉
+Procarduelis nipalensis_暗胸朱雀
+Procnias albus_白钟伞鸟
+Procnias averano_须钟伞鸟
+Procnias nudicollis_裸喉钟伞鸟
+Procnias tricarunculatus_肉垂钟伞鸟
+Progne chalybea_灰胸崖燕
+Progne elegans_南美崖燕
+Progne subis_紫崖燕
+Progne tapera_棕胸崖燕
+Promerops cafer_长尾食蜜鸟
+Prosopeia personata_黄胸辉鹦鹉
+Prosopeia tabuensis_红胸辉鹦鹉
+Prosthemadera novaeseelandiae_簇胸吸蜜鸟
+Protonotaria citrea_蓝翅黄森莺
+Prunella collaris_领岩鹨
+Prunella fulvescens_褐岩鹨
+Prunella modularis_林岩鹨
+Prunella montanella_棕眉山岩鹨
+Prunella ocularis_眼斑岩鹨
+Prunella rubeculoides_鸲岩鹨
+Prunella strophiata_棕胸岩鹨
+Psalidoprocne pristoptera_蓝锯翅燕
+Psaltriparus minimus_短嘴长尾山雀
+Psarisomus dalhousiae_长尾阔嘴鸟
+Psarocolius angustifrons_褐背拟椋鸟
+Psarocolius atrovirens_暗绿拟椋鸟
+Psarocolius bifasciatus_亚马孙拟椋鸟
+Psarocolius decumanus_发冠拟椋鸟
+Psarocolius montezuma_褐拟椋鸟
+Psarocolius viridis_绿拟椋鸟
+Psarocolius wagleri_栗头拟椋鸟
+Psephotus haematonotus_红腰鹦鹉
+Psephotus varius_穆加鹦鹉
 Pseudacris brimleyi_Brimley's Chorus Frog
 Pseudacris clarkii_Spotted Chorus Frog
 Pseudacris crucifer_Spring Peeper
@@ -4938,1585 +4938,1585 @@ Pseudacris ocularis_Little Grass Frog
 Pseudacris ornata_Ornate Chorus Frog
 Pseudacris streckeri_Strecker's Chorus Frog
 Pseudacris triseriata_Striped Chorus Frog
-Pseudasthenes humicola_Dusky-tailed Canastero
-Pseudastur albicollis_White Hawk
-Pseudastur occidentalis_Gray-backed Hawk
-Pseudelaenia leucospodia_Gray-and-white Tyrannulet
-Pseudeos cardinalis_Cardinal Lory
-Pseudibis papillosa_Red-naped Ibis
-Pseudocolaptes boissonneautii_Streaked Tuftedcheek
-Pseudocolaptes lawrencii_Buffy Tuftedcheek
-Pseudocolopteryx citreola_Ticking Doradito
-Pseudocolopteryx dinelliana_Dinelli's Doradito
-Pseudocolopteryx flaviventris_Warbling Doradito
-Pseudocolopteryx sclateri_Crested Doradito
-Pseudoleistes guirahuro_Yellow-rumped Marshbird
-Pseudoleistes virescens_Brown-and-yellow Marshbird
-Pseudonestor xanthophrys_Maui Parrotbill
-Pseudonigrita arnaudi_Gray-headed Social-Weaver
-Pseudopipra pipra_White-crowned Manakin
-Pseudopodoces humilis_Ground Tit
-Pseudorectes ferrugineus_Rusty Pitohui
-Pseudoseisura cristata_Caatinga Cacholote
-Pseudoseisura gutturalis_White-throated Cacholote
-Pseudoseisura lophotes_Brown Cacholote
-Pseudoseisura unirufa_Rufous Cacholote
-Pseudospingus verticalis_Black-headed Hemispingus
-Pseudotriccus pelzelni_Bronze-olive Pygmy-Tyrant
-Pseudotriccus ruficeps_Rufous-headed Pygmy-Tyrant
-Psilopogon annamensis_Indochinese Barbet
-Psilopogon armillaris_Flame-fronted Barbet
-Psilopogon asiaticus_Blue-throated Barbet
-Psilopogon auricularis_Necklaced Barbet
-Psilopogon australis_Little Barbet
-Psilopogon chrysopogon_Gold-whiskered Barbet
-Psilopogon corvinus_Brown-throated Barbet
-Psilopogon duvaucelii_Blue-eared Barbet
-Psilopogon eximius_Bornean Barbet
-Psilopogon faber_Chinese Barbet
-Psilopogon faiostrictus_Green-eared Barbet
-Psilopogon flavifrons_Yellow-fronted Barbet
-Psilopogon franklinii_Golden-throated Barbet
-Psilopogon haemacephalus_Coppersmith Barbet
-Psilopogon henricii_Yellow-crowned Barbet
-Psilopogon incognitus_Moustached Barbet
-Psilopogon lagrandieri_Red-vented Barbet
-Psilopogon lineatus_Lineated Barbet
-Psilopogon malabaricus_Malabar Barbet
-Psilopogon monticola_Mountain Barbet
-Psilopogon mystacophanos_Red-throated Barbet
-Psilopogon nuchalis_五色鳥
-Psilopogon oorti_Black-browed Barbet
-Psilopogon pulcherrimus_Golden-naped Barbet
-Psilopogon pyrolophus_Fire-tufted Barbet
-Psilopogon rafflesii_Red-crowned Barbet
-Psilopogon rubricapillus_Crimson-fronted Barbet
-Psilopogon virens_Great Barbet
-Psilopogon viridis_White-cheeked Barbet
-Psilopogon zeylanicus_Brown-headed Barbet
-Psilopsiagon aurifrons_Mountain Parakeet
-Psilopsiagon aymara_Gray-hooded Parakeet
-Psilorhamphus guttatus_Spotted Bamboowren
-Psilorhinus morio_Brown Jay
-Psiloscops flammeolus_Flammulated Owl
-Psittacara erythrogenys_紅臉鸚鵡
-Psittacara finschi_Crimson-fronted Parakeet
-Psittacara holochlorus_Green Parakeet
-Psittacara leucophthalmus_White-eyed Parakeet
-Psittacara mitratus_Mitred Parakeet
-Psittacara strenuus_Pacific Parakeet
-Psittacara wagleri_Scarlet-fronted Parakeet
-Psittacula alexandri_Red-breasted Parakeet
-Psittacula calthrapae_Layard's Parakeet
-Psittacula columboides_Malabar Parakeet
-Psittacula cyanocephala_Plum-headed Parakeet
-Psittacula eques_Echo Parakeet
-Psittacula eupatria_亞歷山大鸚鵡
-Psittacula finschii_Gray-headed Parakeet
-Psittacula himalayana_Slaty-headed Parakeet
-Psittacula krameri_紅領綠鸚鵡
-Psittacula longicauda_Long-tailed Parakeet
-Psittacus erithacus_灰鸚鵡
-Psittinus cyanurus_Blue-rumped Parrot
+Pseudasthenes humicola_乌尾卡纳灶鸟
+Pseudastur albicollis_白南美鵟
+Pseudastur occidentalis_灰背南美鵟
+Pseudelaenia leucospodia_灰白小霸鹟
+Pseudeos cardinalis_暗红鹦鹉
+Pseudibis papillosa_黑鹮
+Pseudocolaptes boissonneautii_条纹簇颊灶鸫
+Pseudocolaptes lawrencii_黄簇颊灶鸫
+Pseudocolopteryx citreola_滴答多拉霸鹟
+Pseudocolopteryx dinelliana_南美多拉霸鹟
+Pseudocolopteryx flaviventris_拟莺多拉霸鹟
+Pseudocolopteryx sclateri_冠多拉霸鹟
+Pseudoleistes guirahuro_黄腰沼泽雀
+Pseudoleistes virescens_褐黄沼泽雀
+Pseudonestor xanthophrys_毛岛鹦嘴雀
+Pseudonigrita arnaudi_灰头群织雀
+Pseudopipra pipra_白冠娇鹟
+Pseudopodoces humilis_地山雀
+Pseudorectes ferrugineus_锈色林鵙鹟
+Pseudoseisura cristata_棕巨灶鸫
+Pseudoseisura gutturalis_白喉巨灶鸫
+Pseudoseisura lophotes_褐巨灶鸫
+Pseudoseisura unirufa_灰冠巨灶鸫
+Pseudospingus verticalis_黑头拟雀
+Pseudotriccus pelzelni_铜绿侏霸鹟
+Pseudotriccus ruficeps_棕头侏霸鹟
+Psilopogon annamensis_中南拟啄木鸟
+Psilopogon armillaris_蓝顶拟啄木鸟
+Psilopogon asiaticus_蓝喉拟啄木鸟
+Psilopogon auricularis_斑喉拟啄木鸟
+Psilopogon australis_黄耳拟啄木鸟
+Psilopogon chrysopogon_金须拟啄木鸟
+Psilopogon corvinus_褐喉拟啄木鸟
+Psilopogon duvaucelii_黑耳拟啄木鸟
+Psilopogon eximius_加里曼丹拟啄木鸟
+Psilopogon faber_黑眉拟啄木鸟
+Psilopogon faiostrictus_黄纹拟啄木鸟
+Psilopogon flavifrons_黄额拟啄木鸟
+Psilopogon franklinii_金喉拟啄木鸟
+Psilopogon haemacephalus_赤胸拟啄木鸟
+Psilopogon henricii_黄顶拟啄木鸟
+Psilopogon incognitus_休氏拟啄木鸟
+Psilopogon lagrandieri_红臀拟啄木鸟
+Psilopogon lineatus_斑头绿拟啄木鸟
+Psilopogon malabaricus_马拉巴拟啄木鸟
+Psilopogon monticola_山拟啄木鸟
+Psilopogon mystacophanos_丽色拟啄木鸟
+Psilopogon nuchalis_台湾拟啄木鸟
+Psilopogon oorti_马来拟啄木鸟
+Psilopogon pulcherrimus_金枕拟啄木鸟
+Psilopogon pyrolophus_火簇拟啄木鸟
+Psilopogon rafflesii_花彩拟啄木鸟
+Psilopogon rubricapillus_斯里兰卡拟啄木鸟
+Psilopogon virens_大拟啄木鸟
+Psilopogon viridis_小绿拟啄木鸟
+Psilopogon zeylanicus_棕头绿拟啄木鸟
+Psilopsiagon aurifrons_山鹦哥
+Psilopsiagon aymara_灰顶鹦哥
+Psilorhamphus guttatus_斑竹鹩
+Psilorhinus morio_褐鸦
+Psiloscops flammeolus_美洲角鸮
+Psittacara erythrogenys_红头鹦哥
+Psittacara finschi_绯额鹦哥
+Psittacara holochlorus_绿鹦哥
+Psittacara leucophthalmus_白眼鹦哥
+Psittacara mitratus_红耳绿鹦哥
+Psittacara strenuus_尼加拉瓜绿鹦哥
+Psittacara wagleri_红额鹦哥
+Psittacula alexandri_绯胸鹦鹉
+Psittacula calthrapae_艳绿领鹦鹉
+Psittacula columboides_马拉巴鹦鹉
+Psittacula cyanocephala_紫头鹦鹉
+Psittacula eques_毛里求斯鹦鹉
+Psittacula eupatria_亚历山大鹦鹉
+Psittacula finschii_灰头鹦鹉
+Psittacula himalayana_青头鹦鹉
+Psittacula krameri_红领绿鹦鹉
+Psittacula longicauda_长尾鹦鹉
+Psittacus erithacus_非洲灰鹦鹉
+Psittinus cyanurus_蓝腰鹦鹉
 Psittiparus gularis_Gray-headed Parrotbill
-Psophia crepitans_Gray-winged Trumpeter
-Psophia leucoptera_Pale-winged Trumpeter
-Psophia viridis_Dark-winged Trumpeter
-Psophocichla litsitsirupa_Groundscraper Thrush
-Psophodes cristatus_Chirruping Wedgebill
-Psophodes nigrogularis_Western Whipbird
-Psophodes occidentalis_Chiming Wedgebill
-Psophodes olivaceus_Eastern Whipbird
-Pteridophora alberti_King-of-Saxony Bird-of-Paradise
-Pternistis adspersus_Red-billed Francolin
-Pternistis afer_Red-necked Francolin
-Pternistis ahantensis_Ahanta Francolin
-Pternistis bicalcaratus_Double-spurred Francolin
-Pternistis capensis_Cape Francolin
-Pternistis erckelii_Erckel's Francolin
-Pternistis hildebrandti_Hildebrandt's Francolin
-Pternistis leucoscepus_Yellow-necked Francolin
-Pternistis natalensis_Natal Francolin
-Pternistis squamatus_Scaly Francolin
-Pternistis swainsonii_Swainson's Francolin
-Pterocles alchata_Pin-tailed Sandgrouse
-Pterocles exustus_Chestnut-bellied Sandgrouse
-Pterocles namaqua_Namaqua Sandgrouse
-Pterocles orientalis_Black-bellied Sandgrouse
-Pterocles senegallus_Spotted Sandgrouse
-Pterodroma cervicalis_White-necked Petrel
-Pterodroma cookii_Cook's Petrel
-Pterodroma externa_Juan Fernandez Petrel
-Pterodroma hypoleuca_白腹穴鳥
-Pterodroma inexpectata_Mottled Petrel
-Pterodroma madeira_Zino's Petrel
-Pterodroma neglecta_克島圓尾穴鳥
-Pterodroma nigripennis_Black-winged Petrel
-Pterodroma phaeopygia_Galapagos Petrel
-Pterodroma sandwichensis_Hawaiian Petrel
-Pteroglossus aracari_Black-necked Aracari
-Pteroglossus azara_Ivory-billed Aracari
-Pteroglossus bailloni_Saffron Toucanet
-Pteroglossus beauharnaisii_Curl-crested Aracari
-Pteroglossus bitorquatus_Red-necked Aracari
-Pteroglossus castanotis_Chestnut-eared Aracari
-Pteroglossus frantzii_Fiery-billed Aracari
-Pteroglossus inscriptus_Lettered Aracari
-Pteroglossus pluricinctus_Many-banded Aracari
-Pteroglossus torquatus_Collared Aracari
+Psophia crepitans_灰翅喇叭声鹤
+Psophia leucoptera_白翅喇叭声鹤
+Psophia viridis_绿翅喇叭声鹤
+Psophocichla litsitsirupa_非洲地鸫
+Psophodes cristatus_东啸冠鸫
+Psophodes nigrogularis_黑喉啸冠鸫
+Psophodes occidentalis_西啸冠鸫
+Psophodes olivaceus_绿啸冠鸫
+Pteridophora alberti_萨克森极乐鸟
+Pternistis adspersus_红嘴鹧鸪
+Pternistis afer_红喉鹧鸪
+Pternistis ahantensis_褐顶鹧鸪
+Pternistis bicalcaratus_双距鹧鸪
+Pternistis capensis_南非鹧鸪
+Pternistis erckelii_棕顶鹧鸪
+Pternistis hildebrandti_希氏鹧鸪
+Pternistis leucoscepus_黄颈鹧鸪
+Pternistis natalensis_纳塔尔鹧鸪
+Pternistis squamatus_鳞斑鹧鸪
+Pternistis swainsonii_斯氏鹧鸪
+Pterocles alchata_白腹沙鸡
+Pterocles exustus_栗腹沙鸡
+Pterocles namaqua_南非沙鸡
+Pterocles orientalis_黑腹沙鸡
+Pterocles senegallus_斑沙鸡
+Pterodroma cervicalis_白领圆尾鹱
+Pterodroma cookii_黑脚圆尾鹱
+Pterodroma externa_白颈圆尾鹱
+Pterodroma hypoleuca_白额圆尾鹱
+Pterodroma inexpectata_鳞斑圆尾鹱
+Pterodroma madeira_马德拉圆尾鹱
+Pterodroma neglecta_克岛圆尾鹱
+Pterodroma nigripennis_黑翅圆尾鹱
+Pterodroma phaeopygia_暗腰圆尾鹱
+Pterodroma sandwichensis_夏威夷圆尾鹱
+Pteroglossus aracari_黑颈簇舌巨嘴鸟
+Pteroglossus azara_白嘴簇舌巨嘴鸟
+Pteroglossus bailloni_橘黄巨嘴鸟
+Pteroglossus beauharnaisii_曲冠簇舌巨嘴鸟
+Pteroglossus bitorquatus_红颈簇舌巨嘴鸟
+Pteroglossus castanotis_栗耳簇舌巨嘴鸟
+Pteroglossus frantzii_红嘴簇舌巨嘴鸟
+Pteroglossus inscriptus_巴西簇舌巨嘴鸟
+Pteroglossus pluricinctus_多斑簇舌巨嘴鸟
+Pteroglossus torquatus_领簇舌巨嘴鸟
 Pterophylla camellifolia_Common True Katydid
-Pteroptochos castaneus_Chestnut-throated Huet-huet
-Pteroptochos megapodius_Moustached Turca
-Pteroptochos tarnii_Black-throated Huet-huet
-Pterorhinus albogularis_White-throated Laughingthrush
-Pterorhinus berthemyi_Buffy Laughingthrush
-Pterorhinus chinensis_黑喉噪眉
-Pterorhinus davidi_Pere David's Laughingthrush
-Pterorhinus delesserti_Wayanad Laughingthrush
-Pterorhinus mitratus_Chestnut-capped Laughingthrush
-Pterorhinus pectoralis_Greater Necklaced Laughingthrush
-Pterorhinus perspicillatus_黑臉噪眉
-Pterorhinus poecilorhynchus_棕噪眉
-Pterorhinus ruficollis_Rufous-necked Laughingthrush
-Pterorhinus sannio_白頰噪眉
-Pterorhinus treacheri_Chestnut-hooded Laughingthrush
-Pteruthius aeralatus_White-browed Shrike-Babbler
-Pteruthius intermedius_Clicking Shrike-Babbler
-Pteruthius melanotis_Black-eared Shrike-Babbler
+Pteroptochos castaneus_栗喉隐窜鸟
+Pteroptochos megapodius_须隐窜鸟
+Pteroptochos tarnii_黑喉隐窜鸟
+Pterorhinus albogularis_白喉噪鹛
+Pterorhinus berthemyi_棕噪鹛
+Pterorhinus chinensis_黑喉噪鹛
+Pterorhinus davidi_山噪鹛
+Pterorhinus delesserti_灰胸噪鹛
+Pterorhinus mitratus_栗顶噪鹛
+Pterorhinus pectoralis_黑领噪鹛
+Pterorhinus perspicillatus_黑脸噪鹛
+Pterorhinus poecilorhynchus_台湾棕噪鹛
+Pterorhinus ruficollis_栗颈噪鹛
+Pterorhinus sannio_白颊噪鹛
+Pterorhinus treacheri_栗头噪鹛
+Pteruthius aeralatus_红翅鵙鹛
+Pteruthius intermedius_栗额鵙鹛
+Pteruthius melanotis_栗喉鵙鹛
 Pteruthius ripleyi_Himalayan Shrike-Babbler
-Pteruthius rufiventer_Black-headed Shrike-Babbler
-Pteruthius xanthochlorus_Green Shrike-Babbler
-Ptilinopus iozonus_Orange-bellied Fruit-Dove
-Ptilinopus magnificus_Wompoo Fruit-Dove
-Ptilinopus melanospilus_Black-naped Fruit-Dove
-Ptilinopus occipitalis_Yellow-breasted Fruit-Dove
-Ptilinopus pelewensis_Palau Fruit-Dove
-Ptilinopus porphyraceus_Crimson-crowned Fruit-Dove
-Ptilinopus regina_Rose-crowned Fruit-Dove
-Ptilinopus rivoli_White-breasted Fruit-Dove
-Ptilinopus solomonensis_Yellow-bibbed Fruit-Dove (Yellow-banded)
-Ptilinopus superbus_Superb Fruit-Dove
-Ptilinopus viridis_Claret-breasted Fruit-Dove
-Ptiliogonys caudatus_Long-tailed Silky-flycatcher
-Ptiliogonys cinereus_Gray Silky-flycatcher
-Ptilocichla falcata_Falcated Wren-Babbler
-Ptilocichla leucogrammica_Bornean Wren-Babbler
-Ptilocichla mindanensis_Striated Wren-Babbler
-Ptilonorhynchus violaceus_Satin Bowerbird
-Ptilopachus petrosus_Stone Partridge
-Ptiloprora guisei_Rufous-backed Honeyeater
-Ptiloprora perstriata_Gray-streaked Honeyeater
-Ptilopsis leucotis_Northern White-faced Owl
-Ptiloris magnificus_Magnificent Riflebird
-Ptiloris paradiseus_Paradise Riflebird
-Ptiloris victoriae_Victoria's Riflebird
-Ptilorrhoa caerulescens_Blue Jewel-babbler
-Ptilorrhoa castanonota_Chestnut-backed Jewel-babbler
-Ptilorrhoa leucosticta_Spotted Jewel-babbler
-Ptilostomus afer_Piapiac
-Ptilotula fusca_Fuscous Honeyeater
-Ptilotula ornata_Yellow-plumed Honeyeater
-Ptilotula penicillata_White-plumed Honeyeater
-Ptiloxena atroviolacea_Cuban Blackbird
-Ptyonoprogne concolor_Dusky Crag-Martin
-Ptyonoprogne fuligula_Rock Martin
-Ptyonoprogne rupestris_Eurasian Crag-Martin
-Pucrasia macrolopha_Koklass Pheasant
-Puffinus bailloni_Tropical Shearwater
-Puffinus nativitatis_Christmas Shearwater
-Puffinus newelli_Newell's Shearwater
-Puffinus puffinus_Manx Shearwater
-Pulsatrix koeniswaldiana_Tawny-browed Owl
-Pulsatrix melanota_Band-bellied Owl
-Pulsatrix perspicillata_Spectacled Owl
-Purnella albifrons_White-fronted Honeyeater
-Purpureicephalus spurius_Red-capped Parrot
-Pycnonotus aurigaster_白喉紅臀鵯
-Pycnonotus barbatus_Common Bulbul
-Pycnonotus brunneus_Red-eyed Bulbul
-Pycnonotus cafer_Red-vented Bulbul
-Pycnonotus capensis_Cape Bulbul
-Pycnonotus conradi_Streak-eared Bulbul
-Pycnonotus finlaysoni_Stripe-throated Bulbul
-Pycnonotus flavescens_Flavescent Bulbul
-Pycnonotus goiavier_Yellow-vented Bulbul
-Pycnonotus jocosus_紅耳鵯
-Pycnonotus leucogenys_Himalayan Bulbul
-Pycnonotus leucotis_White-eared Bulbul
-Pycnonotus luteolus_White-browed Bulbul
-Pycnonotus nigricans_Black-fronted Bulbul
-Pycnonotus plumosus_Olive-winged Bulbul
-Pycnonotus simplex_Cream-vented Bulbul
-Pycnonotus sinensis_白頭翁
-Pycnonotus striatus_Striated Bulbul
-Pycnonotus taivanus_烏頭翁
-Pycnonotus xantholaemus_Yellow-throated Bulbul
-Pycnonotus xanthopygos_White-spectacled Bulbul
-Pycnonotus xanthorrhous_Brown-breasted Bulbul
-Pycnonotus zeylanicus_Straw-headed Bulbul
-Pycnoptilus floccosus_Pilotbird
-Pygarrhichas albogularis_White-throated Treerunner
-Pygiptila stellaris_Spot-winged Antshrike
-Pygochelidon cyanoleuca_Blue-and-white Swallow
-Pygoscelis adeliae_Adelie Penguin
-Pygoscelis antarcticus_Chinstrap Penguin
-Pygoscelis papua_Gentoo Penguin
-Pyriglena atra_Fringe-backed Fire-eye
-Pyriglena leuconota_East Amazonian Fire-eye
-Pyriglena leucoptera_White-shouldered Fire-eye
-Pyriglena maura_Western Fire-eye
-Pyrilia barrabandi_Orange-cheeked Parrot
-Pyrilia caica_Caica Parrot
-Pyrilia haematotis_Brown-hooded Parrot
-Pyrilia pulchra_Rose-faced Parrot
-Pyrilia pyrilia_Saffron-headed Parrot
-Pyrocephalus rubinus_Vermilion Flycatcher
-Pyroderus scutatus_Red-ruffed Fruitcrow
-Pyrope pyrope_Fire-eyed Diucon
-Pyrrhocorax graculus_Yellow-billed Chough
-Pyrrhocorax pyrrhocorax_紅嘴山鴉
-Pyrrholaemus brunneus_Redthroat
-Pyrrholaemus sagittatus_Speckled Warbler
-Pyrrhomyias cinnamomeus_Cinnamon Flycatcher
-Pyrrhula erythaca_Gray-headed Bullfinch
-Pyrrhula nipalensis_褐鷽
-Pyrrhula pyrrhula_歐亞鷽
-Pyrrhura albipectus_White-necked Parakeet
-Pyrrhura amazonum_Santarem Parakeet
-Pyrrhura calliptera_Brown-breasted Parakeet
-Pyrrhura cruentata_Ochre-marked Parakeet
-Pyrrhura frontalis_Maroon-bellied Parakeet
-Pyrrhura hoematotis_Red-eared Parakeet
-Pyrrhura hoffmanni_Sulphur-winged Parakeet
-Pyrrhura leucotis_Maroon-faced Parakeet
-Pyrrhura melanura_Maroon-tailed Parakeet
-Pyrrhura molinae_Green-cheeked Parakeet
-Pyrrhura orcesi_El Oro Parakeet
-Pyrrhura perlata_Crimson-bellied Parakeet
-Pyrrhura picta_Painted Parakeet
-Pyrrhura rhodocephala_Rose-headed Parakeet
-Pyrrhura roseifrons_Rose-fronted Parakeet
-Pyrrhura rupicola_Black-capped Parakeet
-Pyrrhura viridicata_Santa Marta Parakeet
-Pytilia melba_Green-winged Pytilia
-Quelea quelea_Red-billed Quelea
-Querula purpurata_Purple-throated Fruitcrow
-Quiscalus lugubris_Carib Grackle
-Quiscalus major_Boat-tailed Grackle
-Quiscalus mexicanus_Great-tailed Grackle
-Quiscalus nicaraguensis_Nicaraguan Grackle
-Quiscalus niger_Greater Antillean Grackle
-Quiscalus quiscula_Common Grackle
-Radjah radjah_Radjah Shelduck
-Rallina eurizonoides_灰腳秧雞
-Rallina fasciata_紅腳秧雞
-Rallina tricolor_Red-necked Crake
-Rallus antarcticus_Austral Rail
-Rallus aquaticus_西方秧雞
-Rallus caerulescens_African Rail
-Rallus crepitans_Clapper Rail
-Rallus elegans_King Rail
-Rallus indicus_東亞秧雞
-Rallus limicola_Virginia Rail
-Rallus longirostris_Mangrove Rail
-Rallus obsoletus_Ridgway's Rail
-Rallus semiplumbeus_Bogota Rail
-Rallus tenuirostris_Aztec Rail
-Ramphastos ambiguus_Yellow-throated Toucan
-Ramphastos brevis_Choco Toucan
-Ramphastos dicolorus_Red-breasted Toucan
-Ramphastos sulfuratus_Keel-billed Toucan
-Ramphastos toco_Toco Toucan
-Ramphastos tucanus_White-throated Toucan
-Ramphastos vitellinus_Channel-billed Toucan
-Ramphocaenus melanurus_Long-billed Gnatwren
-Ramphocaenus sticturus_Chattering Gnatwren
-Ramphocelus bresilius_Brazilian Tanager
-Ramphocelus carbo_Silver-beaked Tanager
-Ramphocelus dimidiatus_Crimson-backed Tanager
-Ramphocelus flammigerus_Flame-rumped Tanager
-Ramphocelus melanogaster_Black-bellied Tanager
-Ramphocelus nigrogularis_Masked Crimson Tanager
-Ramphocelus passerinii_Scarlet-rumped Tanager
-Ramphocelus sanguinolentus_Crimson-collared Tanager
-Ramphodon naevius_Saw-billed Hermit
-Ramphomicron microrhynchum_Purple-backed Thornbill
-Ramphotrigon flammulatum_Flammulated Flycatcher
-Ramphotrigon fuscicauda_Dusky-tailed Flatbill
-Ramphotrigon megacephalum_Large-headed Flatbill
-Ramphotrigon ruficauda_Rufous-tailed Flatbill
-Ramsayornis modestus_Brown-backed Honeyeater
-Rauenia bonariensis_Blue-and-yellow Tanager
-Recurvirostra americana_American Avocet
-Recurvirostra andina_Andean Avocet
-Recurvirostra avosetta_反嘴鴴
-Regulus goodfellowi_火冠戴菊鳥
-Regulus ignicapilla_Common Firecrest
-Regulus madeirensis_Madeira Firecrest
-Regulus regulus_戴菊鳥
-Regulus satrapa_Golden-crowned Kinglet
-Reinwardtipicus validus_Orange-backed Woodpecker
-Reinwardtoena reinwardti_Great Cuckoo-Dove
-Remiz consobrinus_攀雀
-Remiz coronatus_White-crowned Penduline-Tit
-Remiz pendulinus_Eurasian Penduline-Tit
-Rhabdotorrhinus corrugatus_Wrinkled Hornbill
-Rhabdotorrhinus exarhatus_Sulawesi Hornbill
-Rhaphidura leucopygialis_Silver-rumped Needletail
-Rhea americana_Greater Rhea
-Rhegmatorhina cristata_Chestnut-crested Antbird
-Rhegmatorhina gymnops_Bare-eyed Antbird
-Rhegmatorhina hoffmannsi_White-breasted Antbird
-Rhegmatorhina melanosticta_Hairy-crested Antbird
-Rhinocrypta lanceolata_Crested Gallito
-Rhinopomastus cyanomelas_Common Scimitarbill
-Rhinortha chlorophaea_Raffles's Malkoha
-Rhipidura albicollis_White-throated Fantail
-Rhipidura albiscapa_Gray Fantail
-Rhipidura albogularis_Spot-breasted Fantail
-Rhipidura albolimbata_Friendly Fantail
-Rhipidura atra_Black Fantail
-Rhipidura aureola_White-browed Fantail
-Rhipidura brachyrhyncha_Dimorphic Fantail
-Rhipidura cyaniceps_Blue-headed Fantail
-Rhipidura dryas_Arafura Fantail
-Rhipidura fuliginosa_New Zealand Fantail
-Rhipidura javanica_Malaysian Pied-Fantail
-Rhipidura leucophrys_Willie-wagtail
-Rhipidura leucothorax_White-bellied Thicket-Fantail
-Rhipidura maculipectus_Black Thicket-Fantail
-Rhipidura nigritorquis_菲律賓扇尾鶲
-Rhipidura perlata_Spotted Fantail
-Rhipidura rufifrons_Rufous Fantail
-Rhipidura rufiventris_Northern Fantail
-Rhipidura teysmanni_Sulawesi Fantail
-Rhipidura threnothorax_Sooty Thicket-Fantail
-Rhipidura verreauxi_Streaked Fantail
-Rhodinocichla rosea_Rosy Thrush-Tanager
-Rhodophoneus cruentus_Rosy-patched Bushshrike
-Rhodospingus cruentus_Crimson-breasted Finch
-Rhodospiza obsoleta_Desert Finch
-Rhodostethia rosea_楔尾鷗
-Rhodothraupis celaeno_Crimson-collared Grosbeak
-Rhopias gularis_Star-throated Antwren
-Rhopophilus pekinensis_Beijing Babbler
-Rhopornis ardesiacus_Slender Antbird
-Rhopospina alaudina_Band-tailed Sierra Finch
-Rhopospina caerulescens_Blue Finch
-Rhopospina fruticeti_Mourning Sierra Finch
-Rhynchocyclus brevirostris_Eye-ringed Flatbill
-Rhynchocyclus olivaceus_Olivaceous Flatbill
-Rhynchophanes mccownii_Thick-billed Longspur
-Rhynchopsitta pachyrhyncha_Thick-billed Parrot
-Rhynchopsitta terrisi_Maroon-fronted Parrot
-Rhynchortyx cinctus_Tawny-faced Quail
-Rhynchospiza stolzmanni_Tumbes Sparrow
-Rhynchospiza strigiceps_Chaco Sparrow
-Rhynchotus rufescens_Red-winged Tinamou
-Rhynochetos jubatus_Kagu
-Rhyticeros cassidix_Knobbed Hornbill
-Rhyticeros plicatus_Blyth's Hornbill
-Rhyticeros undulatus_Wreathed Hornbill
-Rhytipterna holerythra_Rufous Mourner
-Rhytipterna immunda_Pale-bellied Mourner
-Rhytipterna simplex_Grayish Mourner
-Riparia chinensis_棕沙燕
-Riparia diluta_淺灰沙燕
-Riparia paludicola_Plain Martin
-Riparia riparia_灰沙燕
-Rissa tridactyla_三趾鷗
-Rollulus rouloul_Crested Partridge
-Roraimia adusta_Roraiman Barbtail
-Rostratula benghalensis_彩鷸
-Rostrhamus sociabilis_Snail Kite
-Rubigula erythropthalmos_Spectacled Bulbul
-Rubigula flaviventris_Black-crested Bulbul
-Rubigula gularis_Flame-throated Bulbul
-Rupicola peruvianus_Andean Cock-of-the-rock
-Rupicola rupicola_Guianan Cock-of-the-rock
-Rupornis magnirostris_Roadside Hawk
-Rynchops niger_Black Skimmer
-Sakesphorus canadensis_Black-crested Antshrike
-Sakesphorus cristatus_Silvery-cheeked Antshrike
-Sakesphorus luctuosus_Glossy Antshrike
-Salpinctes obsoletus_Rock Wren
-Salpornis salvadori_African Spotted Creeper
-Saltator albicollis_Lesser Antillean Saltator
-Saltator atriceps_Black-headed Saltator
-Saltator atripennis_Black-winged Saltator
-Saltator aurantiirostris_Golden-billed Saltator
-Saltator cinctus_Masked Saltator
-Saltator coerulescens_Blue-gray Saltator
-Saltator fuliginosus_Black-throated Grosbeak
-Saltator grandis_Cinnamon-bellied Saltator
-Saltator grossus_Slate-colored Grosbeak
-Saltator maxillosus_Thick-billed Saltator
-Saltator maximus_Buff-throated Saltator
-Saltator nigriceps_Black-cowled Saltator
-Saltator olivascens_Olivaceous Saltator
-Saltator orenocensis_Orinocan Saltator
-Saltator similis_Green-winged Saltator
-Saltator striatipectus_Streaked Saltator
-Saltatricula atricollis_Black-throated Saltator
-Saltatricula multicolor_Many-colored Chaco Finch
-Sapayoa aenigma_Sapayoa
-Sappho sparganurus_Red-tailed Comet
-Sarcops calvus_Coleto
-Sarothrura elegans_Buff-spotted Flufftail
-Sarothrura insularis_Madagascar Flufftail
-Sarothrura pulchra_White-spotted Flufftail
-Sarothrura rufa_Red-chested Flufftail
-Sasia abnormis_Rufous Piculet
-Sasia ochracea_White-browed Piculet
-Saucerottia beryllina_Berylline Hummingbird
-Saucerottia cyanocephala_Azure-crowned Hummingbird
-Saucerottia tobaci_Copper-rumped Hummingbird
-Saundersilarus saundersi_黑嘴鷗
+Pteruthius rufiventer_棕腹鵙鹛
+Pteruthius xanthochlorus_淡绿鵙鹛
+Ptilinopus iozonus_橙腹果鸠
+Ptilinopus magnificus_巨果鸠
+Ptilinopus melanospilus_黑项果鸠
+Ptilinopus occipitalis_栗耳果鸠
+Ptilinopus pelewensis_帕劳果鸠
+Ptilinopus porphyraceus_紫顶果鸠
+Ptilinopus regina_粉顶果鸠
+Ptilinopus rivoli_白胸果鸠
+Ptilinopus solomonensis_黄胸果鸠
+Ptilinopus superbus_华丽果鸠
+Ptilinopus viridis_紫红胸果鸠
+Ptiliogonys caudatus_长尾丝鹟
+Ptiliogonys cinereus_灰丝鹟
+Ptilocichla falcata_菲律宾地鹛
+Ptilocichla leucogrammica_加里曼丹地鹛
+Ptilocichla mindanensis_条纹地鹛
+Ptilonorhynchus violaceus_缎蓝园丁鸟
+Ptilopachus petrosus_石鹑
+Ptiloprora guisei_红背嗜蜜鸟
+Ptiloprora perstriata_黑背嗜蜜鸟
+Ptilopsis leucotis_白脸角鸮
+Ptiloris magnificus_丽色掩鼻风鸟
+Ptiloris paradiseus_大掩鼻风鸟
+Ptiloris victoriae_小掩鼻风鸟
+Ptilorrhoa caerulescens_蓝丽鸫
+Ptilorrhoa castanonota_栗背丽鸫
+Ptilorrhoa leucosticta_斑丽鸫
+Ptilostomus afer_须嘴鸦
+Ptilotula fusca_黄翅灰吸蜜鸟
+Ptilotula ornata_黄痣吸蜜鸟
+Ptilotula penicillata_白痣吸蜜鸟
+Ptiloxena atroviolacea_古巴黑鹂
+Ptyonoprogne concolor_纯色岩燕
+Ptyonoprogne fuligula_非洲岩燕
+Ptyonoprogne rupestris_岩燕
+Pucrasia macrolopha_勺鸡
+Puffinus bailloni_热带鹱
+Puffinus nativitatis_黑鹱
+Puffinus newelli_夏威夷鹱
+Puffinus puffinus_大西洋鹱
+Pulsatrix koeniswaldiana_茶眉眼镜鸮
+Pulsatrix melanota_斑腹眼镜鸮
+Pulsatrix perspicillata_眼镜鸮
+Purnella albifrons_白额澳蜜鸟
+Purpureicephalus spurius_红顶鹦鹉
+Pycnonotus aurigaster_白喉红臀鹎
+Pycnonotus barbatus_黑眼鹎
+Pycnonotus brunneus_红眼褐鹎
+Pycnonotus cafer_黑喉红臀鹎
+Pycnonotus capensis_南非鹎
+Pycnonotus conradi_条耳鹎
+Pycnonotus finlaysoni_纹喉鹎
+Pycnonotus flavescens_黄绿鹎
+Pycnonotus goiavier_白眉黄臀鹎
+Pycnonotus jocosus_红耳鹎
+Pycnonotus leucogenys_白颊鹎
+Pycnonotus leucotis_白耳鹎
+Pycnonotus luteolus_白眉鹎
+Pycnonotus nigricans_红眼鹎
+Pycnonotus plumosus_橄榄褐鹎
+Pycnonotus simplex_白眼褐鹎
+Pycnonotus sinensis_白头鹎
+Pycnonotus striatus_纵纹绿鹎
+Pycnonotus taivanus_台湾鹎
+Pycnonotus xantholaemus_黄喉鹎
+Pycnonotus xanthopygos_白眶鹎
+Pycnonotus xanthorrhous_黄臀鹎
+Pycnonotus zeylanicus_黄冠鹎
+Pycnoptilus floccosus_随莺
+Pygarrhichas albogularis_白喉爬树雀
+Pygiptila stellaris_点翅蚁鵙
+Pygochelidon cyanoleuca_蓝白南美燕
+Pygoscelis adeliae_阿德利企鹅
+Pygoscelis antarcticus_纹颊企鹅
+Pygoscelis papua_白眉企鹅
+Pyriglena atra_镶背红眼蚁鸟
+Pyriglena leuconota_白背红眼蚁鸟
+Pyriglena leucoptera_白肩红眼蚁鸟
+Pyriglena maura_西白背红眼蚁鸟
+Pyrilia barrabandi_橙颊鹦哥
+Pyrilia caica_盖加鹦哥
+Pyrilia haematotis_褐冠鹦哥
+Pyrilia pulchra_粉脸鹦哥
+Pyrilia pyrilia_橙头鹦哥
+Pyrocephalus rubinus_猩红霸鹟
+Pyroderus scutatus_红领果伞鸟
+Pyrope pyrope_红眼蒙霸鹟
+Pyrrhocorax graculus_黄嘴山鸦
+Pyrrhocorax pyrrhocorax_红嘴山鸦
+Pyrrholaemus brunneus_红喉刺莺
+Pyrrholaemus sagittatus_斑刺莺
+Pyrrhomyias cinnamomeus_桂红霸鹟
+Pyrrhula erythaca_灰头灰雀
+Pyrrhula nipalensis_褐灰雀
+Pyrrhula pyrrhula_红腹灰雀
+Pyrrhura albipectus_白颈鹦哥
+Pyrrhura amazonum_圣塔伦鹦哥
+Pyrrhura calliptera_褐胸鹦哥
+Pyrrhura cruentata_蓝喉鹦哥
+Pyrrhura frontalis_红腹鹦哥
+Pyrrhura hoematotis_红耳鹦哥
+Pyrrhura hoffmanni_黄翅鹦哥
+Pyrrhura leucotis_白耳鹦哥
+Pyrrhura melanura_栗尾鹦哥
+Pyrrhura molinae_绿颊锥尾鹦哥
+Pyrrhura orcesi_厄瓜多尔鹦哥
+Pyrrhura perlata_珠颈鹦哥
+Pyrrhura picta_彩鹦哥
+Pyrrhura rhodocephala_赤头鹦哥
+Pyrrhura roseifrons_赤额鹦哥
+Pyrrhura rupicola_黑顶鹦哥
+Pyrrhura viridicata_圣马塔鹦哥
+Pytilia melba_绿翅斑腹雀
+Quelea quelea_红嘴奎利亚雀
+Querula purpurata_紫喉果伞鸟
+Quiscalus lugubris_辉拟八哥
+Quiscalus major_宽尾拟八哥
+Quiscalus mexicanus_大尾拟八哥
+Quiscalus nicaraguensis_尼加拉瓜拟八哥
+Quiscalus niger_黑拟八哥
+Quiscalus quiscula_拟八哥
+Radjah radjah_白腹麻鸭
+Rallina eurizonoides_白喉斑秧鸡
+Rallina fasciata_红腿斑秧鸡
+Rallina tricolor_红颈秧鸡
+Rallus antarcticus_火地岛秧鸡
+Rallus aquaticus_西方秧鸡
+Rallus caerulescens_暗蓝秧鸡
+Rallus crepitans_长嘴秧鸡
+Rallus elegans_王秧鸡
+Rallus indicus_普通秧鸡
+Rallus limicola_弗吉尼亚秧鸡
+Rallus longirostris_红树林秧鸡
+Rallus obsoletus_里氏秧鸡
+Rallus semiplumbeus_波哥大秧鸡
+Rallus tenuirostris_阿芝秧鸡
+Ramphastos ambiguus_黑嘴巨嘴鸟
+Ramphastos brevis_乔科巨嘴鸟
+Ramphastos dicolorus_红胸巨嘴鸟
+Ramphastos sulfuratus_厚嘴巨嘴鸟
+Ramphastos toco_巨嘴鸟
+Ramphastos tucanus_红嘴巨嘴鸟
+Ramphastos vitellinus_凹嘴巨嘴鸟
+Ramphocaenus melanurus_长嘴蚋莺
+Ramphocaenus sticturus_噪蚋莺
+Ramphocelus bresilius_巴西厚嘴唐纳雀
+Ramphocelus carbo_银嘴唐纳雀
+Ramphocelus dimidiatus_绯背厚嘴唐纳雀
+Ramphocelus flammigerus_火腰厚嘴唐纳雀
+Ramphocelus melanogaster_黑腹厚嘴唐纳雀
+Ramphocelus nigrogularis_绯红厚嘴唐纳雀
+Ramphocelus passerinii_红腰厚嘴唐纳雀
+Ramphocelus sanguinolentus_绯领厚嘴唐纳雀
+Ramphodon naevius_锯嘴蜂鸟
+Ramphomicron microrhynchum_紫背刺嘴蜂鸟
+Ramphotrigon flammulatum_火红霸鹟
+Ramphotrigon fuscicauda_暗尾扁嘴霸鹟
+Ramphotrigon megacephalum_大头扁嘴霸鹟
+Ramphotrigon ruficauda_棕尾扁嘴霸鹟
+Ramsayornis modestus_褐背胶蜜鸟
+Rauenia bonariensis_橙腹裸鼻雀
+Recurvirostra americana_褐胸反嘴鹬
+Recurvirostra andina_安第斯反嘴鹬
+Recurvirostra avosetta_反嘴鹬
+Regulus goodfellowi_台湾戴菊
+Regulus ignicapilla_火冠戴菊
+Regulus madeirensis_马德拉火冠戴菊
+Regulus regulus_戴菊
+Regulus satrapa_金冠戴菊
+Reinwardtipicus validus_橙背啄木鸟
+Reinwardtoena reinwardti_赤灰长尾鸠
+Remiz consobrinus_中华攀雀
+Remiz coronatus_白冠攀雀
+Remiz pendulinus_欧亚攀雀
+Rhabdotorrhinus corrugatus_皱盔犀鸟
+Rhabdotorrhinus exarhatus_白颊犀鸟
+Rhaphidura leucopygialis_银腰针尾雨燕
+Rhea americana_大美洲鸵
+Rhegmatorhina cristata_栗冠蚁鸟
+Rhegmatorhina gymnops_裸眼蚁鸟
+Rhegmatorhina hoffmannsi_白胸蚁鸟
+Rhegmatorhina melanosticta_发冠蚁鸟
+Rhinocrypta lanceolata_冠窜鸟
+Rhinopomastus cyanomelas_弯嘴林戴胜
+Rhinortha chlorophaea_棕胸地鹃
+Rhipidura albicollis_白喉扇尾鹟
+Rhipidura albiscapa_灰扇尾鹟
+Rhipidura albogularis_白点扇尾鹟
+Rhipidura albolimbata_睦扇尾鹟
+Rhipidura atra_黑扇尾鹟
+Rhipidura aureola_白眉扇尾鹟
+Rhipidura brachyrhyncha_棕色扇尾鹟
+Rhipidura cyaniceps_蓝头扇尾鹟
+Rhipidura dryas_杂色扇尾鹟
+Rhipidura fuliginosa_新西兰灰扇尾鹟
+Rhipidura javanica_斑扇尾鹟
+Rhipidura leucophrys_黑白扇尾鹟
+Rhipidura leucothorax_白胸扇尾鹟
+Rhipidura maculipectus_黑薮扇尾鹟
+Rhipidura nigritorquis_菲律宾斑扇尾鹟
+Rhipidura perlata_珠点扇尾鹟
+Rhipidura rufifrons_棕额扇尾鹟
+Rhipidura rufiventris_北扇尾鹟
+Rhipidura teysmanni_锈腹扇尾鹟
+Rhipidura threnothorax_乌黑扇尾鹟
+Rhipidura verreauxi_点胸扇尾鹟
+Rhodinocichla rosea_鸫唐纳雀
+Rhodophoneus cruentus_粉斑丛鵙
+Rhodospingus cruentus_红胸雀
+Rhodospiza obsoleta_巨嘴沙雀
+Rhodostethia rosea_楔尾鸥
+Rhodothraupis celaeno_朱领锡嘴雀
+Rhopias gularis_星喉蚁鹩
+Rhopophilus pekinensis_山鹛
+Rhopornis ardesiacus_纤蚁鸟
+Rhopospina alaudina_斑尾岭雀鹀
+Rhopospina caerulescens_蓝雀鹀
+Rhopospina fruticeti_黑岭雀鹀
+Rhynchocyclus brevirostris_眼环扁嘴霸鹟
+Rhynchocyclus olivaceus_绿扁嘴霸鹟
+Rhynchophanes mccownii_麦氏铁爪鹀
+Rhynchopsitta pachyrhyncha_厚嘴鹦哥
+Rhynchopsitta terrisi_暗红额鹦哥
+Rhynchortyx cinctus_茶脸鹑
+Rhynchospiza stolzmanni_斯贝猛雀鹀
+Rhynchospiza strigiceps_纹顶猛雀鹀
+Rhynchotus rufescens_红翅䳍
+Rhynochetos jubatus_鹭鹤
+Rhyticeros cassidix_苏拉威西皱盔犀鸟
+Rhyticeros plicatus_蓝喉皱盔犀鸟
+Rhyticeros undulatus_花冠皱盔犀鸟
+Rhytipterna holerythra_棕悲霸鹟
+Rhytipterna immunda_淡腹悲霸鹟
+Rhytipterna simplex_灰悲霸鹟
+Riparia chinensis_灰喉沙燕
+Riparia diluta_淡色沙燕
+Riparia paludicola_非洲褐喉沙燕
+Riparia riparia_崖沙燕
+Rissa tridactyla_三趾鸥
+Rollulus rouloul_冕鹧鸪
+Roraimia adusta_红斑尾雀
+Rostratula benghalensis_彩鹬
+Rostrhamus sociabilis_食螺鸢
+Rubigula erythropthalmos_小褐鹎
+Rubigula flaviventris_黑冠黄鹎
+Rubigula gularis_火喉黄鹎
+Rupicola peruvianus_安第斯冠伞鸟
+Rupicola rupicola_圭亚那冠伞鸟
+Rupornis magnirostris_阔嘴鵟
+Rynchops niger_黑剪嘴鸥
+Sakesphorus canadensis_黑冠蚁鵙
+Sakesphorus cristatus_银颊蚁鵙
+Sakesphorus luctuosus_辉蚁鵙
+Salpinctes obsoletus_岩鹪鹩
+Salpornis salvadori_非洲斑旋木雀
+Saltator albicollis_小安第斯舞雀
+Saltator atriceps_黑头舞雀
+Saltator atripennis_黑翅舞雀
+Saltator aurantiirostris_金嘴舞雀
+Saltator cinctus_花脸舞雀
+Saltator coerulescens_灰背舞雀
+Saltator fuliginosus_黑喉粗嘴雀
+Saltator grandis_棕腹灰背舞雀
+Saltator grossus_灰蓝粗嘴雀
+Saltator maxillosus_厚嘴舞雀
+Saltator maximus_黄喉舞雀
+Saltator nigriceps_黑巾舞雀
+Saltator olivascens_暗绿舞雀
+Saltator orenocensis_白眉舞雀
+Saltator similis_绿翅舞雀
+Saltator striatipectus_斑纹舞雀
+Saltatricula atricollis_黑喉舞雀
+Saltatricula multicolor_彩雀
+Sapayoa aenigma_阔嘴霸鹟
+Sappho sparganurus_红尾彗星蜂鸟
+Sarcops calvus_秃椋鸟
+Sarothrura elegans_黄斑侏秧鸡
+Sarothrura insularis_马岛侏秧鸡
+Sarothrura pulchra_白斑侏秧鸡
+Sarothrura rufa_红胸侏秧鸡
+Sasia abnormis_棕啄木鸟
+Sasia ochracea_白眉棕啄木鸟
+Saucerottia beryllina_绿蜂鸟
+Saucerottia cyanocephala_红嘴蜂鸟
+Saucerottia tobaci_铜色腰蜂鸟
+Saundersilarus saundersi_黑嘴鸥
 Saxicola caprata_白斑黑石䳭
-Saxicola ferreus_灰叢鴝
-Saxicola maurus_Siberian Stonechat
-Saxicola rubetra_Whinchat
-Saxicola rubicola_European Stonechat
-Saxicola stejnegeri_黑喉鴝
-Saxicola torquatus_African Stonechat
-Sayornis nigricans_Black Phoebe
-Sayornis phoebe_Eastern Phoebe
-Sayornis saya_Say's Phoebe
+Saxicola ferreus_灰林䳭
+Saxicola maurus_黑喉石䳭
+Saxicola rubetra_草原石䳭
+Saxicola rubicola_欧石䳭
+Saxicola stejnegeri_东亚石䳭
+Saxicola torquatus_非洲石䳭
+Sayornis nigricans_黑长尾霸鹟
+Sayornis phoebe_灰胸长尾霸鹟
+Sayornis saya_棕腹长尾霸鹟
 Scaphiopus couchii_Couch's Spadefoot
-Scelorchilus albicollis_White-throated Tapaculo
-Scelorchilus rubecula_Chucao Tapaculo
-Scenopoeetes dentirostris_Tooth-billed Bowerbird
-Schetba rufa_Rufous Vanga
-Schiffornis aenea_Foothill Schiffornis
-Schiffornis major_Varzea Schiffornis
-Schiffornis olivacea_Olivaceous Schiffornis
-Schiffornis stenorhyncha_Russet-winged Schiffornis
-Schiffornis turdina_Brown-winged Schiffornis
-Schiffornis veraepacis_Northern Schiffornis
-Schiffornis virescens_Greenish Schiffornis
-Schistes geoffroyi_Geoffroy's Daggerbill
-Schistochlamys melanopis_Black-faced Tanager
-Schistochlamys ruficapillus_Cinnamon Tanager
-Schoenicola platyurus_Broad-tailed Grassbird
-Schoenicola striatus_Bristled Grassbird
-Schoeniophylax phryganophilus_Chotoy Spinetail
-Schoeniparus brunneus_頭烏線
-Schoeniparus castaneceps_Rufous-winged Fulvetta
-Schoeniparus cinereus_Yellow-throated Fulvetta
-Schoeniparus dubius_Rusty-capped Fulvetta
-Schoeniparus rufogularis_Rufous-throated Fulvetta
-Sciaphylax castanea_Zimmer's Antbird
-Sciaphylax hemimelaena_Chestnut-tailed Antbird
+Scelorchilus albicollis_白喉窜鸟
+Scelorchilus rubecula_智利窜鸟
+Scenopoeetes dentirostris_齿嘴园丁鸟
+Schetba rufa_棕钩嘴鵙
+Schiffornis aenea_山希夫霸鹟
+Schiffornis major_大希夫霸鹟
+Schiffornis olivacea_圭亚那希夫霸鹟
+Schiffornis stenorhyncha_红翅希夫霸鹟
+Schiffornis turdina_拟鸫希夫霸鹟
+Schiffornis veraepacis_北希夫霸鹟
+Schiffornis virescens_绿希夫霸鹟
+Schistes geoffroyi_楔嘴蜂鸟
+Schistochlamys melanopis_黑脸唐纳雀
+Schistochlamys ruficapillus_黄棕唐纳雀
+Schoenicola platyurus_阔尾芦莺
+Schoenicola striatus_须草莺
+Schoeniophylax phryganophilus_霍托针尾雀
+Schoeniparus brunneus_褐顶雀鹛
+Schoeniparus castaneceps_栗头雀鹛
+Schoeniparus cinereus_黄喉雀鹛
+Schoeniparus dubius_褐胁雀鹛
+Schoeniparus rufogularis_棕喉雀鹛
+Sciaphylax castanea_北栗尾蚁鸟
+Sciaphylax hemimelaena_南栗尾蚁鸟
 Sciurus carolinensis_Eastern Gray Squirrel
-Sclateria naevia_Silvered Antbird
-Scleroptila afra_Gray-winged Francolin
-Scleroptila gutturalis_Orange River Francolin
-Scleroptila levaillantii_Red-winged Francolin
-Scleroptila shelleyi_Shelley's Francolin (Shelley's)
-Sclerurus albigularis_Gray-throated Leaftosser
-Sclerurus caudacutus_Black-tailed Leaftosser
-Sclerurus guatemalensis_Scaly-throated Leaftosser
-Sclerurus mexicanus_Middle American Leaftosser
-Sclerurus obscurior_South American Leaftosser
-Sclerurus rufigularis_Short-billed Leaftosser
-Sclerurus scansor_Rufous-breasted Leaftosser
-Scolopax bukidnonensis_Bukidnon Woodcock
-Scolopax minor_American Woodcock
-Scolopax rusticola_山鷸
-Scopus umbretta_Hamerkop
-Scotocerca inquieta_Scrub Warbler
+Sclateria naevia_银色蚁鸟
+Scleroptila afra_灰翅鹧鸪
+Scleroptila gutturalis_橙翅斑鹧鸪
+Scleroptila levaillantii_红翅鹧鸪
+Scleroptila shelleyi_谢氏鹧鸪
+Sclerurus albigularis_灰喉硬尾雀
+Sclerurus caudacutus_黑尾硬尾雀
+Sclerurus guatemalensis_鳞喉硬尾雀
+Sclerurus mexicanus_茶喉硬尾雀
+Sclerurus obscurior_暗色硬尾雀
+Sclerurus rufigularis_短嘴硬尾雀
+Sclerurus scansor_棕胸硬尾雀
+Scolopax bukidnonensis_菲律宾丘鹬
+Scolopax minor_小丘鹬
+Scolopax rusticola_丘鹬
+Scopus umbretta_锤头鹳
+Scotocerca inquieta_纹鹪莺
 Scudderia curvicauda_Curve-tailed Bush Katydid
 Scudderia furcata_Fork-tailed Bush Katydid
 Scudderia texensis_Texas Bush Katydid
-Scytalopus acutirostris_Tschudi's Tapaculo
-Scytalopus affinis_Ancash Tapaculo
-Scytalopus altirostris_Neblina Tapaculo
-Scytalopus alvarezlopezi_Tatama Tapaculo
-Scytalopus androstictus_Loja Tapaculo
-Scytalopus argentifrons_Silvery-fronted Tapaculo
-Scytalopus atratus_White-crowned Tapaculo
-Scytalopus bolivianus_Bolivian Tapaculo
-Scytalopus canus_Paramillo Tapaculo
-Scytalopus caracae_Caracas Tapaculo
-Scytalopus chocoensis_Choco Tapaculo
-Scytalopus diamantinensis_Diamantina Tapaculo
-Scytalopus femoralis_Rufous-vented Tapaculo
-Scytalopus frankeae_Jalca Tapaculo
-Scytalopus fuscus_Dusky Tapaculo
-Scytalopus griseicollis_Pale-bellied Tapaculo
-Scytalopus intermedius_Utcubamba Tapaculo
-Scytalopus iraiensis_Marsh Tapaculo
-Scytalopus latebricola_Brown-rumped Tapaculo
-Scytalopus latrans_Blackish Tapaculo
-Scytalopus macropus_Large-footed Tapaculo
-Scytalopus magellanicus_Magellanic Tapaculo
-Scytalopus meridanus_Merida Tapaculo
-Scytalopus micropterus_Long-tailed Tapaculo
-Scytalopus novacapitalis_Brasilia Tapaculo
-Scytalopus opacus_Paramo Tapaculo
-Scytalopus pachecoi_Planalto Tapaculo
-Scytalopus parkeri_Chusquea Tapaculo
-Scytalopus parvirostris_Trilling Tapaculo
-Scytalopus perijanus_Perija Tapaculo
-Scytalopus petrophilus_Rock Tapaculo
-Scytalopus robbinsi_Ecuadorian Tapaculo
-Scytalopus rodriguezi_Magdalena Tapaculo
-Scytalopus sanctaemartae_Santa Marta Tapaculo
-Scytalopus schulenbergi_Diademed Tapaculo
-Scytalopus simonsi_Puna Tapaculo
-Scytalopus speluncae_Mouse-colored Tapaculo
-Scytalopus spillmanni_Spillmann's Tapaculo
-Scytalopus stilesi_Stiles's Tapaculo
-Scytalopus superciliaris_White-browed Tapaculo
-Scytalopus unicolor_Unicolored Tapaculo
-Scytalopus urubambae_Vilcabamba Tapaculo
-Scytalopus vicinior_Nariño Tapaculo
-Scytalopus zimmeri_Zimmer's Tapaculo
-Scythrops novaehollandiae_Channel-billed Cuckoo
-Seiurus aurocapilla_Ovenbird
-Selasphorus calliope_Calliope Hummingbird
-Selasphorus ellioti_Wine-throated Hummingbird
-Selasphorus heloisa_Bumblebee Hummingbird
-Selasphorus platycercus_Broad-tailed Hummingbird
-Selasphorus rufus_Rufous Hummingbird
-Selasphorus sasin_Allen's Hummingbird
-Selenidera gouldii_Gould's Toucanet
-Selenidera maculirostris_Spot-billed Toucanet
-Selenidera piperivora_Guianan Toucanet
-Selenidera reinwardtii_Golden-collared Toucanet
-Selenidera spectabilis_Yellow-eared Toucanet
-Seleucidis melanoleucus_Twelve-wired Bird-of-Paradise
-Semioptera wallacii_Standardwing Bird-of-Paradise
-Semnornis frantzii_Prong-billed Barbet
-Semnornis ramphastinus_Toucan Barbet
-Sephanoides sephaniodes_Green-backed Firecrown
-Sericornis citreogularis_Yellow-throated Scrubwren
-Sericornis frontalis_White-browed Scrubwren
-Sericornis humilis_Tasmanian Scrubwren
-Sericornis magnirostra_Large-billed Scrubwren
-Sericornis papuensis_Papuan Scrubwren
-Sericossypha albocristata_White-capped Tanager
-Serilophus lunatus_Silver-breasted Broadbill
-Serinus alario_Black-headed Canary
-Serinus canaria_Island Canary
-Serinus canicollis_Cape Canary
-Serinus flavivertex_Yellow-crowned Canary
-Serinus pusillus_Fire-fronted Serin
-Serinus serinus_European Serin
-Serpophaga cinerea_Torrent Tyrannulet
-Serpophaga griseicapilla_Straneck's Tyrannulet
-Serpophaga hypoleuca_River Tyrannulet
+Scytalopus acutirostris_楚氏窜鸟
+Scytalopus affinis_安卡什窜鸟
+Scytalopus altirostris_涅比窜鸟
+Scytalopus alvarezlopezi_塔塔马窜鸟
+Scytalopus androstictus_洛哈窜鸟
+Scytalopus argentifrons_银额窜鸟
+Scytalopus atratus_白冠窜鸟
+Scytalopus bolivianus_玻利维亚窜鸟
+Scytalopus canus_帕拉窜鸟
+Scytalopus caracae_加拉加斯窜鸟
+Scytalopus chocoensis_乔科窜鸟
+Scytalopus diamantinensis_灰腹岩窜鸟
+Scytalopus femoralis_棕肛窜鸟
+Scytalopus frankeae_哈尔卡窜鸟
+Scytalopus fuscus_暗黑窜鸟
+Scytalopus griseicollis_马托窜鸟
+Scytalopus intermedius_乌省窜鸟
+Scytalopus iraiensis_湿地窜鸟
+Scytalopus latebricola_褐腰窜鸟
+Scytalopus latrans_黑窜鸟
+Scytalopus macropus_大脚窜鸟
+Scytalopus magellanicus_安第斯窜鸟
+Scytalopus meridanus_梅里达窜鸟
+Scytalopus micropterus_长尾窜鸟
+Scytalopus novacapitalis_巴西窜鸟
+Scytalopus opacus_棕臀黑窜鸟
+Scytalopus pachecoi_高原窜鸟
+Scytalopus parkeri_丘斯窜鸟
+Scytalopus parvirostris_颤音窜鸟
+Scytalopus perijanus_暗褐腰窜鸟
+Scytalopus petrophilus_岩窜鸟
+Scytalopus robbinsi_厄瓜多尔窜鸟
+Scytalopus rodriguezi_扇尾窜鸟
+Scytalopus sanctaemartae_圣岛窜鸟
+Scytalopus schulenbergi_花冠窜鸟
+Scytalopus simonsi_蓬那窜鸟
+Scytalopus speluncae_鼠色窜鸟
+Scytalopus spillmanni_斯氏窜鸟
+Scytalopus stilesi_白喉扇尾窜鸟
+Scytalopus superciliaris_白眉窜鸟
+Scytalopus unicolor_纯色窜鸟
+Scytalopus urubambae_维尔窜鸟
+Scytalopus vicinior_太平洋窜鸟
+Scytalopus zimmeri_济氏窜鸟
+Scythrops novaehollandiae_沟嘴鹃
+Seiurus aurocapilla_橙顶灶莺
+Selasphorus calliope_星蜂鸟
+Selasphorus ellioti_瑰喉蜂鸟
+Selasphorus heloisa_大瑰喉蜂鸟
+Selasphorus platycercus_宽尾煌蜂鸟
+Selasphorus rufus_棕煌蜂鸟
+Selasphorus sasin_艾氏煌蜂鸟
+Selenidera gouldii_高氏小巨嘴鸟
+Selenidera maculirostris_点嘴小巨嘴鸟
+Selenidera piperivora_圭亚那小巨嘴鸟
+Selenidera reinwardtii_金领小巨嘴鸟
+Selenidera spectabilis_黄耳小巨嘴鸟
+Seleucidis melanoleucus_十二线极乐鸟
+Semioptera wallacii_幡羽极乐鸟
+Semnornis frantzii_厚嘴拟啄木鸟
+Semnornis ramphastinus_巨嘴拟啄木鸟
+Sephanoides sephaniodes_绿背火冠蜂鸟
+Sericornis citreogularis_黄喉丝刺莺
+Sericornis frontalis_白眉丝刺莺
+Sericornis humilis_褐色丝刺莺
+Sericornis magnirostra_巨嘴丝刺莺
+Sericornis papuensis_巴布亚丝刺莺
+Sericossypha albocristata_白顶唐纳雀
+Serilophus lunatus_银胸丝冠鸟
+Serinus alario_黑头丝雀
+Serinus canaria_金丝雀
+Serinus canicollis_南非丝雀
+Serinus flavivertex_黄顶丝雀
+Serinus pusillus_金额丝雀
+Serinus serinus_欧洲丝雀
+Serpophaga cinerea_灰姬霸鹟
+Serpophaga griseicapilla_灰冠姬霸鹟
+Serpophaga hypoleuca_河姬霸鹟
 Serpophaga munda_White-bellied Tyrannulet
-Serpophaga nigricans_Sooty Tyrannulet
-Serpophaga subcristata_White-crested/White-bellied Tyrannulet
-Setopagis parvula_Little Nightjar
-Setophaga adelaidae_Adelaide's Warbler
-Setophaga americana_Northern Parula
-Setophaga caerulescens_Black-throated Blue Warbler
-Setophaga castanea_Bay-breasted Warbler
-Setophaga cerulea_Cerulean Warbler
-Setophaga chrysoparia_Golden-cheeked Warbler
-Setophaga citrina_Hooded Warbler
-Setophaga coronata_Yellow-rumped Warbler
-Setophaga discolor_Prairie Warbler
-Setophaga dominica_Yellow-throated Warbler
-Setophaga fusca_Blackburnian Warbler
-Setophaga graciae_Grace's Warbler
-Setophaga kirtlandii_Kirtland's Warbler
-Setophaga magnolia_Magnolia Warbler
-Setophaga nigrescens_Black-throated Gray Warbler
-Setophaga occidentalis_Hermit Warbler
-Setophaga palmarum_Palm Warbler
-Setophaga pensylvanica_Chestnut-sided Warbler
-Setophaga petechia_Yellow Warbler
-Setophaga pinus_Pine Warbler
-Setophaga pitiayumi_Tropical Parula
-Setophaga pityophila_Olive-capped Warbler
-Setophaga ruticilla_American Redstart
-Setophaga striata_Blackpoll Warbler
-Setophaga tigrina_Cape May Warbler
-Setophaga townsendi_Townsend's Warbler
-Setophaga virens_Black-throated Green Warbler
-Sheppardia gunningi_East Coast Akalat
-Sheppardia sharpei_Sharpe's Akalat
-Sholicola albiventris_White-bellied Sholakili
-Sholicola major_Nilgiri Sholakili
-Sialia currucoides_Mountain Bluebird
-Sialia mexicana_Western Bluebird
-Sialia sialis_Eastern Bluebird
-Sicalis auriventris_Greater Yellow-Finch
-Sicalis citrina_Stripe-tailed Yellow-Finch
-Sicalis flaveola_橙黃雀鵐
-Sicalis lebruni_Patagonian Yellow-Finch
-Sicalis luteocephala_Citron-headed Yellow-Finch
-Sicalis luteola_Grassland Yellow-Finch
-Sicalis olivascens_Greenish Yellow-Finch
+Serpophaga nigricans_烟姬霸鹟
+Serpophaga subcristata_白冠姬霸鹟
+Setopagis parvula_小夜鹰
+Setophaga adelaidae_黄腹灰林莺
+Setophaga americana_北森莺
+Setophaga caerulescens_黑喉蓝林莺
+Setophaga castanea_栗胸林莺
+Setophaga cerulea_蓝林莺
+Setophaga chrysoparia_金颊黑背林莺
+Setophaga citrina_黑枕威森莺
+Setophaga coronata_黄腰白喉林莺
+Setophaga discolor_草原绿林莺
+Setophaga dominica_黄喉林莺
+Setophaga fusca_橙胸林莺
+Setophaga graciae_黄喉纹胁林莺
+Setophaga kirtlandii_黑纹背林莺
+Setophaga magnolia_纹胸林莺
+Setophaga nigrescens_黑喉灰林莺
+Setophaga occidentalis_黄脸林莺
+Setophaga palmarum_棕榈林莺
+Setophaga pensylvanica_栗胁林莺
+Setophaga petechia_黄林莺
+Setophaga pinus_松莺
+Setophaga pitiayumi_绿背森莺
+Setophaga pityophila_绿顶林莺
+Setophaga ruticilla_橙尾鸲莺
+Setophaga striata_白颊林莺
+Setophaga tigrina_栗颊林莺
+Setophaga townsendi_黄眉林莺
+Setophaga virens_黑喉绿林莺
+Sheppardia gunningi_东非阿卡拉鸲
+Sheppardia sharpei_沙氏阿卡鸲
+Sholicola albiventris_白腹蓝地鸲
+Sholicola major_棕胁蓝地鸲
+Sialia currucoides_山蓝鸲
+Sialia mexicana_西蓝鸲
+Sialia sialis_东蓝鸲
+Sicalis auriventris_大黄雀鹀
+Sicalis citrina_柠黄雀鹀
+Sicalis flaveola_橙黄雀鹀
+Sicalis lebruni_巴塔黄雀鹀
+Sicalis luteocephala_黄头黄雀鹀
+Sicalis luteola_草原黄雀鹀
+Sicalis olivascens_绿黄雀鹀
 Sicalis uropygialis_Bright-rumped Yellow-Finch
-Sinosuthora webbiana_粉紅鸚嘴
-Siphonorhis brewsteri_Least Pauraque
-Sipia berlepschi_Stub-tailed Antbird
-Sipia laemosticta_Dull-mantled Antbird
-Sipia nigricauda_Esmeraldas Antbird
-Sipia palliata_Magdalena Antbird
+Sinosuthora webbiana_棕头鸦雀
+Siphonorhis brewsteri_中美夜鹰
+Sipia berlepschi_短尾蚁鸟
+Sipia laemosticta_暗背蚁鸟
+Sipia nigricauda_埃斯蚁鸟
+Sipia palliata_褐背蚁鸟
 Siren_Siren
-Sirystes albocinereus_White-rumped Sirystes
-Sirystes albogriseus_Choco Sirystes
-Sirystes sibilator_Sibilant Sirystes
-Sitta canadensis_Red-breasted Nuthatch
-Sitta carolinensis_White-breasted Nuthatch
-Sitta cinnamoventris_Chestnut-bellied Nuthatch
-Sitta europaea_茶腹鳾
-Sitta frontalis_Velvet-fronted Nuthatch
-Sitta himalayensis_White-tailed Nuthatch
-Sitta krueperi_Krüper's Nuthatch
-Sitta magna_Giant Nuthatch
-Sitta nagaensis_Chestnut-vented Nuthatch
-Sitta neumayer_Western Rock Nuthatch
-Sitta pusilla_Brown-headed Nuthatch
-Sitta pygmaea_Pygmy Nuthatch
-Sitta tephronota_Eastern Rock Nuthatch
-Sitta villosa_Snowy-browed Nuthatch
-Sitta whiteheadi_Corsican Nuthatch
-Sitta yunnanensis_Yunnan Nuthatch
-Sittasomus griseicapillus_Olivaceous Woodcreeper
-Sittiparus castaneoventris_赤腹山雀
-Sittiparus owstoni_Owston's Tit
-Sittiparus varius_雜色山雀
-Smicrornis brevirostris_Weebill
-Smithornis capensis_African Broadbill
-Smithornis rufolateralis_Rufous-sided Broadbill
-Snowornis subalaris_Gray-tailed Piha
-Somateria mollissima_Common Eider
-Somateria spectabilis_King Eider
-Spartonoica maluroides_Bay-capped Wren-Spinetail
-Spatula clypeata_琵嘴鴨
-Spatula cyanoptera_Cinnamon Teal
-Spatula discors_Blue-winged Teal
-Spatula platalea_Red Shoveler
-Spatula puna_Puna Teal
-Spatula querquedula_白眉鴨
+Sirystes albocinereus_白腰西利霸鹟
+Sirystes albogriseus_白翅西利霸鹟
+Sirystes sibilator_西利霸鹟
+Sitta canadensis_红胸䴓
+Sitta carolinensis_白胸䴓
+Sitta cinnamoventris_栗腹䴓
+Sitta europaea_普通䴓
+Sitta frontalis_绒额䴓
+Sitta himalayensis_白尾䴓
+Sitta krueperi_克氏䴓
+Sitta magna_巨䴓
+Sitta nagaensis_栗臀䴓
+Sitta neumayer_岩䴓
+Sitta pusilla_褐头䴓
+Sitta pygmaea_小䴓
+Sitta tephronota_东岩䴓
+Sitta villosa_黑头䴓
+Sitta whiteheadi_科西嘉䴓
+Sitta yunnanensis_滇䴓
+Sittasomus griseicapillus_绿䴕雀
+Sittiparus castaneoventris_台湾杂色山雀
+Sittiparus owstoni_伊豆杂色山雀
+Sittiparus varius_杂色山雀
+Smicrornis brevirostris_褐阔嘴莺
+Smithornis capensis_非洲阔嘴鸟
+Smithornis rufolateralis_棕胁阔嘴鸟
+Snowornis subalaris_灰尾伞鸟
+Somateria mollissima_欧绒鸭
+Somateria spectabilis_王绒鸭
+Spartonoica maluroides_栗顶针尾雀
+Spatula clypeata_琵嘴鸭
+Spatula cyanoptera_桂红鸭
+Spatula discors_蓝翅鸭
+Spatula platalea_赤琵嘴鸭
+Spatula puna_安第斯银鸭
+Spatula querquedula_白眉鸭
 Spea bombifrons_Plains Spadefoot
-Spelaeornis caudatus_Rufous-throated Wren-Babbler
-Spelaeornis oatesi_Chin Hills Wren-Babbler
-Spelaeornis troglodytoides_Bar-winged Wren-Babbler
-Spermestes cucullata_Bronze Mannikin
-Spermophaga haematina_Western Bluebill
-Sphecotheres vieilloti_Australasian Figbird
-Spheniscus demersus_African Penguin
-Spheniscus magellanicus_Magellanic Penguin
-Sphenoeacus afer_Cape Grassbird
-Sphenopsis frontalis_Oleaginous Hemispingus
-Sphenopsis melanotis_Black-eared Hemispingus
-Sphyrapicus nuchalis_Red-naped Sapsucker
-Sphyrapicus ruber_Red-breasted Sapsucker
-Sphyrapicus thyroideus_Williamson's Sapsucker
-Sphyrapicus varius_Yellow-bellied Sapsucker
-Spiloptila clamans_Cricket Longtail
-Spilornis cheela_大冠鷲
-Spilornis holospilus_Philippine Serpent-Eagle
-Spindalis zena_Western Spindalis
-Spinus atratus_Black Siskin
-Spinus barbatus_Black-chinned Siskin
-Spinus crassirostris_Thick-billed Siskin
-Spinus cucullatus_Red Siskin
-Spinus lawrencei_Lawrence's Goldfinch
-Spinus magellanicus_Hooded Siskin
-Spinus notatus_Black-headed Siskin
-Spinus olivaceus_Olivaceous Siskin
-Spinus pinus_Pine Siskin
-Spinus psaltria_Lesser Goldfinch
-Spinus spinescens_Andean Siskin
-Spinus spinus_黃雀
-Spinus tristis_American Goldfinch
-Spinus xanthogastrus_Yellow-bellied Siskin
-Spiza americana_Dickcissel
-Spizaetus isidori_Black-and-chestnut Eagle
-Spizaetus melanoleucus_Black-and-white Hawk-Eagle
-Spizaetus ornatus_Ornate Hawk-Eagle
-Spizaetus tyrannus_Black Hawk-Eagle
-Spizella atrogularis_Black-chinned Sparrow
-Spizella breweri_Brewer's Sparrow
-Spizella pallida_Clay-colored Sparrow
-Spizella passerina_Chipping Sparrow
-Spizella pusilla_Field Sparrow
-Spizella wortheni_Worthen's Sparrow
-Spizelloides arborea_American Tree Sparrow
-Spiziapteryx circumcincta_Spot-winged Falconet
-Spizixos canifrons_Crested Finchbill
-Spizixos semitorques_白環鸚嘴鵯
-Spodiopsar cineraceus_灰椋鳥
-Spodiopsar sericeus_絲光椋鳥
-Spodiornis rusticus_Slaty Finch
-Sporathraupis cyanocephala_Blue-capped Tanager
-Sporophila albogularis_White-throated Seedeater
-Sporophila angolensis_Chestnut-bellied Seed-Finch
-Sporophila atrirostris_Black-billed Seed-Finch
-Sporophila bouvreuil_Copper Seedeater
-Sporophila bouvronides_Lesson's Seedeater
-Sporophila caerulescens_Double-collared Seedeater
-Sporophila castaneiventris_Chestnut-bellied Seedeater
-Sporophila cinnamomea_Chestnut Seedeater
-Sporophila collaris_Rusty-collared Seedeater
-Sporophila corvina_Variable Seedeater
-Sporophila crassirostris_Large-billed Seed-Finch
-Sporophila falcirostris_Temminck's Seedeater
-Sporophila fringilloides_White-naped Seedeater
-Sporophila frontalis_Buffy-fronted Seedeater
-Sporophila funerea_Thick-billed Seed-Finch
-Sporophila hypochroma_Rufous-rumped Seedeater
-Sporophila hypoxantha_Tawny-bellied Seedeater
-Sporophila intermedia_Gray Seedeater
-Sporophila leucoptera_White-bellied Seedeater
-Sporophila lineola_Lined Seedeater
-Sporophila luctuosa_Black-and-white Seedeater
-Sporophila minuta_Ruddy-breasted Seedeater
-Sporophila morelleti_Morelet's Seedeater
+Spelaeornis caudatus_棕喉鹩鹛
+Spelaeornis oatesi_缅甸鹩鹛
+Spelaeornis troglodytoides_斑翅鹩鹛
+Spermestes cucullata_铜色文鸟
+Spermophaga haematina_红胸蓝嘴雀
+Sphecotheres vieilloti_澳裸眼鹂
+Spheniscus demersus_南非企鹅
+Spheniscus magellanicus_南美企鹅
+Sphenoeacus afer_草莺
+Sphenopsis frontalis_绿拟雀
+Sphenopsis melanotis_黑耳拟雀
+Sphyrapicus nuchalis_红颈吸汁啄木鸟
+Sphyrapicus ruber_红胸吸汁啄木鸟
+Sphyrapicus thyroideus_威氏吸汁啄木鸟
+Sphyrapicus varius_黄腹吸汁啄木鸟
+Spiloptila clamans_蟋蟀鹪莺
+Spilornis cheela_蛇雕
+Spilornis holospilus_菲律宾蛇雕
+Spindalis zena_鹀唐纳雀
+Spinus atratus_黑金翅雀
+Spinus barbatus_黑颏金翅雀
+Spinus crassirostris_厚嘴金翅雀
+Spinus cucullatus_黑头红金翅雀
+Spinus lawrencei_加州金翅雀
+Spinus magellanicus_冠金翅雀
+Spinus notatus_橙胸金翅雀
+Spinus olivaceus_绿金翅雀
+Spinus pinus_松金翅雀
+Spinus psaltria_暗背金翅雀
+Spinus spinescens_安第斯金翅雀
+Spinus spinus_黄雀
+Spinus tristis_北美金翅雀
+Spinus xanthogastrus_黄腹金翅雀
+Spiza americana_美洲雀
+Spizaetus isidori_黑栗雕
+Spizaetus melanoleucus_黑白鹰雕
+Spizaetus ornatus_丽鹰雕
+Spizaetus tyrannus_黑鹰雕
+Spizella atrogularis_黑颏雀鹀
+Spizella breweri_布氏雀鹀
+Spizella pallida_褐雀鹀
+Spizella passerina_棕顶雀鹀
+Spizella pusilla_田雀鹀
+Spizella wortheni_沃氏雀鹀
+Spizelloides arborea_美洲树雀鹀
+Spiziapteryx circumcincta_斑翅花隼
+Spizixos canifrons_凤头雀嘴鹎
+Spizixos semitorques_领雀嘴鹎
+Spodiopsar cineraceus_灰椋鸟
+Spodiopsar sericeus_丝光椋鸟
+Spodiornis rusticus_蓝灰雀鹀
+Sporathraupis cyanocephala_蓝枕裸鼻雀
+Sporophila albogularis_白喉食籽雀
+Sporophila angolensis_小籽雀
+Sporophila atrirostris_黑嘴籽雀
+Sporophila bouvreuil_黑顶食籽雀
+Sporophila bouvronides_莱氏食籽雀
+Sporophila caerulescens_双领食籽雀
+Sporophila castaneiventris_栗腹食籽雀
+Sporophila cinnamomea_栗食籽雀
+Sporophila collaris_红领食籽雀
+Sporophila corvina_黑食籽雀
+Sporophila crassirostris_大嘴籽雀
+Sporophila falcirostris_巴西食籽雀
+Sporophila fringilloides_白枕籽雀
+Sporophila frontalis_黄额食籽雀
+Sporophila funerea_厚嘴籽雀
+Sporophila hypochroma_棕腰食籽雀
+Sporophila hypoxantha_茶腹食籽雀
+Sporophila intermedia_灰食籽雀
+Sporophila leucoptera_白腹食籽雀
+Sporophila lineola_白颊食籽雀
+Sporophila luctuosa_黑白食籽雀
+Sporophila minuta_棕胸食籽雀
+Sporophila morelleti_中美食籽雀
 Sporophila murallae_Caqueta Seedeater
-Sporophila nigricollis_Yellow-bellied Seedeater
-Sporophila nuttingi_Nicaraguan Seed-Finch
-Sporophila palustris_Marsh Seedeater
-Sporophila peruviana_Parrot-billed Seedeater
-Sporophila pileata_Pearly-bellied Seedeater
-Sporophila plumbea_Plumbeous Seedeater
-Sporophila ruficollis_Dark-throated Seedeater
-Sporophila schistacea_Slate-colored Seedeater
-Sporophila simplex_Drab Seedeater
-Sporophila telasco_Chestnut-throated Seedeater
-Sporophila torqueola_Cinnamon-rumped Seedeater
-Sporopipes frontalis_Speckle-fronted Weaver
-Sporopipes squamifrons_Scaly Weaver
-Stachyris maculata_Chestnut-rumped Babbler
-Stachyris nigriceps_Gray-throated Babbler
-Stachyris nigricollis_Black-throated Babbler
-Stachyris poliocephala_Gray-headed Babbler
-Stachyris strialata_Spot-necked Babbler
-Stachyris thoracica_White-bibbed Babbler
-Stactolaema leucotis_White-eared Barbet
-Stactolaema olivacea_Green Barbet
-Stagonopleura bella_Beautiful Firetail
-Staphida torqueola_栗耳鳳眉
-Steatornis caripensis_Oilbird
-Stelgidillas gracilirostris_Slender-billed Greenbul
-Stelgidopteryx ruficollis_Southern Rough-winged Swallow
-Stelgidopteryx serripennis_Northern Rough-winged Swallow
-Stenostira scita_Fairy Flycatcher
-Stephanoaetus coronatus_Crowned Eagle
-Stephanophorus diadematus_Diademed Tanager
-Stephanoxis lalandi_Green-crowned Plovercrest
-Stephanoxis loddigesii_Purple-crowned Plovercrest
-Stercorarius antarcticus_Brown Skua
-Stercorarius longicaudus_長尾賊鷗
-Stercorarius maccormicki_灰賊鷗
-Stercorarius parasiticus_短尾賊鷗
-Stercorarius pomarinus_中賊鷗
-Stercorarius skua_Great Skua
-Sterna aurantia_River Tern
-Sterna dougallii_紅燕鷗
-Sterna forsteri_Forster's Tern
-Sterna hirundinacea_South American Tern
-Sterna hirundo_燕鷗
-Sterna paradisaea_Arctic Tern
-Sterna repressa_White-cheeked Tern
-Sterna striata_White-fronted Tern
-Sterna sumatrana_蒼燕鷗
-Sterna trudeaui_Snowy-crowned Tern
-Sterna vittata_Antarctic Tern
-Sternula albifrons_小燕鷗
-Sternula antillarum_美洲小燕鷗
-Sternula saundersi_Saunders's Tern
-Sternula superciliaris_Yellow-billed Tern
-Stigmatura budytoides_Greater Wagtail-Tyrant
-Stigmatura napensis_Lesser Wagtail-Tyrant
-Stilpnia cayana_Burnished-buff Tanager
-Stilpnia cyanicollis_Blue-necked Tanager
-Stilpnia cyanoptera_Black-headed Tanager
-Stilpnia heinei_Black-capped Tanager
-Stilpnia larvata_Golden-hooded Tanager
-Stilpnia nigrocincta_Masked Tanager
-Stilpnia peruviana_Black-backed Tanager
-Stilpnia preciosa_Chestnut-backed Tanager
-Stilpnia vitriolina_Scrub Tanager
-Stiphrornis erythrothorax_Orange-breasted Forest Robin
-Stipiturus malachurus_Southern Emuwren
-Stizoptera bichenovii_Double-barred Finch
-Stomiopera unicolor_White-gaped Honeyeater
-Strepera fuliginosa_Black Currawong
-Strepera graculina_Pied Currawong
-Strepera versicolor_Gray Currawong
-Streptopelia capicola_Ring-necked Dove
-Streptopelia chinensis_Spotted Dove
-Streptopelia decaocto_灰斑鳩
-Streptopelia decipiens_Mourning Collared-Dove
-Streptopelia lugens_Dusky Turtle-Dove
-Streptopelia orientalis_金背鳩
-Streptopelia roseogrisea_African Collared-Dove
-Streptopelia semitorquata_Red-eyed Dove
-Streptopelia senegalensis_Laughing Dove
-Streptopelia tranquebarica_紅鳩
-Streptopelia turtur_歐斑鳩
-Streptopelia vinacea_Vinaceous Dove
-Streptoprocne biscutata_Biscutate Swift
-Streptoprocne rutila_Chestnut-collared Swift
-Streptoprocne zonaris_White-collared Swift
-Strix aluco_Tawny Owl
-Strix chacoensis_Chaco Owl
-Strix fulvescens_Fulvous Owl
-Strix hadorami_Desert Owl
-Strix hylophila_Rusty-barred Owl
-Strix leptogrammica_褐林鴞
-Strix nebulosa_Great Gray Owl
-Strix nivicolum_東方灰林鴞
-Strix occidentalis_Spotted Owl
-Strix ocellata_Mottled Wood-Owl
-Strix rufipes_Rufous-legged Owl
-Strix seloputo_Spotted Wood-Owl
-Strix uralensis_Ural Owl
-Strix varia_Barred Owl
-Strix woodfordii_African Wood-Owl
-Struthidea cinerea_Apostlebird
-Sturnella magna_Eastern Meadowlark
-Sturnella neglecta_Western Meadowlark
-Sturnia blythii_Malabar Starling
-Sturnia malabarica_灰頭椋鳥
-Sturnia pagodarum_黑冠椋鳥
-Sturnia sinensis_灰背椋鳥
-Sturnus unicolor_Spotless Starling
-Sturnus vulgaris_歐洲椋鳥
-Sublegatus arenarum_Northern Scrub-Flycatcher
-Sublegatus modestus_Southern Scrub-Flycatcher
-Sublegatus obscurior_Amazonian Scrub-Flycatcher
-Sugomel nigrum_Black Honeyeater
-Suiriri suiriri_Suiriri Flycatcher
-Sula dactylatra_藍臉鰹鳥
-Sula leucogaster_白腹鰹鳥
-Sula nebouxii_Blue-footed Booby
-Sula sula_紅腳鰹鳥
-Surnia ulula_Northern Hawk Owl
-Surniculus dicruroides_烏鵑
-Surniculus lugubris_方尾烏鵑
-Surniculus velutinus_Philippine Drongo-Cuckoo
-Suthora nipalensis_Black-throated Parrotbill
-Suthora verreauxi_黃羽鸚嘴
-Swynnertonia swynnertoni_Swynnerton's Robin
-Sylvia abyssinica_African Hill Babbler
-Sylvia atricapilla_Eurasian Blackcap
-Sylvia atriceps_Rwenzori Hill Babbler
-Sylvia borin_Garden Warbler
-Sylvia nigricapillus_Bush Blackcap
-Sylvietta brachyura_Northern Crombec
-Sylvietta rufescens_Cape Crombec
-Sylvietta ruficapilla_Red-capped Crombec
-Sylvietta virens_Green Crombec
-Sylvietta whytii_Red-faced Crombec
-Sylviorthorhynchus desmursii_Des Murs's Wiretail
-Sylviorthorhynchus yanacensis_Tawny Tit-Spinetail
-Sylviparus modestus_Yellow-browed Tit
-Syma torotoro_Yellow-billed Kingfisher
-Symposiachrus trivirgatus_Spectacled Monarch
-Synallaxis albescens_Pale-breasted Spinetail
-Synallaxis albigularis_Dark-breasted Spinetail
-Synallaxis albilora_White-lored Spinetail
-Synallaxis azarae_Azara's Spinetail
-Synallaxis brachyura_Slaty Spinetail
-Synallaxis cabanisi_Cabanis's Spinetail
-Synallaxis candei_White-whiskered Spinetail
-Synallaxis castanea_Black-throated Spinetail
-Synallaxis cherriei_Chestnut-throated Spinetail
-Synallaxis cinerascens_Gray-bellied Spinetail
-Synallaxis cinerea_Bahia Spinetail
-Synallaxis cinnamomea_Stripe-breasted Spinetail
-Synallaxis courseni_Apurimac Spinetail
-Synallaxis erythrothorax_Rufous-breasted Spinetail
-Synallaxis frontalis_Sooty-fronted Spinetail
-Synallaxis fuscorufa_Rusty-headed Spinetail
-Synallaxis gujanensis_Plain-crowned Spinetail
-Synallaxis hellmayri_Red-shouldered Spinetail
-Synallaxis hypochondriaca_Great Spinetail
-Synallaxis hypospodia_Cinereous-breasted Spinetail
-Synallaxis infuscata_Pinto's Spinetail
-Synallaxis kollari_Hoary-throated Spinetail
-Synallaxis macconnelli_McConnell's Spinetail
-Synallaxis maranonica_Marañon Spinetail
-Synallaxis moesta_Dusky Spinetail
-Synallaxis ruficapilla_Rufous-capped Spinetail
-Synallaxis rutilans_Ruddy Spinetail
-Synallaxis scutata_Ochre-cheeked Spinetail
-Synallaxis spixi_Spix's Spinetail
-Synallaxis stictothorax_Necklaced Spinetail
-Synallaxis subpudica_Silvery-throated Spinetail
-Synallaxis tithys_Blackish-headed Spinetail
-Synallaxis unirufa_Rufous Spinetail
-Syndactyla dimidiata_Russet-mantled Foliage-gleaner
-Syndactyla guttulata_Guttulate Foliage-gleaner
-Syndactyla ruficollis_Rufous-necked Foliage-gleaner
-Syndactyla rufosuperciliata_Buff-browed Foliage-gleaner
-Syndactyla striata_Bolivian Recurvebill
-Syndactyla subalaris_Lineated Foliage-gleaner
-Syndactyla ucayalae_Peruvian Recurvebill
-Synoicus chinensis_小鵪鶉
-Synoicus ypsilophorus_Brown Quail
-Syrigma sibilatrix_Whistling Heron
-Syrrhaptes paradoxus_Pallas's Sandgrouse
-Systellura decussata_Tschudi's Nightjar
-Systellura longirostris_Band-winged Nightjar
-Taccocua leschenaultii_Sirkeer Malkoha
-Tachornis phoenicobia_Antillean Palm-Swift
-Tachornis squamata_Fork-tailed Palm-Swift
-Tachuris rubrigastra_Many-colored Rush Tyrant
-Tachybaptus dominicus_Least Grebe
-Tachybaptus novaehollandiae_Australasian Grebe
-Tachybaptus ruficollis_小鸊鷉
-Tachycineta albilinea_Mangrove Swallow
-Tachycineta albiventer_White-winged Swallow
-Tachycineta bicolor_Tree Swallow
-Tachycineta euchrysea_Golden Swallow
-Tachycineta leucopyga_Chilean Swallow
-Tachycineta leucorrhoa_White-rumped Swallow
-Tachycineta thalassina_Violet-green Swallow
-Tachyeres patachonicus_Flying Steamer-Duck
-Tachyphonus coronatus_Ruby-crowned Tanager
-Tachyphonus delatrii_Tawny-crested Tanager
-Tachyphonus phoenicius_Red-shouldered Tanager
-Tachyphonus rufus_White-lined Tanager
-Tachyphonus surinamus_Fulvous-crested Tanager
-Tadorna cana_South African Shelduck
-Tadorna ferruginea_瀆鳧
-Tadorna tadorna_花鳧
-Tadorna tadornoides_Australian Shelduck
-Tadorna variegata_Paradise Shelduck
-Taenioptynx brodiei_鵂鶹
-Taeniopygia guttata_Zebra Finch
-Taeniotriccus andrei_Black-chested Tyrant
-Talaphorus chlorocercus_Olive-spotted Hummingbird
-Talegalla fuscirostris_Yellow-legged Brushturkey
-Talegalla jobiensis_Red-legged Brushturkey
+Sporophila nigricollis_黄腹食籽雀
+Sporophila nuttingi_尼加拉瓜籽雀
+Sporophila palustris_沼泽食籽雀
+Sporophila peruviana_鹦嘴食籽雀
+Sporophila pileata_珠白腹食籽雀
+Sporophila plumbea_铅色食籽雀
+Sporophila ruficollis_黑喉食籽雀
+Sporophila schistacea_灰蓝食籽雀
+Sporophila simplex_黄褐食籽雀
+Sporophila telasco_栗喉食籽雀
+Sporophila torqueola_白领食籽雀
+Sporopipes frontalis_点额织雀
+Sporopipes squamifrons_鳞额编织雀
+Stachyris maculata_红腰穗鹛
+Stachyris nigriceps_黑头穗鹛
+Stachyris nigricollis_黑喉穗鹛
+Stachyris poliocephala_灰头穗鹛
+Stachyris strialata_斑颈穗鹛
+Stachyris thoracica_白领穗鹛
+Stactolaema leucotis_白耳拟啄木鸟
+Stactolaema olivacea_非洲绿拟啄木鸟
+Stagonopleura bella_艳火尾雀
+Staphida torqueola_栗颈凤鹛
+Steatornis caripensis_油夜鹰
+Stelgidillas gracilirostris_细嘴绿鹎
+Stelgidopteryx ruficollis_红翎毛翅燕
+Stelgidopteryx serripennis_中北美毛翅燕
+Stenostira scita_仙玉鹟
+Stephanoaetus coronatus_非洲冠雕
+Stephanophorus diadematus_凤冠裸鼻雀
+Stephanoxis lalandi_绿凤冠蜂鸟
+Stephanoxis loddigesii_紫凤冠蜂鸟
+Stercorarius antarcticus_棕贼鸥
+Stercorarius longicaudus_长尾贼鸥
+Stercorarius maccormicki_南极贼鸥
+Stercorarius parasiticus_短尾贼鸥
+Stercorarius pomarinus_中贼鸥
+Stercorarius skua_北贼鸥
+Sterna aurantia_黄嘴河燕鸥
+Sterna dougallii_粉红燕鸥
+Sterna forsteri_弗氏燕鸥
+Sterna hirundinacea_南美燕鸥
+Sterna hirundo_普通燕鸥
+Sterna paradisaea_北极燕鸥
+Sterna repressa_白颊燕鸥
+Sterna striata_澳洲燕鸥
+Sterna sumatrana_黑枕燕鸥
+Sterna trudeaui_白顶燕鸥
+Sterna vittata_南极燕鸥
+Sternula albifrons_白额燕鸥
+Sternula antillarum_小白额燕鸥
+Sternula saundersi_桑氏白额燕鸥
+Sternula superciliaris_南美白额燕鸥
+Stigmatura budytoides_大霸鹟
+Stigmatura napensis_小霸鹟
+Stilpnia cayana_亮黄靓唐纳雀
+Stilpnia cyanicollis_蓝颈靓唐纳雀
+Stilpnia cyanoptera_黑头靓唐纳雀
+Stilpnia heinei_黑顶靓唐纳雀
+Stilpnia larvata_金头靓唐纳雀
+Stilpnia nigrocincta_花脸靓唐纳雀
+Stilpnia peruviana_黑背靓唐纳雀
+Stilpnia preciosa_栗背靓唐纳雀
+Stilpnia vitriolina_朱顶靓唐纳雀
+Stiphrornis erythrothorax_橙胸林鸲
+Stipiturus malachurus_帚尾鹩莺
+Stizoptera bichenovii_双斑草雀
+Stomiopera unicolor_白颊纹吸蜜鸟
+Strepera fuliginosa_黑噪钟鹊
+Strepera graculina_斑噪钟鹊
+Strepera versicolor_灰噪钟鹊
+Streptopelia capicola_环颈斑鸠
+Streptopelia chinensis_珠颈斑鸠
+Streptopelia decaocto_灰斑鸠
+Streptopelia decipiens_灰头斑鸠
+Streptopelia lugens_粉胸斑鸠
+Streptopelia orientalis_山斑鸠
+Streptopelia roseogrisea_粉头斑鸠
+Streptopelia semitorquata_红眼斑鸠
+Streptopelia senegalensis_棕斑鸠
+Streptopelia tranquebarica_火斑鸠
+Streptopelia turtur_欧斑鸠
+Streptopelia vinacea_酒红斑鸠
+Streptoprocne biscutata_巴西黑雨燕
+Streptoprocne rutila_栗领黑雨燕
+Streptoprocne zonaris_白领黑雨燕
+Strix aluco_西灰林鸮
+Strix chacoensis_查科林鸮
+Strix fulvescens_茶色林鸮
+Strix hadorami_沙漠灰林鸮
+Strix hylophila_锈斑林鸮
+Strix leptogrammica_褐林鸮
+Strix nebulosa_乌林鸮
+Strix nivicolum_灰林鸮
+Strix occidentalis_斑林鸮
+Strix ocellata_白领林鸮
+Strix rufipes_棕斑林鸮
+Strix seloputo_点斑林鸮
+Strix uralensis_长尾林鸮
+Strix varia_横斑林鸮
+Strix woodfordii_非洲林鸮
+Struthidea cinerea_灰短嘴澳鸦
+Sturnella magna_东草地鹨
+Sturnella neglecta_西草地鹨
+Sturnia blythii_马拉巴椋鸟
+Sturnia malabarica_灰头椋鸟
+Sturnia pagodarum_黑冠椋鸟
+Sturnia sinensis_灰背椋鸟
+Sturnus unicolor_纯色椋鸟
+Sturnus vulgaris_紫翅椋鸟
+Sublegatus arenarum_北灌丛霸鹟
+Sublegatus modestus_南灌丛霸鹟
+Sublegatus obscurior_亚马孙灌丛霸鹟
+Sugomel nigrum_黑吸蜜鸟
+Suiriri suiriri_平原霸鹟
+Sula dactylatra_蓝脸鲣鸟
+Sula leucogaster_褐鲣鸟
+Sula nebouxii_蓝脚鲣鸟
+Sula sula_红脚鲣鸟
+Surnia ulula_猛鸮
+Surniculus dicruroides_叉尾乌鹃
+Surniculus lugubris_乌鹃
+Surniculus velutinus_菲律宾乌鹃
+Suthora nipalensis_橙额鸦雀
+Suthora verreauxi_金色鸦雀
+Swynnertonia swynnertoni_斯氏鸲
+Sylvia abyssinica_非洲雅鹛
+Sylvia atricapilla_黑顶林莺
+Sylvia atriceps_黑头非洲雅鹛
+Sylvia borin_庭园林莺
+Sylvia nigricapillus_黑顶鹛莺
+Sylvietta brachyura_短尾森莺
+Sylvietta rufescens_棕长嘴森莺
+Sylvietta ruficapilla_红顶森莺
+Sylvietta virens_绿森莺
+Sylvietta whytii_棕红脸森莺
+Sylviorthorhynchus desmursii_阿根廷线尾雀
+Sylviorthorhynchus yanacensis_茶色针尾雀
+Sylviparus modestus_黄眉林雀
+Syma torotoro_黄嘴翡翠
+Symposiachrus trivirgatus_眼镜王鹟
+Synallaxis albescens_淡胸针尾雀
+Synallaxis albigularis_暗胸针尾雀
+Synallaxis albilora_白眼先针尾雀
+Synallaxis azarae_阿氏针尾雀
+Synallaxis brachyura_蓝灰针尾雀
+Synallaxis cabanisi_卡氏针尾雀
+Synallaxis candei_白须针尾雀
+Synallaxis castanea_黑喉针尾雀
+Synallaxis cherriei_栗喉针尾雀
+Synallaxis cinerascens_灰腹针尾雀
+Synallaxis cinerea_巴西针尾雀
+Synallaxis cinnamomea_纹胸针尾雀
+Synallaxis courseni_阿波针尾雀
+Synallaxis erythrothorax_棕胸针尾雀
+Synallaxis frontalis_烟额针尾雀
+Synallaxis fuscorufa_锈头针尾雀
+Synallaxis gujanensis_纯顶针尾雀
+Synallaxis hellmayri_雷氏针尾雀
+Synallaxis hypochondriaca_大针尾雀
+Synallaxis hypospodia_灰胸针尾雀
+Synallaxis infuscata_纯色针尾雀
+Synallaxis kollari_灰喉针尾雀
+Synallaxis macconnelli_马氏针尾雀
+Synallaxis maranonica_马拉针尾雀
+Synallaxis moesta_暗色针尾雀
+Synallaxis ruficapilla_棕顶针尾雀
+Synallaxis rutilans_赤黄针尾雀
+Synallaxis scutata_褐颊针尾雀
+Synallaxis spixi_斯氏针尾雀
+Synallaxis stictothorax_项圈针尾雀
+Synallaxis subpudica_银喉针尾雀
+Synallaxis tithys_黑头针尾雀
+Synallaxis unirufa_棕色针尾雀
+Syndactyla dimidiata_草黄拾叶雀
+Syndactyla guttulata_点斑拾叶雀
+Syndactyla ruficollis_棕颈拾叶雀
+Syndactyla rufosuperciliata_黄眉拾叶雀
+Syndactyla striata_玻利维亚拾叶雀
+Syndactyla subalaris_线纹拾叶雀
+Syndactyla ucayalae_秘鲁拾叶雀
+Synoicus chinensis_蓝胸鹑
+Synoicus ypsilophorus_褐鹌鹑
+Syrigma sibilatrix_啸鹭
+Syrrhaptes paradoxus_毛腿沙鸡
+Systellura decussata_小斑翅夜鹰
+Systellura longirostris_斑翅夜鹰
+Taccocua leschenaultii_短嘴地鹃
+Tachornis phoenicobia_西印棕雨燕
+Tachornis squamata_叉尾棕雨燕
+Tachuris rubrigastra_多色苇霸鹟
+Tachybaptus dominicus_侏䴙䴘
+Tachybaptus novaehollandiae_黑喉小䴙䴘
+Tachybaptus ruficollis_小䴙䴘
+Tachycineta albilinea_红树燕
+Tachycineta albiventer_白翅树燕
+Tachycineta bicolor_双色树燕
+Tachycineta euchrysea_金色树燕
+Tachycineta leucopyga_白臀树燕
+Tachycineta leucorrhoa_白腰树燕
+Tachycineta thalassina_紫绿树燕
+Tachyeres patachonicus_花斑船鸭
+Tachyphonus coronatus_红冠黑唐纳雀
+Tachyphonus delatrii_黄冠黑唐纳雀
+Tachyphonus phoenicius_红肩黑唐纳雀
+Tachyphonus rufus_纹肩黑唐纳雀
+Tachyphonus surinamus_暗黄顶黑唐纳雀
+Tadorna cana_灰头麻鸭
+Tadorna ferruginea_赤麻鸭
+Tadorna tadorna_翘鼻麻鸭
+Tadorna tadornoides_棕胸麻鸭
+Tadorna variegata_黑胸麻鸭
+Taenioptynx brodiei_领鸺鹠
+Taeniopygia guttata_巽他斑胸草雀
+Taeniotriccus andrei_黑胸霸鹟
+Talaphorus chlorocercus_绿斑蜂鸟
+Talegalla fuscirostris_黑嘴塚雉
+Talegalla jobiensis_褐领塚雉
 Tamias striatus_Eastern Chipmunk
 Tamiasciurus hudsonicus_Red Squirrel
-Tangara arthus_Golden Tanager
-Tangara chilensis_Paradise Tanager
-Tangara cyanocephala_Red-necked Tanager
-Tangara cyanoventris_Gilt-edged Tanager
-Tangara desmaresti_Brassy-breasted Tanager
-Tangara dowii_Spangle-cheeked Tanager
-Tangara florida_Emerald Tanager
-Tangara gyrola_Bay-headed Tanager
-Tangara icterocephala_Silver-throated Tanager
-Tangara inornata_Plain-colored Tanager
-Tangara labradorides_Metallic-green Tanager
-Tangara lavinia_Rufous-winged Tanager
-Tangara mexicana_Turquoise Tanager
-Tangara nigroviridis_Beryl-spangled Tanager
-Tangara parzudakii_Flame-faced Tanager
-Tangara schrankii_Green-and-gold Tanager
-Tangara seledon_Green-headed Tanager
-Tangara vassorii_Blue-and-black Tanager
-Tangara velia_Opal-rumped Tanager
-Tangara xanthocephala_Saffron-crowned Tanager
-Tanygnathus sumatranus_Azure-rumped Parrot
-Tanysiptera galatea_Common Paradise-Kingfisher
-Tanysiptera sylvia_Buff-breasted Paradise-Kingfisher
-Tapera naevia_Striped Cuckoo
-Taraba major_Great Antshrike
-Tarphonomus certhioides_Chaco Earthcreeper
-Tarphonomus harterti_Bolivian Earthcreeper
-Tarsiger chrysaeus_Golden Bush-Robin
-Tarsiger cyanurus_藍尾鴝
-Tarsiger indicus_白眉林鴝
-Tarsiger johnstoniae_栗背林鴝
-Tarsiger rufilatus_Himalayan Bluetail
-Tauraco corythaix_Knysna Turaco
-Tauraco fischeri_Fischer's Turaco
-Tauraco hartlaubi_Hartlaub's Turaco
-Tauraco leucotis_White-cheeked Turaco
-Tauraco livingstonii_Livingstone's Turaco
-Tauraco macrorhynchus_Yellow-billed Turaco
-Tauraco persa_Guinea Turaco
-Tauraco porphyreolophus_Purple-crested Turaco
-Tauraco schalowi_Schalow's Turaco
-Tchagra australis_Brown-crowned Tchagra
-Tchagra senegalus_Black-crowned Tchagra
-Tchagra tchagra_Southern Tchagra
-Teledromas fuscus_Sandy Gallito
-Telespiza ultima_Nihoa Finch
+Tangara arthus_金靓唐纳雀
+Tangara chilensis_仙靓唐纳雀
+Tangara cyanocephala_红颈靓唐纳雀
+Tangara cyanoventris_金边靓唐纳雀
+Tangara desmaresti_铜胸靓唐纳雀
+Tangara dowii_斑颊靓唐纳雀
+Tangara florida_翠绿靓唐纳雀
+Tangara gyrola_栗头靓唐纳雀
+Tangara icterocephala_银喉靓唐纳雀
+Tangara inornata_纯色靓唐纳雀
+Tangara labradorides_辉绿靓唐纳雀
+Tangara lavinia_棕翅靓唐纳雀
+Tangara mexicana_青绿靓唐纳雀
+Tangara nigroviridis_辉斑靓唐纳雀
+Tangara parzudakii_火脸靓唐纳雀
+Tangara schrankii_绿金靓唐纳雀
+Tangara seledon_绿头靓唐纳雀
+Tangara vassorii_蓝黑靓唐纳雀
+Tangara velia_白腰靓唐纳雀
+Tangara xanthocephala_黄顶靓唐纳雀
+Tanygnathus sumatranus_青蓝腰鹦鹉
+Tanysiptera galatea_普通仙翡翠
+Tanysiptera sylvia_白尾仙翡翠
+Tapera naevia_纵纹鹃
+Taraba major_大蚁鵙
+Tarphonomus certhioides_查科爬地雀
+Tarphonomus harterti_玻利维亚爬地雀
+Tarsiger chrysaeus_金色林鸲
+Tarsiger cyanurus_红胁蓝尾鸲
+Tarsiger indicus_白眉林鸲
+Tarsiger johnstoniae_台湾林鸲
+Tarsiger rufilatus_蓝眉林鸲
+Tauraco corythaix_尼斯那蕉鹃
+Tauraco fischeri_费氏蕉鹃
+Tauraco hartlaubi_蓝冠蕉鹃
+Tauraco leucotis_白颊蕉鹃
+Tauraco livingstonii_利氏蕉鹃
+Tauraco macrorhynchus_黄嘴蕉鹃
+Tauraco persa_绿冠蕉鹃
+Tauraco porphyreolophus_紫冠蕉鹃
+Tauraco schalowi_沙氏蕉鹃
+Tchagra australis_褐冠红翅鵙
+Tchagra senegalus_黑冠红翅鵙
+Tchagra tchagra_南非红翅鵙
+Teledromas fuscus_沙色窜鸟
+Telespiza ultima_尼岛拟管舌雀
 Telophorus bocagei_Gray-green Bushshrike
-Telophorus dohertyi_Doherty's Bushshrike
-Telophorus nigrifrons_Black-fronted Bushshrike
-Telophorus olivaceus_Olive Bushshrike
+Telophorus dohertyi_杜氏丛鵙
+Telophorus nigrifrons_黑额丛鵙
+Telophorus olivaceus_暗绿丛鵙
 Telophorus sulfureopectus_Sulphur-breasted Bushshrike
-Telophorus viridis_Four-colored Bushshrike
-Telophorus zeylonus_Bokmakierie
-Temnurus temnurus_Ratchet-tailed Treepie
-Tephrodornis pondicerianus_Common Woodshrike
-Tephrodornis sylvicola_Malabar Woodshrike
-Tephrodornis virgatus_Large Woodshrike
-Terenotriccus erythrurus_Ruddy-tailed Flycatcher
-Terenura maculata_Streak-capped Antwren
-Terenura sicki_Orange-bellied Antwren
-Teretistris fernandinae_Yellow-headed Warbler
-Teretistris fornsi_Oriente Warbler
-Terpsiphone affinis_Blyth's Paradise-Flycatcher
-Terpsiphone atrocaudata_紫綬帶
-Terpsiphone bourbonnensis_Mascarene Paradise-Flycatcher
-Terpsiphone cinnamomea_Rufous Paradise-Flycatcher
-Terpsiphone incei_阿穆爾綬帶
-Terpsiphone mutata_Malagasy Paradise-Flycatcher
-Terpsiphone paradisi_Indian Paradise-Flycatcher
-Terpsiphone rufiventer_Black-headed Paradise-Flycatcher
-Terpsiphone viridis_African Paradise-Flycatcher
-Tersina viridis_Swallow Tanager
-Tesia cyaniventer_Gray-bellied Tesia
-Tesia everetti_Russet-capped Tesia
-Tesia olivea_Slaty-bellied Tesia
-Tesia superciliaris_Javan Tesia
-Tetrao urogallus_Western Capercaillie
-Tetraogallus caucasicus_Caucasian Snowcock
-Tetraogallus tibetanus_Tibetan Snowcock
-Tetrastes bonasia_Hazel Grouse
-Tetrax tetrax_Little Bustard
-Thalassarche melanophris_Black-browed Albatross
-Thalasseus bengalensis_小鳳頭燕鷗
-Thalasseus bergii_鳳頭燕鷗
-Thalasseus elegans_Elegant Tern
-Thalasseus maximus_Royal Tern
-Thalasseus sandvicensis_白嘴端燕鷗
-Thalurania colombica_Crowned Woodnymph
-Thalurania furcata_Fork-tailed Woodnymph
-Thalurania glaucopis_Violet-capped Woodnymph
-Thamnistes anabatinus_Russet Antshrike
-Thamnolaea cinnamomeiventris_Mocking Cliff-Chat
-Thamnomanes ardesiacus_Dusky-throated Antshrike
-Thamnomanes caesius_Cinereous Antshrike
-Thamnomanes saturninus_Saturnine Antshrike
-Thamnomanes schistogynus_Bluish-slate Antshrike
-Thamnophilus aethiops_White-shouldered Antshrike
-Thamnophilus amazonicus_Amazonian Antshrike
-Thamnophilus ambiguus_Sooretama Slaty-Antshrike
-Thamnophilus aroyae_Upland Antshrike
-Thamnophilus atrinucha_Black-crowned Antshrike
-Thamnophilus bernardi_Collared Antshrike
-Thamnophilus bridgesi_Black-hooded Antshrike
-Thamnophilus caerulescens_Variable Antshrike
-Thamnophilus cryptoleucus_Castelnau's Antshrike
-Thamnophilus doliatus_Barred Antshrike
-Thamnophilus melanonotus_Black-backed Antshrike
-Thamnophilus multistriatus_Bar-crested Antshrike
-Thamnophilus murinus_Mouse-colored Antshrike
-Thamnophilus nigriceps_Black Antshrike
-Thamnophilus nigrocinereus_Blackish-gray Antshrike
-Thamnophilus palliatus_Chestnut-backed Antshrike
-Thamnophilus pelzelni_Planalto Slaty-Antshrike
-Thamnophilus praecox_Cocha Antshrike
-Thamnophilus punctatus_Northern Slaty-Antshrike
-Thamnophilus ruficapillus_Rufous-capped Antshrike
-Thamnophilus schistaceus_Plain-winged Antshrike
-Thamnophilus stictocephalus_Natterer's Slaty-Antshrike
-Thamnophilus sticturus_Bolivian Slaty-Antshrike
-Thamnophilus tenuepunctatus_Lined Antshrike
-Thamnophilus torquatus_Rufous-winged Antshrike
-Thamnophilus unicolor_Uniform Antshrike
-Thamnophilus zarumae_Chapman's Antshrike
-Thectocercus acuticaudatus_Blue-crowned Parakeet
-Theristicus caerulescens_Plumbeous Ibis
-Theristicus caudatus_Buff-necked Ibis
-Theristicus melanopis_Black-faced Ibis
-Thescelocichla leucopleura_Swamp Greenbul
-Thinocorus orbignyianus_Gray-breasted Seedsnipe
-Thinocorus rumicivorus_Least Seedsnipe
-Thlypopsis ornata_Rufous-chested Tanager
-Thlypopsis pyrrhocoma_Chestnut-headed Tanager
-Thlypopsis sordida_Orange-headed Tanager
-Thlypopsis superciliaris_Superciliaried Hemispingus
-Thraupis abbas_Yellow-winged Tanager
-Thraupis cyanoptera_Azure-shouldered Tanager
-Thraupis episcopus_Blue-gray Tanager
-Thraupis ornata_Golden-chevroned Tanager
-Thraupis palmarum_Palm Tanager
-Thraupis sayaca_Sayaca Tanager
-Threnetes leucurus_Pale-tailed Barbthroat
-Threnetes ruckeri_Band-tailed Barbthroat
-Threskiornis melanocephalus_黑頭白䴉
-Threskiornis molucca_Australian Ibis
-Thripadectes flammulatus_Flammulated Treehunter
-Thripadectes holostictus_Striped Treehunter
-Thripadectes ignobilis_Uniform Treehunter
-Thripadectes melanorhynchus_Black-billed Treehunter
-Thripadectes rufobrunneus_Streak-breasted Treehunter
-Thripadectes scrutator_Rufous-backed Treehunter
-Thripadectes virgaticeps_Streak-capped Treehunter
-Thripophaga cherriei_Orinoco Softtail
-Thripophaga fusciceps_Plain Softtail
-Thripophaga macroura_Striated Softtail
-Thryomanes bewickii_Bewick's Wren
-Thryophilus nicefori_Niceforo's Wren
-Thryophilus pleurostictus_Banded Wren
-Thryophilus rufalbus_Rufous-and-white Wren
-Thryophilus sernai_Antioquia Wren
-Thryophilus sinaloa_Sinaloa Wren
-Thryothorus ludovicianus_Carolina Wren
-Tiaris olivaceus_Yellow-faced Grassquit
-Tichodroma muraria_Wallcreeper
-Tickellia hodgsoni_Broad-billed Warbler
-Tigrisoma lineatum_Rufescent Tiger-Heron
-Tigrisoma mexicanum_Bare-throated Tiger-Heron
-Timalia pileata_Chestnut-capped Babbler
-Tinamotis pentlandii_Puna Tinamou
-Tinamus guttatus_White-throated Tinamou
-Tinamus major_Great Tinamou
-Tinamus solitarius_Solitary Tinamou
-Tinamus tao_Gray Tinamou
-Tityra cayana_Black-tailed Tityra
-Tityra inquisitor_Black-crowned Tityra
-Tityra semifasciata_Masked Tityra
-Tockus deckeni_Von der Decken's Hornbill
-Tockus erythrorhynchus_Northern Red-billed Hornbill
-Tockus kempi_Western Red-billed Hornbill
-Tockus leucomelas_Southern Yellow-billed Hornbill
-Tockus rufirostris_Southern Red-billed Hornbill
-Todiramphus australasia_Cinnamon-banded Kingfisher
-Todiramphus chloris_白領翡翠
-Todiramphus funebris_Sombre Kingfisher
-Todiramphus macleayii_Forest Kingfisher
-Todiramphus sacer_Pacific Kingfisher
-Todiramphus sanctus_Sacred Kingfisher
-Todiramphus sordidus_Torresian Kingfisher
-Todiramphus tristrami_Melanesian Kingfisher
-Todiramphus winchelli_Rufous-lored Kingfisher
-Todirostrum chrysocrotaphum_Yellow-browed Tody-Flycatcher
-Todirostrum cinereum_Common Tody-Flycatcher
-Todirostrum maculatum_Spotted Tody-Flycatcher
-Todirostrum nigriceps_Black-headed Tody-Flycatcher
-Todirostrum pictum_Painted Tody-Flycatcher
-Todirostrum poliocephalum_Gray-headed Tody-Flycatcher
-Todus angustirostris_Narrow-billed Tody
-Todus mexicanus_Puerto Rican Tody
-Todus multicolor_Cuban Tody
-Todus subulatus_Broad-billed Tody
-Todus todus_Jamaican Tody
-Tolmomyias assimilis_Yellow-margined Flycatcher
-Tolmomyias flaviventris_Yellow-breasted Flycatcher (Ochre-lored)
-Tolmomyias poliocephalus_Gray-crowned Flycatcher
-Tolmomyias sulphurescens_Yellow-olive Flycatcher
-Tolmomyias traylori_Orange-eyed Flycatcher
-Topaza pella_Crimson Topaz
-Topaza pyra_Fiery Topaz
-Torreornis inexpectata_Zapata Sparrow
-Touit batavicus_Lilac-tailed Parrotlet
-Touit dilectissimus_Blue-fronted Parrotlet
-Touit huetii_Scarlet-shouldered Parrotlet
-Touit melanonotus_Brown-backed Parrotlet
-Touit purpuratus_Sapphire-rumped Parrotlet
-Touit stictopterus_Spot-winged Parrotlet
-Touit surdus_Golden-tailed Parrotlet
-Toxorhamphus novaeguineae_Yellow-bellied Longbill
-Toxostoma bendirei_Bendire's Thrasher
-Toxostoma cinereum_Gray Thrasher
-Toxostoma crissale_Crissal Thrasher
-Toxostoma curvirostre_Curve-billed Thrasher
-Toxostoma lecontei_LeConte's Thrasher
-Toxostoma longirostre_Long-billed Thrasher
-Toxostoma ocellatum_Ocellated Thrasher
-Toxostoma redivivum_California Thrasher
-Toxostoma rufum_Brown Thrasher
-Trachyphonus darnaudii_D'Arnaud's Barbet
-Trachyphonus erythrocephalus_Red-and-yellow Barbet
-Trachyphonus purpuratus_Yellow-billed Barbet
-Trachyphonus vaillantii_Crested Barbet
-Tregellasia capito_Pale-yellow Robin
-Treron affinis_Gray-fronted Green-Pigeon
-Treron bicinctus_橙胸綠鳩
-Treron calvus_African Green-Pigeon
-Treron curvirostra_厚嘴綠鳩
-Treron formosae_紅頭綠鳩
-Treron fulvicollis_Cinnamon-headed Green-Pigeon
-Treron olax_Little Green-Pigeon
-Treron phayrei_Ashy-headed Green-Pigeon
-Treron phoenicopterus_Yellow-footed Green-Pigeon
-Treron sieboldii_綠鳩
-Treron sphenurus_Wedge-tailed Green-Pigeon
-Treron vernans_Pink-necked Green-Pigeon
-Tribonyx mortierii_Tasmanian Nativehen
-Tribonyx ventralis_Black-tailed Nativehen
-Trichoglossus chlorolepidotus_Scaly-breasted Lorikeet
-Trichoglossus haematodus_新幾內亞彩虹吸蜜鸚鵡
-Trichoglossus moluccanus_彩虹吸蜜鸚鵡
-Trichoglossus rubritorquis_紅領吸蜜鸚鵡
-Tricholaema diademata_Red-fronted Barbet
-Tricholaema hirsuta_Hairy-breasted Barbet
-Tricholaema lacrymosa_Spot-flanked Barbet
-Tricholaema leucomelas_Pied Barbet
-Tricholaema melanocephala_Black-throated Barbet
-Tricholestes criniger_Hairy-backed Bulbul
-Trichothraupis melanops_Black-goggled Tanager
-Triclaria malachitacea_Blue-bellied Parrot
-Tringa brevipes_黃足鷸
-Tringa erythropus_鶴鷸
-Tringa flavipes_小黃腳鷸
-Tringa glareola_鷹斑鷸
-Tringa guttifer_諾氏鷸
-Tringa incana_美洲黃足鷸
-Tringa melanoleuca_Greater Yellowlegs
-Tringa nebularia_青足鷸
-Tringa ochropus_白腰草鷸
-Tringa semipalmata_Willet
-Tringa solitaria_Solitary Sandpiper
-Tringa stagnatilis_小青足鷸
-Tringa totanus_赤足鷸
-Trochalopteron affine_Black-faced Laughingthrush
-Trochalopteron chrysopterum_Assam Laughingthrush
-Trochalopteron elliotii_Elliot's Laughingthrush
-Trochalopteron erythrocephalum_Chestnut-crowned Laughingthrush
-Trochalopteron henrici_Prince Henry's Laughingthrush
-Trochalopteron imbricatum_Bhutan Laughingthrush
-Trochalopteron lineatum_Streaked Laughingthrush
-Trochalopteron melanostigma_Silver-eared Laughingthrush
-Trochalopteron milnei_Red-tailed Laughingthrush
-Trochalopteron morrisonianum_台灣噪眉
-Trochalopteron peninsulae_Malayan Laughingthrush
-Trochalopteron squamatum_Blue-winged Laughingthrush
-Trochalopteron subunicolor_Scaly Laughingthrush
-Trochalopteron variegatum_Variegated Laughingthrush
-Trochalopteron virgatum_Striped Laughingthrush
-Trochocercus cyanomelas_African Crested-Flycatcher
-Trochocercus nitens_Blue-headed Crested-Flycatcher
-Troglodytes aedon_House Wren
-Troglodytes hiemalis_Winter Wren
-Troglodytes ochraceus_Ochraceous Wren
-Troglodytes pacificus_Pacific Wren
-Troglodytes rufociliatus_Rufous-browed Wren
-Troglodytes solstitialis_Mountain Wren
-Troglodytes troglodytes_鷦鷯
-Trogon bairdii_Baird's Trogon
-Trogon caligatus_Gartered Trogon
-Trogon chionurus_White-tailed Trogon
-Trogon citreolus_Citreoline Trogon
-Trogon clathratus_Lattice-tailed Trogon
-Trogon collaris_Collared Trogon
-Trogon comptus_Blue-tailed Trogon
-Trogon curucui_Blue-crowned Trogon
-Trogon elegans_Elegant Trogon
-Trogon massena_Slaty-tailed Trogon
-Trogon melanocephalus_Black-headed Trogon
-Trogon melanurus_Black-tailed Trogon
-Trogon mesurus_Ecuadorian Trogon
-Trogon mexicanus_Mountain Trogon
-Trogon personatus_Masked Trogon
-Trogon ramonianus_Amazonian Trogon
-Trogon rufus_Black-throated Trogon
-Trogon surrucura_Surucua Trogon
-Trogon violaceus_Guianan Trogon
-Trogon viridis_Green-backed Trogon
-Tropicoperdix chloropus_Scaly-breasted Partridge
-Tumbezia salvini_Tumbes Tyrant
-Tunchiornis ochraceiceps_Tawny-crowned Greenlet
-Turdinus atrigularis_Black-throated Wren-Babbler
-Turdinus macrodactylus_Large Wren-Babbler
-Turdinus marmoratus_Marbled Wren-Babbler
-Turdoides hartlaubii_Hartlaub's Babbler
-Turdoides jardineii_Arrow-marked Babbler
-Turdoides leucopygia_White-rumped Babbler
-Turdoides plebejus_Brown Babbler
-Turdoides reinwardtii_Blackcap Babbler
-Turdoides sharpei_Black-lored Babbler
-Turdus abyssinicus_Abyssinian Thrush
-Turdus albicollis_White-necked Thrush
-Turdus albocinctus_White-collared Blackbird
-Turdus amaurochalinus_Creamy-bellied Thrush
-Turdus assimilis_White-throated Thrush
-Turdus atrogularis_黑頸鶇
-Turdus aurantius_White-chinned Thrush
-Turdus boulboul_Gray-winged Blackbird
-Turdus cardis_烏灰鶇
-Turdus celaenops_Izu Thrush
-Turdus chiguanco_Chiguanco Thrush
-Turdus chrysolaus_赤腹鶇
-Turdus dissimilis_Black-breasted Thrush
-Turdus eunomus_斑點鶇
-Turdus falcklandii_Austral Thrush
-Turdus feae_褐頭鶇
-Turdus flavipes_Yellow-legged Thrush
-Turdus fulviventris_Chestnut-bellied Thrush
-Turdus fumigatus_Cocoa Thrush
-Turdus fuscater_Great Thrush
-Turdus grayi_Clay-colored Thrush
-Turdus hauxwelli_Hauxwell's Thrush
-Turdus hortulorum_灰背鶇
-Turdus ignobilis_Black-billed Thrush
-Turdus iliacus_Redwing
-Turdus infuscatus_Black Thrush
-Turdus lawrencii_Lawrence's Thrush
-Turdus leucomelas_Pale-breasted Thrush
-Turdus leucops_Pale-eyed Thrush
-Turdus libonyana_Kurrichane Thrush
-Turdus maculirostris_Ecuadorian Thrush
-Turdus mandarinus_中國黑鶇
-Turdus maranonicus_Marañon Thrush
-Turdus menachensis_Yemen Thrush
-Turdus merula_歐亞黑鶇
-Turdus migratorius_American Robin
-Turdus naumanni_紅尾鶇
-Turdus nigrescens_Sooty Thrush
-Turdus nigriceps_Andean Slaty Thrush
-Turdus nudigenis_Spectacled Thrush
-Turdus obscurus_白眉鶇
-Turdus obsoletus_Pale-vented Thrush
-Turdus olivaceus_Olive Thrush
-Turdus olivater_Black-hooded Thrush
-Turdus pallidus_白腹鶇
-Turdus pelios_African Thrush
-Turdus philomelos_Song Thrush
-Turdus pilaris_Fieldfare
-Turdus plebejus_Mountain Thrush
-Turdus plumbeus_Red-legged Thrush
-Turdus poliocephalus_Island Thrush
-Turdus reevei_Plumbeous-backed Thrush
-Turdus rubrocanus_Chestnut Thrush
-Turdus ruficollis_赤頸鶇
-Turdus rufitorques_Rufous-collared Robin
-Turdus rufiventris_Rufous-bellied Thrush
-Turdus rufopalliatus_Rufous-backed Robin
-Turdus sanchezorum_Varzea Thrush
-Turdus serranus_Glossy-black Thrush
-Turdus simillimus_Indian Blackbird
-Turdus smithi_Karoo Thrush
-Turdus subalaris_Blacksmith Thrush
-Turdus swalesi_La Selle Thrush
-Turdus tephronotus_African Bare-eyed Thrush
-Turdus torquatus_Ring Ouzel
-Turdus unicolor_Tickell's Thrush
-Turdus viscivorus_Mistle Thrush
-Turnix maculosus_Red-backed Buttonquail
-Turnix suscitator_棕三趾鶉
-Turnix sylvaticus_林三趾鶉
-Turnix varius_Painted Buttonquail
-Turtur abyssinicus_Black-billed Wood-Dove
-Turtur afer_Blue-spotted Wood-Dove
-Turtur brehmeri_Blue-headed Wood-Dove
-Turtur chalcospilos_Emerald-spotted Wood-Dove
-Turtur tympanistria_Tambourine Dove
-Tylas eduardi_Tylas Vanga
-Tympanuchus cupido_Greater Prairie-Chicken
-Tympanuchus pallidicinctus_Lesser Prairie-Chicken
-Tympanuchus phasianellus_Sharp-tailed Grouse
-Tyranneutes stolzmanni_Dwarf Tyrant-Manakin
-Tyranneutes virescens_Tiny Tyrant-Manakin
-Tyrannopsis sulphurea_Sulphury Flycatcher
-Tyrannulus elatus_Yellow-crowned Tyrannulet
-Tyrannus albogularis_White-throated Kingbird
-Tyrannus caudifasciatus_Loggerhead Kingbird
-Tyrannus couchii_Couch's Kingbird
-Tyrannus crassirostris_Thick-billed Kingbird
-Tyrannus dominicensis_Gray Kingbird
-Tyrannus forficatus_Scissor-tailed Flycatcher
-Tyrannus melancholicus_Tropical Kingbird
-Tyrannus niveigularis_Snowy-throated Kingbird
-Tyrannus savana_Fork-tailed Flycatcher
-Tyrannus tyrannus_Eastern Kingbird
-Tyrannus verticalis_Western Kingbird
-Tyrannus vociferans_Cassin's Kingbird
-Tyto alba_Barn Owl
-Tyto novaehollandiae_Australian Masked-Owl
-Tyto tenebricosa_Sooty Owl
-Upucerthia dumetaria_Scale-throated Earthcreeper
-Upucerthia saturatior_Patagonian Forest Earthcreeper
-Upucerthia validirostris_Buff-breasted Earthcreeper
-Upupa epops_戴勝
-Upupa marginata_Madagascar Hoopoe
-Uraeginthus angolensis_Southern Cordonbleu
-Uraeginthus bengalus_Red-cheeked Cordonbleu
-Uranomitra franciae_Andean Emerald
-Uria aalge_崖海鴉
-Uria lomvia_Thick-billed Murre
-Urocissa caerulea_台灣藍鵲
-Urocissa erythroryncha_紅嘴藍鵲
-Urocissa flavirostris_Yellow-billed Blue-Magpie
-Urocissa ornata_Sri Lanka Blue-Magpie
-Urocolius indicus_Red-faced Mousebird
-Urocolius macrourus_Blue-naped Mousebird
-Urocynchramus pylzowi_Przevalski's Pinktail
-Urodynamis taitensis_Long-tailed Koel
-Uromyias agilis_Agile Tit-Tyrant
-Uromyias agraphia_Unstreaked Tit-Tyrant
-Uropsalis lyra_Lyre-tailed Nightjar
-Uropsalis segmentata_Swallow-tailed Nightjar
-Uropsila leucogastra_White-bellied Wren
-Urosphena pallidipes_Pale-footed Bush Warbler
-Urosphena squameiceps_短尾鶯
-Urosphena subulata_Timor Stubtail
-Urosphena whiteheadi_Bornean Stubtail
-Urothraupis stolzmanni_Black-backed Bush Tanager
-Urotriorchis macrourus_Long-tailed Hawk
-Vanellus armatus_Blacksmith Lapwing
+Telophorus viridis_四色丛鵙
+Telophorus zeylonus_南非丛鵙
+Temnurus temnurus_塔尾树鹊
+Tephrodornis pondicerianus_林鵙
+Tephrodornis sylvicola_西钩嘴林鵙
+Tephrodornis virgatus_钩嘴林鵙
+Terenotriccus erythrurus_红尾霸鹟
+Terenura maculata_纹顶蚁鹩
+Terenura sicki_橙腹蚁鹩
+Teretistris fernandinae_黄头灰森莺
+Teretistris fornsi_灰森莺
+Terpsiphone affinis_中南寿带
+Terpsiphone atrocaudata_紫寿带
+Terpsiphone bourbonnensis_毛里求斯寿带
+Terpsiphone cinnamomea_棕寿带
+Terpsiphone incei_寿带
+Terpsiphone mutata_马岛寿带
+Terpsiphone paradisi_印度寿带
+Terpsiphone rufiventer_红腹寿带
+Terpsiphone viridis_非洲寿带
+Tersina viridis_燕嘴唐纳雀
+Tesia cyaniventer_灰腹地莺
+Tesia everetti_褐冠地莺
+Tesia olivea_金冠地莺
+Tesia superciliaris_眉纹地莺
+Tetrao urogallus_西方松鸡
+Tetraogallus caucasicus_高加索雪鸡
+Tetraogallus tibetanus_藏雪鸡
+Tetrastes bonasia_花尾榛鸡
+Tetrax tetrax_小鸨
+Thalassarche melanophris_黑眉信天翁
+Thalasseus bengalensis_小凤头燕鸥
+Thalasseus bergii_大凤头燕鸥
+Thalasseus elegans_美洲凤头燕鸥
+Thalasseus maximus_橙嘴凤头燕鸥
+Thalasseus sandvicensis_白嘴端凤头燕鸥
+Thalurania colombica_蓝顶妍蜂鸟
+Thalurania furcata_叉尾妍蜂鸟
+Thalurania glaucopis_紫顶妍蜂鸟
+Thamnistes anabatinus_褐蚁鵙
+Thamnolaea cinnamomeiventris_桂红蚁䳭
+Thamnomanes ardesiacus_灰喉蚁鵙
+Thamnomanes caesius_灰蚁鵙
+Thamnomanes saturninus_暗色蚁鵙
+Thamnomanes schistogynus_蓝蚁鵙
+Thamnophilus aethiops_白肩蚁鵙
+Thamnophilus amazonicus_亚马孙蚁鵙
+Thamnophilus ambiguus_索瑞蚁鵙
+Thamnophilus aroyae_山蚁鵙
+Thamnophilus atrinucha_西蓝灰蚁鵙
+Thamnophilus bernardi_领蚁鵙
+Thamnophilus bridgesi_黑头蚁鵙
+Thamnophilus caerulescens_杂色蚁鵙
+Thamnophilus cryptoleucus_卡氏蚁鵙
+Thamnophilus doliatus_横斑蚁鵙
+Thamnophilus melanonotus_黑背蚁鵙
+Thamnophilus multistriatus_斑冠蚁鵙
+Thamnophilus murinus_鼠灰蚁鵙
+Thamnophilus nigriceps_黑蚁鵙
+Thamnophilus nigrocinereus_黑灰蚁鵙
+Thamnophilus palliatus_栗背蚁鵙
+Thamnophilus pelzelni_高原蚁鵙
+Thamnophilus praecox_厄瓜多尔蚁鵙
+Thamnophilus punctatus_蓝灰蚁鵙
+Thamnophilus ruficapillus_棕顶蚁鵙
+Thamnophilus schistaceus_黑顶蚁鵙
+Thamnophilus stictocephalus_纳氏蚁鵙
+Thamnophilus sticturus_玻利维亚蚁鵙
+Thamnophilus tenuepunctatus_线纹蚁鵙
+Thamnophilus torquatus_棕翅蚁鵙
+Thamnophilus unicolor_纯色蚁鵙
+Thamnophilus zarumae_查氏蚁鵙
+Thectocercus acuticaudatus_蓝冠鹦哥
+Theristicus caerulescens_铅色鹮
+Theristicus caudatus_黄颈鹮
+Theristicus melanopis_黑脸鹮
+Thescelocichla leucopleura_沼泽鹎
+Thinocorus orbignyianus_灰胸籽鹬
+Thinocorus rumicivorus_小籽鹬
+Thlypopsis ornata_棕胸灰背雀
+Thlypopsis pyrrhocoma_栗头唐纳雀
+Thlypopsis sordida_橙头灰背雀
+Thlypopsis superciliaris_白眉拟雀
+Thraupis abbas_黄翅裸鼻雀
+Thraupis cyanoptera_蓝肩裸鼻雀
+Thraupis episcopus_灰蓝裸鼻雀
+Thraupis ornata_金肩纹裸鼻雀
+Thraupis palmarum_棕榈裸鼻雀
+Thraupis sayaca_灰喉裸鼻雀
+Threnetes leucurus_淡尾髭喉蜂鸟
+Threnetes ruckeri_斑尾髭喉蜂鸟
+Threskiornis melanocephalus_黑头白鹮
+Threskiornis molucca_澳洲白鹮
+Thripadectes flammulatus_火红树猎雀
+Thripadectes holostictus_纵纹树猎雀
+Thripadectes ignobilis_纯色树猎雀
+Thripadectes melanorhynchus_黑嘴树猎雀
+Thripadectes rufobrunneus_纹胸树猎雀
+Thripadectes scrutator_黄喉树猎雀
+Thripadectes virgaticeps_纹顶树猎雀
+Thripophaga cherriei_委内瑞拉软尾雀
+Thripophaga fusciceps_纯色软尾雀
+Thripophaga macroura_条纹软尾雀
+Thryomanes bewickii_比氏苇鹪鹩
+Thryophilus nicefori_尼氏苇鹪鹩
+Thryophilus pleurostictus_斑苇鹪鹩
+Thryophilus rufalbus_棕白苇鹪鹩
+Thryophilus sernai_淡脸苇鹪鹩
+Thryophilus sinaloa_斑臀苇鹪鹩
+Thryothorus ludovicianus_卡罗苇鹪鹩
+Tiaris olivaceus_黄脸草雀
+Tichodroma muraria_红翅旋壁雀
+Tickellia hodgsoni_宽嘴鹟莺
+Tigrisoma lineatum_栗虎鹭
+Tigrisoma mexicanum_裸喉虎鹭
+Timalia pileata_红顶鹛
+Tinamotis pentlandii_北山䳍
+Tinamus guttatus_白喉䳍
+Tinamus major_大䳍
+Tinamus solitarius_孤䳍
+Tinamus tao_灰䳍
+Tityra cayana_黑尾蒂泰霸鹟
+Tityra inquisitor_黑顶蒂泰霸鹟
+Tityra semifasciata_花脸蒂泰霸鹟
+Tockus deckeni_德氏弯嘴犀鸟
+Tockus erythrorhynchus_红嘴弯嘴犀鸟
+Tockus kempi_西非红嘴犀鸟
+Tockus leucomelas_南黄弯嘴犀鸟
+Tockus rufirostris_南红嘴犀鸟
+Todiramphus australasia_冠翡翠
+Todiramphus chloris_白领翡翠
+Todiramphus funebris_淡黑翡翠
+Todiramphus macleayii_林翡翠
+Todiramphus sacer_太平洋翡翠
+Todiramphus sanctus_白眉翡翠
+Todiramphus sordidus_托列斯翡翠
+Todiramphus tristrami_美岛翡翠
+Todiramphus winchelli_菲律宾翡翠
+Todirostrum chrysocrotaphum_黄眉哑霸鹟
+Todirostrum cinereum_哑霸鹟
+Todirostrum maculatum_斑哑霸鹟
+Todirostrum nigriceps_黑头哑霸鹟
+Todirostrum pictum_彩哑霸鹟
+Todirostrum poliocephalum_灰头哑霸鹟
+Todus angustirostris_狭嘴短尾鴗
+Todus mexicanus_波多黎各短尾鴗
+Todus multicolor_杂色短尾鴗
+Todus subulatus_阔嘴短尾鴗
+Todus todus_短尾鴗
+Tolmomyias assimilis_黄羽缘霸鹟
+Tolmomyias flaviventris_黄胸霸鹟
+Tolmomyias poliocephalus_灰顶霸鹟
+Tolmomyias sulphurescens_黄绿霸鹟
+Tolmomyias traylori_黄眼霸鹟
+Topaza pella_赤叉尾蜂鸟
+Topaza pyra_火红叉尾蜂鸟
+Torreornis inexpectata_萨帕塔鹀
+Touit batavicus_淡紫尾鹦哥
+Touit dilectissimus_蓝额鹦哥
+Touit huetii_紫肩鹦哥
+Touit melanonotus_褐背鹦哥
+Touit purpuratus_青腰鹦哥
+Touit stictopterus_斑翅鹦哥
+Touit surdus_金尾鹦哥
+Toxorhamphus novaeguineae_黄腹弯嘴吸蜜鸟
+Toxostoma bendirei_本氏弯嘴嘲鸫
+Toxostoma cinereum_灰弯嘴嘲鸫
+Toxostoma crissale_栗臀弯嘴嘲鸫
+Toxostoma curvirostre_弯嘴嘲鸫
+Toxostoma lecontei_勒氏弯嘴嘲鸫
+Toxostoma longirostre_长弯嘴嘲鸫
+Toxostoma ocellatum_墨西哥弯嘴嘲鸫
+Toxostoma redivivum_加州弯嘴嘲鸫
+Toxostoma rufum_褐弯嘴嘲鸫
+Trachyphonus darnaudii_东非拟啄木鸟
+Trachyphonus erythrocephalus_红黄拟啄木鸟
+Trachyphonus purpuratus_黄嘴拟啄木鸟
+Trachyphonus vaillantii_南非拟啄木鸟
+Tregellasia capito_淡黄歌鸲鹟
+Treron affinis_灰额绿鸠
+Treron bicinctus_橙胸绿鸠
+Treron calvus_非洲绿鸠
+Treron curvirostra_厚嘴绿鸠
+Treron formosae_红顶绿鸠
+Treron fulvicollis_棕头绿鸠
+Treron olax_小绿鸠
+Treron phayrei_灰头绿鸠
+Treron phoenicopterus_黄脚绿鸠
+Treron sieboldii_红翅绿鸠
+Treron sphenurus_楔尾绿鸠
+Treron vernans_红颈绿鸠
+Tribonyx mortierii_绿水鸡
+Tribonyx ventralis_黑尾水鸡
+Trichoglossus chlorolepidotus_鳞胸鹦鹉
+Trichoglossus haematodus_椰果鹦鹉
+Trichoglossus moluccanus_彩虹吸蜜鹦鹉
+Trichoglossus rubritorquis_红领鹦鹉
+Tricholaema diademata_红额拟啄木鸟
+Tricholaema hirsuta_丝胸拟啄木鸟
+Tricholaema lacrymosa_斑胁拟啄木鸟
+Tricholaema leucomelas_斑拟啄木鸟
+Tricholaema melanocephala_黑喉拟啄木鸟
+Tricholestes criniger_丝背鹎
+Trichothraupis melanops_黑脸唐拉格雀
+Triclaria malachitacea_蓝腹鹦哥
+Tringa brevipes_灰尾漂鹬
+Tringa erythropus_鹤鹬
+Tringa flavipes_小黄脚鹬
+Tringa glareola_林鹬
+Tringa guttifer_小青脚鹬
+Tringa incana_漂鹬
+Tringa melanoleuca_大黄脚鹬
+Tringa nebularia_青脚鹬
+Tringa ochropus_白腰草鹬
+Tringa semipalmata_斑翅鹬
+Tringa solitaria_褐腰草鹬
+Tringa stagnatilis_泽鹬
+Tringa totanus_红脚鹬
+Trochalopteron affine_黑顶噪鹛
+Trochalopteron chrysopterum_金翅噪鹛
+Trochalopteron elliotii_橙翅噪鹛
+Trochalopteron erythrocephalum_红头噪鹛
+Trochalopteron henrici_灰腹噪鹛
+Trochalopteron imbricatum_丽星噪鹛
+Trochalopteron lineatum_细纹噪鹛
+Trochalopteron melanostigma_银耳噪鹛
+Trochalopteron milnei_赤尾噪鹛
+Trochalopteron morrisonianum_玉山噪鹛
+Trochalopteron peninsulae_马来噪鹛
+Trochalopteron squamatum_蓝翅噪鹛
+Trochalopteron subunicolor_纯色噪鹛
+Trochalopteron variegatum_杂色噪鹛
+Trochalopteron virgatum_纹耳噪鹛
+Trochocercus cyanomelas_非洲凤头鹟
+Trochocercus nitens_蓝头凤头鹟
+Troglodytes aedon_莺鹪鹩
+Troglodytes hiemalis_冬鹪鹩
+Troglodytes ochraceus_赭鹪鹩
+Troglodytes pacificus_阿拉斯加鹪鹩
+Troglodytes rufociliatus_棕眉鹪鹩
+Troglodytes solstitialis_山鹪鹩
+Troglodytes troglodytes_鹪鹩
+Trogon bairdii_拜氏美洲咬鹃
+Trogon caligatus_斑尾美洲咬鹃
+Trogon chionurus_白尾美洲咬鹃
+Trogon citreolus_黄纹美洲咬鹃
+Trogon clathratus_花尾美洲咬鹃
+Trogon collaris_白领美洲咬鹃
+Trogon comptus_白眼美洲咬鹃
+Trogon curucui_蓝顶美洲咬鹃
+Trogon elegans_优雅美洲咬鹃
+Trogon massena_灰尾美洲咬鹃
+Trogon melanocephalus_黑头美洲咬鹃
+Trogon melanurus_黑尾美洲咬鹃
+Trogon mesurus_厄瓜多尔咬鹃
+Trogon mexicanus_高山美洲咬鹃
+Trogon personatus_美洲咬鹃
+Trogon ramonianus_亚马逊咬鹃
+Trogon rufus_亚马逊黑喉咬鹃
+Trogon surrucura_苏鲁美洲咬鹃
+Trogon violaceus_紫头美洲咬鹃
+Trogon viridis_绿背美洲咬鹃
+Tropicoperdix chloropus_绿脚树鹧鸪
+Tumbezia salvini_通贝斯唧霸鹟
+Tunchiornis ochraceiceps_褐顶绿莺雀
+Turdinus atrigularis_黑喉鹪鹛
+Turdinus macrodactylus_大鹪鹛
+Turdinus marmoratus_石纹鹪鹛
+Turdoides hartlaubii_安哥拉鸫鹛
+Turdoides jardineii_箭纹鸫鹛
+Turdoides leucopygia_白腰鸫鹛
+Turdoides plebejus_非洲褐鸫鹛
+Turdoides reinwardtii_黑头鸫鹛
+Turdoides sharpei_黑眼先鸫鹛
+Turdus abyssinicus_东非鸫
+Turdus albicollis_南美白颈鸫
+Turdus albocinctus_白颈鸫
+Turdus amaurochalinus_淡腹鸫
+Turdus assimilis_白喉鸫
+Turdus atrogularis_黑喉鸫
+Turdus aurantius_白颏鸫
+Turdus boulboul_灰翅鸫
+Turdus cardis_乌灰鸫
+Turdus celaenops_伊岛鸫
+Turdus chiguanco_秘鲁鸫
+Turdus chrysolaus_赤胸鸫
+Turdus dissimilis_黑胸鸫
+Turdus eunomus_斑鸫
+Turdus falcklandii_南美鸫
+Turdus feae_褐头鸫
+Turdus flavipes_黄腿鸫
+Turdus fulviventris_栗腹鸫
+Turdus fumigatus_淡臀鸫
+Turdus fuscater_大棕鸫
+Turdus grayi_褐背鸫
+Turdus hauxwelli_豪氏鸫
+Turdus hortulorum_灰背鸫
+Turdus ignobilis_黑嘴鸫
+Turdus iliacus_白眉歌鸫
+Turdus infuscatus_美洲黑鸫
+Turdus lawrencii_罗氏鸫
+Turdus leucomelas_淡胸鸫
+Turdus leucops_淡眼鸫
+Turdus libonyana_橙腹鸫
+Turdus maculirostris_厄瓜多尔鸫
+Turdus mandarinus_乌鸫
+Turdus maranonicus_马谷鸫
+Turdus menachensis_也门鸫
+Turdus merula_欧乌鸫
+Turdus migratorius_旅鸫
+Turdus naumanni_红尾斑鸫
+Turdus nigrescens_乌鸲鸫
+Turdus nigriceps_安第斯灰鸫
+Turdus nudigenis_裸眼鸫
+Turdus obscurus_白眉鸫
+Turdus obsoletus_白臀鸫
+Turdus olivaceus_橄榄鸫
+Turdus olivater_黑冠鸫
+Turdus pallidus_白腹鸫
+Turdus pelios_非洲鸫
+Turdus philomelos_欧歌鸫
+Turdus pilaris_田鸫
+Turdus plebejus_美洲山鸫
+Turdus plumbeus_红腿鸫
+Turdus poliocephalus_塔岛鸫
+Turdus reevei_铅背鸫
+Turdus rubrocanus_灰头鸫
+Turdus ruficollis_赤颈鸫
+Turdus rufitorques_中美棕颈鸫
+Turdus rufiventris_棕腹鸫
+Turdus rufopalliatus_棕背鸲鸫
+Turdus sanchezorum_亚马逊裸眼鸫
+Turdus serranus_辉背鸫
+Turdus simillimus_南亚乌鸫
+Turdus smithi_南非鸫
+Turdus subalaris_石鸫
+Turdus swalesi_红腹鸫
+Turdus tephronotus_非洲裸眼鸫
+Turdus torquatus_环颈鸫
+Turdus unicolor_蒂氏鸫
+Turdus viscivorus_槲鸫
+Turnix maculosus_红背三趾鹑
+Turnix suscitator_棕三趾鹑
+Turnix sylvaticus_林三趾鹑
+Turnix varius_彩三趾鹑
+Turtur abyssinicus_黑嘴森鸠
+Turtur afer_蓝斑森鸠
+Turtur brehmeri_蓝头森鸠
+Turtur chalcospilos_绿点森鸠
+Turtur tympanistria_白胸森鸠
+Tylas eduardi_泰拉钩嘴鵙
+Tympanuchus cupido_草原松鸡
+Tympanuchus pallidicinctus_小草原松鸡
+Tympanuchus phasianellus_尖尾松鸡
+Tyranneutes stolzmanni_侏霸娇鹟
+Tyranneutes virescens_小霸娇鹟
+Tyrannopsis sulphurea_黄白喉霸鹟
+Tyrannulus elatus_黄顶小霸鹟
+Tyrannus albogularis_白喉王霸鹟
+Tyrannus caudifasciatus_圆头王霸鹟
+Tyrannus couchii_库氏王霸鹟
+Tyrannus crassirostris_厚嘴王霸鹟
+Tyrannus dominicensis_灰王霸鹟
+Tyrannus forficatus_剪尾王霸鹟
+Tyrannus melancholicus_热带王霸鹟
+Tyrannus niveigularis_雪喉王霸鹟
+Tyrannus savana_叉尾王霸鹟
+Tyrannus tyrannus_东王霸鹟
+Tyrannus verticalis_西王霸鹟
+Tyrannus vociferans_卡氏王霸鹟
+Tyto alba_西仓鸮
+Tyto novaehollandiae_大草鸮
+Tyto tenebricosa_乌草鸮
+Upucerthia dumetaria_鳞喉爬地雀
+Upucerthia saturatior_林爬地雀
+Upucerthia validirostris_黄胸爬地雀
+Upupa epops_戴胜
+Upupa marginata_马岛戴胜
+Uraeginthus angolensis_蓝饰雀
+Uraeginthus bengalus_红颊蓝饰雀
+Uranomitra franciae_安第斯蜂鸟
+Uria aalge_崖海鸦
+Uria lomvia_厚嘴崖海鸦
+Urocissa caerulea_台湾蓝鹊
+Urocissa erythroryncha_红嘴蓝鹊
+Urocissa flavirostris_黄嘴蓝鹊
+Urocissa ornata_斯里兰卡蓝鹊
+Urocolius indicus_红脸鼠鸟
+Urocolius macrourus_蓝枕鼠鸟
+Urocynchramus pylzowi_朱鹀
+Urodynamis taitensis_长尾噪鹃
+Uromyias agilis_敏雀霸鹟
+Uromyias agraphia_无纹雀霸鹟
+Uropsalis lyra_大燕尾夜鹰
+Uropsalis segmentata_小燕尾夜鹰
+Uropsila leucogastra_白腹鹪鹩
+Urosphena pallidipes_淡脚树莺
+Urosphena squameiceps_鳞头树莺
+Urosphena subulata_帝汶短尾莺
+Urosphena whiteheadi_印尼短尾莺
+Urothraupis stolzmanni_黑背丛雀
+Urotriorchis macrourus_非洲长尾鹰
+Vanellus armatus_黑背麦鸡
 Vanellus cayanus_Pied Lapwing
-Vanellus chilensis_Southern Lapwing
-Vanellus cinereus_跳鴴
-Vanellus coronatus_Crowned Lapwing
-Vanellus duvaucelii_River Lapwing
-Vanellus indicus_Red-wattled Lapwing
-Vanellus leucurus_White-tailed Lapwing
-Vanellus malabaricus_Yellow-wattled Lapwing
-Vanellus melanocephalus_Spot-breasted Lapwing
-Vanellus melanopterus_Black-winged Lapwing
-Vanellus miles_Masked Lapwing
-Vanellus resplendens_Andean Lapwing
-Vanellus senegallus_Wattled Lapwing
-Vanellus spinosus_Spur-winged Lapwing
-Vanellus tectus_Black-headed Lapwing
-Vanellus tricolor_Banded Lapwing
-Vanellus vanellus_小辮鴴
-Vanga curvirostris_Hook-billed Vanga
-Vermivora chrysoptera_Golden-winged Warbler
-Vermivora cyanoptera_Blue-winged Warbler
-Vidua chalybeata_靛藍維達雀
-Vidua fischeri_Straw-tailed Whydah
-Vidua funerea_Variable Indigobird
-Vidua macroura_針尾維達雀
-Vireo altiloquus_Black-whiskered Vireo
-Vireo atricapilla_Black-capped Vireo
-Vireo bairdi_Cozumel Vireo
-Vireo bellii_Bell's Vireo
-Vireo brevipennis_Slaty Vireo
-Vireo carmioli_Yellow-winged Vireo
-Vireo cassinii_Cassin's Vireo
-Vireo chivi_Chivi Vireo
-Vireo crassirostris_Thick-billed Vireo
-Vireo flavifrons_Yellow-throated Vireo
-Vireo flavoviridis_Yellow-green Vireo
-Vireo gilvus_Warbling Vireo
-Vireo gracilirostris_Noronha Vireo
-Vireo griseus_White-eyed Vireo
-Vireo gundlachii_Cuban Vireo
-Vireo huttoni_Hutton's Vireo
-Vireo hypochryseus_Golden Vireo
-Vireo latimeri_Puerto Rican Vireo
-Vireo leucophrys_Brown-capped Vireo
-Vireo magister_Yucatan Vireo
-Vireo masteri_Choco Vireo
-Vireo modestus_Jamaican Vireo
-Vireo nelsoni_Dwarf Vireo
-Vireo olivaceus_Red-eyed Vireo
-Vireo pallens_Mangrove Vireo
-Vireo philadelphicus_Philadelphia Vireo
-Vireo plumbeus_Plumbeous Vireo
-Vireo sclateri_Tepui Vireo
-Vireo solitarius_Blue-headed Vireo
-Vireo vicinior_Gray Vireo
-Vireolanius eximius_Yellow-browed Shrike-Vireo
-Vireolanius leucotis_Slaty-capped Shrike-Vireo
-Vireolanius melitophrys_Chestnut-sided Shrike-Vireo
-Vireolanius pulchellus_Green Shrike-Vireo
-Volatinia jacarina_Blue-black Grassquit
-Wetmorethraupis sterrhopteron_Orange-throated Tanager
-Willisornis poecilinotus_Common Scale-backed Antbird
-Willisornis vidua_Xingu Scale-backed Antbird
-Xanthocephalus xanthocephalus_Yellow-headed Blackbird
-Xanthomixis zosterops_Spectacled Tetraka
-Xanthopsar flavus_Saffron-cowled Blackbird
-Xanthotis macleayanus_Macleay's Honeyeater
-Xema sabini_叉尾鷗
-Xenerpestes singularis_Equatorial Graytail
-Xenodacnis parina_Tit-like Dacnis
-Xenoglaux loweryi_Long-whiskered Owlet
-Xenopipo atronitens_Black Manakin
-Xenopirostris damii_Van Dam's Vanga
-Xenopirostris polleni_Pollen's Vanga
-Xenops minutus_Plain Xenops
-Xenops rutilans_Streaked Xenops
-Xenops tenuirostris_Slender-billed Xenops
-Xenopsaris albinucha_White-naped Xenopsaris
-Xenospiza baileyi_Sierra Madre Sparrow
-Xenotriccus callizonus_Belted Flycatcher
-Xenotriccus mexicanus_Pileated Flycatcher
-Xenus cinereus_反嘴鷸
-Xiphidiopicus percussus_Cuban Green Woodpecker
-Xiphocolaptes albicollis_White-throated Woodcreeper
-Xiphocolaptes major_Great Rufous Woodcreeper
-Xiphocolaptes promeropirhynchus_Strong-billed Woodcreeper
-Xipholena punicea_Pompadour Cotinga
-Xiphorhynchus elegans_Elegant Woodcreeper
-Xiphorhynchus erythropygius_Spotted Woodcreeper
-Xiphorhynchus flavigaster_Ivory-billed Woodcreeper
-Xiphorhynchus fuscus_Lesser Woodcreeper
-Xiphorhynchus guttatus_Buff-throated Woodcreeper
-Xiphorhynchus lachrymosus_Black-striped Woodcreeper
-Xiphorhynchus obsoletus_Striped Woodcreeper
-Xiphorhynchus ocellatus_Ocellated Woodcreeper
-Xiphorhynchus pardalotus_Chestnut-rumped Woodcreeper
-Xiphorhynchus spixii_Spix's Woodcreeper
-Xiphorhynchus susurrans_Cocoa Woodcreeper
-Xiphorhynchus triangularis_Olive-backed Woodcreeper
-Xolmis irupero_White Monjita
-Yuhina brunneiceps_冠羽畫眉
-Yuhina flavicollis_Whiskered Yuhina
-Yuhina gularis_Stripe-throated Yuhina
-Yuhina nigrimenta_Black-chinned Yuhina
-Yuhina occipitalis_Rufous-vented Yuhina
-Yungipicus canicapillus_小啄木
-Yungipicus kizuki_Japanese Pygmy Woodpecker
-Yungipicus moluccensis_Sunda Pygmy Woodpecker
-Yungipicus nanus_Brown-capped Pygmy Woodpecker
-Zapornia bicolor_Black-tailed Crake
-Zapornia flavirostra_Black Crake
-Zapornia fusca_緋秧雞
-Zapornia parva_Little Crake
-Zapornia paykullii_斑脇秧雞
-Zapornia pusilla_小秧雞
-Zapornia tabuensis_Spotless Crake
-Zavattariornis stresemanni_Stresemann's Bush-Crow
-Zebrilus undulatus_Zigzag Heron
-Zeledonia coronata_Wrenthrush
-Zenaida asiatica_White-winged Dove
-Zenaida auriculata_Eared Dove
-Zenaida aurita_Zenaida Dove
-Zenaida macroura_Mourning Dove
-Zenaida meloda_West Peruvian Dove
-Zentrygon albifacies_White-faced Quail-Dove
-Zentrygon carrikeri_Tuxtla Quail-Dove
-Zentrygon frenata_White-throated Quail-Dove
-Zentrygon goldmani_Russet-crowned Quail-Dove
-Zentrygon lawrencii_Purplish-backed Quail-Dove
-Zentrygon linearis_Lined Quail-Dove
-Zimmerius acer_Guianan Tyrannulet
-Zimmerius albigularis_Choco Tyrannulet
-Zimmerius bolivianus_Bolivian Tyrannulet
-Zimmerius chrysops_Golden-faced Tyrannulet
-Zimmerius cinereicapilla_Red-billed Tyrannulet
-Zimmerius gracilipes_Slender-footed Tyrannulet
-Zimmerius parvus_Mistletoe Tyrannulet
-Zimmerius vilissimus_Guatemalan Tyrannulet
-Zimmerius villarejoi_Mishana Tyrannulet
-Zimmerius viridiflavus_Peruvian Tyrannulet
-Zonotrichia albicollis_White-throated Sparrow
-Zonotrichia atricapilla_Golden-crowned Sparrow
-Zonotrichia capensis_Rufous-collared Sparrow
-Zonotrichia leucophrys_White-crowned Sparrow
-Zonotrichia querula_Harris's Sparrow
-Zoothera aurea_白氏地鶇
-Zoothera heinei_Russet-tailed Thrush
-Zoothera lunulata_Bassian Thrush
-Zoothera major_Amami Thrush
-Zosterops abyssinicus_Abyssinian White-eye
-Zosterops anderssoni_Southern Yellow White-eye
-Zosterops atricapilla_Black-capped White-eye
-Zosterops atriceps_Cream-throated White-eye
-Zosterops atrifrons_Black-crowned White-eye
-Zosterops auriventer_Hume's White-eye
-Zosterops ceylonensis_Sri Lanka White-eye
-Zosterops chloronothos_Mauritius White-eye
-Zosterops citrinella_Ashy-bellied White-eye
-Zosterops erythropleurus_紅脇繡眼
-Zosterops eurycricotus_Kilimanjaro White-eye
-Zosterops everetti_Everett's White-eye
-Zosterops flavifrons_Yellow-fronted White-eye
-Zosterops flavilateralis_Pale White-eye
-Zosterops japonicus_日菲繡眼
-Zosterops lateralis_Silvereye
-Zosterops luteus_Australian Yellow White-eye
-Zosterops maderaspatanus_Malagasy White-eye
-Zosterops mauritianus_Mauritius Gray White-eye
-Zosterops metcalfii_Yellow-throated White-eye
-Zosterops meyeni_低地繡眼
-Zosterops pallidus_Orange River White-eye
-Zosterops palpebrosus_印度繡眼
-Zosterops senegalensis_Northern Yellow White-eye
-Zosterops simplex_斯氏繡眼
-Zosterops virens_Cape White-eye
+Vanellus chilensis_凤头距翅麦鸡
+Vanellus cinereus_灰头麦鸡
+Vanellus coronatus_冕麦鸡
+Vanellus duvaucelii_距翅麦鸡
+Vanellus indicus_肉垂麦鸡
+Vanellus leucurus_白尾麦鸡
+Vanellus malabaricus_黄垂麦鸡
+Vanellus melanocephalus_斑胸麦鸡
+Vanellus melanopterus_黑翅麦鸡
+Vanellus miles_白颈麦鸡
+Vanellus resplendens_安第斯麦鸡
+Vanellus senegallus_黑喉麦鸡
+Vanellus spinosus_黑胸麦鸡
+Vanellus tectus_非洲麦鸡
+Vanellus tricolor_三色麦鸡
+Vanellus vanellus_凤头麦鸡
+Vanga curvirostris_钩嘴鵙
+Vermivora chrysoptera_金翅虫森莺
+Vermivora cyanoptera_蓝翅虫森莺
+Vidua chalybeata_靛蓝维达雀
+Vidua fischeri_草尾维达雀
+Vidua funerea_暗紫维达雀
+Vidua macroura_针尾维达雀
+Vireo altiloquus_黑髭莺雀
+Vireo atricapilla_黑顶莺雀
+Vireo bairdi_科岛莺雀
+Vireo bellii_贝氏莺雀
+Vireo brevipennis_灰蓝莺雀
+Vireo carmioli_黄翅莺雀
+Vireo cassinii_卡氏莺雀
+Vireo chivi_南美红眼莺雀
+Vireo crassirostris_厚嘴莺雀
+Vireo flavifrons_黄喉莺雀
+Vireo flavoviridis_黄绿莺雀
+Vireo gilvus_歌莺雀
+Vireo gracilirostris_巴西莺雀
+Vireo griseus_白眼莺雀
+Vireo gundlachii_古巴莺雀
+Vireo huttoni_赫氏莺雀
+Vireo hypochryseus_金莺雀
+Vireo latimeri_波多黎各莺雀
+Vireo leucophrys_褐顶莺雀
+Vireo magister_尤卡莺雀
+Vireo masteri_乔科莺雀
+Vireo modestus_牙买加莺雀
+Vireo nelsoni_侏莺雀
+Vireo olivaceus_红眼莺雀
+Vireo pallens_红树莺雀
+Vireo philadelphicus_费城莺雀
+Vireo plumbeus_铅色莺雀
+Vireo sclateri_蓝顶绿莺雀
+Vireo solitarius_蓝头莺雀
+Vireo vicinior_灰莺雀
+Vireolanius eximius_黄眉鵙雀
+Vireolanius leucotis_灰顶鵙雀
+Vireolanius melitophrys_栗胁鵙雀
+Vireolanius pulchellus_绿鵙雀
+Volatinia jacarina_蓝黑草鹀
+Wetmorethraupis sterrhopteron_橙喉唐纳雀
+Willisornis poecilinotus_鳞背蚁鸟
+Willisornis vidua_新谷鳞背蚁鸟
+Xanthocephalus xanthocephalus_黄头黑鹂
+Xanthomixis zosterops_短嘴旋木鹎
+Xanthopsar flavus_橙头黑鹂
+Xanthotis macleayanus_黄纹吸蜜鸟
+Xema sabini_叉尾鸥
+Xenerpestes singularis_赤道灰尾雀
+Xenodacnis parina_辉蓝锥嘴雀
+Xenoglaux loweryi_长须鸺鹠
+Xenopipo atronitens_黑娇鹟
+Xenopirostris damii_范氏厚嘴鵙
+Xenopirostris polleni_白额厚嘴鵙
+Xenops minutus_白喉翘嘴雀
+Xenops rutilans_纵纹翘嘴雀
+Xenops tenuirostris_细嘴翘嘴雀
+Xenopsaris albinucha_白枕霸鹟
+Xenospiza baileyi_异雀鹀
+Xenotriccus callizonus_带霸鹟
+Xenotriccus mexicanus_墨西哥霸鹟
+Xenus cinereus_翘嘴鹬
+Xiphidiopicus percussus_古巴绿啄木鸟
+Xiphocolaptes albicollis_白喉䴕雀
+Xiphocolaptes major_大棕䴕雀
+Xiphocolaptes promeropirhynchus_强嘴䴕雀
+Xipholena punicea_白翅紫伞鸟
+Xiphorhynchus elegans_优雅䴕雀
+Xiphorhynchus erythropygius_点斑䴕雀
+Xiphorhynchus flavigaster_白嘴䴕雀
+Xiphorhynchus fuscus_小䴕雀
+Xiphorhynchus guttatus_黄喉䴕雀
+Xiphorhynchus lachrymosus_黑纹䴕雀
+Xiphorhynchus obsoletus_纵纹䴕雀
+Xiphorhynchus ocellatus_眼斑䴕雀
+Xiphorhynchus pardalotus_栗腰䴕雀
+Xiphorhynchus spixii_斯氏䴕雀
+Xiphorhynchus susurrans_可岛䴕雀
+Xiphorhynchus triangularis_绿背䴕雀
+Xolmis irupero_白蒙霸鹟
+Yuhina brunneiceps_褐头凤鹛
+Yuhina flavicollis_黄颈凤鹛
+Yuhina gularis_纹喉凤鹛
+Yuhina nigrimenta_黑颏凤鹛
+Yuhina occipitalis_棕臀凤鹛
+Yungipicus canicapillus_星头啄木鸟
+Yungipicus kizuki_小星头啄木鸟
+Yungipicus moluccensis_巽他啄木鸟
+Yungipicus nanus_褐头啄木鸟
+Zapornia bicolor_棕背田鸡
+Zapornia flavirostra_黑苦恶鸟
+Zapornia fusca_红胸田鸡
+Zapornia parva_姬田鸡
+Zapornia paykullii_斑胁田鸡
+Zapornia pusilla_小田鸡
+Zapornia tabuensis_无斑田鸡
+Zavattariornis stresemanni_灰丛鸦
+Zebrilus undulatus_波斑鹭
+Zeledonia coronata_冠鹩森莺
+Zenaida asiatica_白翅哀鸽
+Zenaida auriculata_斑颊哀鸽
+Zenaida aurita_鸣哀鸽
+Zenaida macroura_哀鸽
+Zenaida meloda_南美哀鸽
+Zentrygon albifacies_灰头白脸鹑鸠
+Zentrygon carrikeri_卡氏鹑鸠
+Zentrygon frenata_白喉鹑鸠
+Zentrygon goldmani_黄顶鹑鸠
+Zentrygon lawrencii_紫背鹑鸠
+Zentrygon linearis_白脸鹑鸠
+Zimmerius acer_圭亚那小霸鹟
+Zimmerius albigularis_灰喉金脸小霸鹟
+Zimmerius bolivianus_玻利维亚小霸鹟
+Zimmerius chrysops_金脸小霸鹟
+Zimmerius cinereicapilla_红嘴小霸鹟
+Zimmerius gracilipes_细脚小霸鹟
+Zimmerius parvus_槲小霸鹟
+Zimmerius vilissimus_稚小霸鹟
+Zimmerius villarejoi_绿头小霸鹟
+Zimmerius viridiflavus_秘鲁小霸鹟
+Zonotrichia albicollis_白喉带鹀
+Zonotrichia atricapilla_金冠带鹀
+Zonotrichia capensis_红领带鹀
+Zonotrichia leucophrys_白冠带鹀
+Zonotrichia querula_赫氏带鹀
+Zoothera aurea_虎斑地鸫
+Zoothera heinei_黄尾地鸫
+Zoothera lunulata_绿尾地鸫
+Zoothera major_琉球地鸫
+Zosterops abyssinicus_白胸绣眼鸟
+Zosterops anderssoni_南黄绣眼鸟
+Zosterops atricapilla_黑冠绣眼鸟
+Zosterops atriceps_摩鹿加绣眼鸟
+Zosterops atrifrons_白额绣眼鸟
+Zosterops auriventer_休氏绣眼鸟
+Zosterops ceylonensis_斯里兰卡绣眼鸟
+Zosterops chloronothos_毛里求斯绣眼鸟
+Zosterops citrinella_苍腹绣眼鸟
+Zosterops erythropleurus_红胁绣眼鸟
+Zosterops eurycricotus_宽颈绣眼鸟
+Zosterops everetti_埃氏绣眼鸟
+Zosterops flavifrons_黄额绣眼鸟
+Zosterops flavilateralis_灰白绣眼鸟
+Zosterops japonicus_日本绣眼鸟
+Zosterops lateralis_灰胸绣眼鸟
+Zosterops luteus_澳洲黄绣眼鸟
+Zosterops maderaspatanus_马岛绣眼鸟
+Zosterops mauritianus_毛岛灰绣眼鸟
+Zosterops metcalfii_黄喉绣眼鸟
+Zosterops meyeni_低地绣眼鸟
+Zosterops pallidus_苍色绣眼鸟
+Zosterops palpebrosus_灰腹绣眼鸟
+Zosterops senegalensis_黄绣眼鸟
+Zosterops simplex_暗绿绣眼鸟
+Zosterops virens_南非绣眼鸟


### PR DESCRIPTION
Names in labels_zh are mostly error or not translated into Chinese, this pr translated names to Chinese according to IOC 14.2(https://www.worldbirdnames.org/new/ioc-lists/master-list-2/)