### PR TITLE
Mapped AU, NZ, IE, ZA locales to en_uk labels for correct spelling

### DIFF
--- a/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt
+++ b/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt
@@ -209,7 +209,7 @@ class SoundClassifier(
     if (language == "en") {
       val country = localeList.get(0).country
       language = when (country) {
-          "GB" -> "en_uk"
+          "GB", "AU", "NZ", "IE", "ZA" -> "en_uk"
           else -> "en"
       }
     } else if (language == "pt") {


### PR DESCRIPTION
Currently, the app defaults to US English for Australia, which uses incorrect spellings (e.g., 'Gray' vs 'Grey'). This fix maps AU, NZ, IE, and ZA locales to the existing en_uk label set to ensure correct local naming conventions. Tested with Grey Goshawk call to ensure the fix is working.